### PR TITLE
fix: export option type

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,68 @@ for _, alias := range m.Payload.Aliases {
 	fmt.Println(alias)
 }
 ```
+
+### Wrapping the Client
+
+Wrapping the client can be useful when you want to override default behavior, such as always setting
+context or disallowing (to the best of Go's ability) access to specific receiver functions on
+`opslevel.Client`. Here is an example of wrapping the client to always require context to be passed
+while also maintaining the ability to pass in default options, with the ability to extend your own
+set of options if need-be:
+
+```go
+type Client struct{
+	*opslevel.Client
+
+	do opsLevelDefaultOptions
+	customOption string
+}
+
+func NewClient(ctx context.Context, apiToken string, options ...Option) *Client {
+	var c Client
+
+	for i := range options{
+		options[i](&c)
+	}
+	c.Client = opslevel.NewClient(apiToken, c.do.opsLevelOptions(ctx)...)
+
+	return &c, nil
+}
+
+type opsLevelDefaultOptions struct{
+	url *string
+	pageSize *int
+}
+
+func (o *opsLevelDefaultOptions) opsLevelOptions(ctx context.Context) []opslevel.Option {
+	opts := []opslevel.Option{opslevel.SetContext(ctx)} // Always set the context.
+
+	if o.url != nil {
+		ops = append(opts, opslevel.SetURL(*o.url))
+	}
+	if o.pageSize != nil {
+		ops = append(opts, opslevel.SetPageSize(*o.pageSize))
+	}
+}
+
+// Option is our own functional option type for our own custom client.
+type Option func(*Client)
+
+func WithURL(url string) Option {
+	return func(c *Client) {
+		c.do.url = &url
+	}
+}
+
+func WithPageSize(pageSize int) Option {
+	return func(c *Client) {
+		c.do.pageSize = &pageSize
+	}
+}
+
+func WithCustomOption(custom string) Option {
+	return func(c *Client) {
+		c.customOption = custom
+	}
+}
+```

--- a/client.go
+++ b/client.go
@@ -31,33 +31,33 @@ type Client struct {
 	client   *graphql.Client
 }
 
-type option func(*ClientSettings)
+type Option func(*ClientSettings)
 
-func SetURL(url string) option {
+func SetURL(url string) Option {
 	return func(c *ClientSettings) {
 		c.url = url
 	}
 }
 
-func SetContext(ctx context.Context) option {
+func SetContext(ctx context.Context) Option {
 	return func(c *ClientSettings) {
 		c.ctx = ctx
 	}
 }
 
-func SetPageSize(size int) option {
+func SetPageSize(size int) Option {
 	return func(c *ClientSettings) {
 		c.pageSize = size
 	}
 }
 
-func SetAPIVisibility(visibility string) option {
+func SetAPIVisibility(visibility string) Option {
 	return func(c *ClientSettings) {
 		c.apiVisibility = visibility
 	}
 }
 
-func SetUserAgentExtra(extra string) option {
+func SetUserAgentExtra(extra string) Option {
 	return func(c *ClientSettings) {
 		c.userAgentExtra = extra
 	}
@@ -74,7 +74,7 @@ func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-func NewClient(apiToken string, options ...option) *Client {
+func NewClient(apiToken string, options ...Option) *Client {
 	httpToken := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: apiToken, TokenType: "Bearer"},
 	)


### PR DESCRIPTION
_This shouldn't be a breaking change, it doesn't update or remove from any of the public-facing API._

If this type isn't exported it makes it pretty difficult to write types that wrap around opslevel.Client. Right now if you want to support setting the URL/page size on a wrapped client with functional options, for example, you have to do one of the following hacky options:

1.
```go
switch {
case do.url != nil && do.pageSize != nil:
	// both are non-nil, apply both.
	return opslevel.NewClient(apiToken, opslevel.SetContext(ctx), opslevel.SetURL(*do.url), opslevel.SetPageSize(*do.pageSize))
case do.url != nil:
	// url is non-nil, only apply it.
	return opslevel.NewClient(apiToken, opslevel.SetContext(ctx), opslevel.SetURL(*do.url))
case do.pageSize != nil:
	// pageSize is non-nil, only apply it.
	return opslevel.NewClient(apiToken, opslevel.SetContext(ctx), opslevel.SetPageSize(*do.pageSize))
default:
	// neither were provided, just return a client with the context set.
	return opslevel.NewClient(apiToken, opslevel.SetContext(ctx))
}
```
(extremely verbose and gets pretty clunky pretty quickly, requiring 2^n cases where n is the number of `opslevel.option`s you want to support)

2.
```go
urlOpt := opslevel.SetContext(ctx)
if do.url != nil {
    urlOpt = opslevel.SetURL(*do.url)
}

pageOpt := opslevel.SetContext(ctx)
if do.pageSize != nil {
    pageOpt = opslevel.SetPageSize(*do.pageSize)
}
...
return opslevel.NewClient(apiToken, opslevel.SetContext(ctx), urlOpt, pageOpt, ...)
```
(this works because you can technically pass `opslevel.SetContext` more than once to `opslevel.NewClient`)

3.
```go
return opslevel.NewClient(apiToken, func(c *ClientSettings) {
   if do.url != nil {
      opslevel.SetURL(*do.url)(c)
   }
   ....
})
```
(works because go will implicitly assert anonymous functions even if the type is unexported, will not work with an explicit custom type)