### PR TITLE
fix update group method

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -9,8 +10,8 @@ import (
 )
 
 type IdentifierInput struct {
-	Id    graphql.ID     `graphql:"id,omitempty" json:"id,omitempty"`
-	Alias graphql.String `graphql:"alias,omitempty" json:"alias,omitempty"`
+	Id    graphql.ID     `graphql:"id" json:"id,omitempty"`
+	Alias graphql.String `graphql:"alias" json:"alias,omitempty"`
 }
 
 type PageInfo struct {
@@ -49,15 +50,22 @@ func (p *IdResponsePayload) Mutate(client *Client, m interface{}, v PayloadVaria
 	return FormatErrors(p.Errors)
 }
 
-func NewId(id string) *IdentifierInput {
-	return &IdentifierInput{
-		Id: graphql.ID(id),
+func IsID(value string) bool {
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return false
 	}
+	return strings.HasPrefix(string(decoded), "gid://")
 }
 
-func NewIdFromAlias(alias string) *IdentifierInput {
+func NewIdentifier(value string) *IdentifierInput {
+	if IsID(value) {
+		return &IdentifierInput{
+			Id: graphql.ID(value),
+		}
+	}
 	return &IdentifierInput{
-		Alias: graphql.String(alias),
+		Alias: graphql.String(value),
 	}
 }
 
@@ -86,10 +94,6 @@ func FormatErrors(errs []OpsLevelErrors) error {
 func NewID(id string) *graphql.ID {
 	output := graphql.ID(id)
 	return &output
-}
-
-func NewString(v string) graphql.String {
-	return graphql.String(v)
 }
 
 func NewInt(i int) *int {

--- a/common.go
+++ b/common.go
@@ -37,9 +37,9 @@ type IdResponsePayload struct {
 }
 
 type ResourceDeletePayload struct {
-	Alias  string           `graphql:"deletedAlias,omitempty" json:"alias,omitempty"`
-	Id     graphql.ID       `graphql:"deletedId,omitempty" json:"id,omitempty"`
-	Errors []OpsLevelErrors `graphql:"errors,omitempty" json:"errors,omitempty"`
+	Alias  string           `graphql:"deletedAlias" json:"alias,omitempty"`
+	Id     graphql.ID       `graphql:"deletedId" json:"id,omitempty"`
+	Errors []OpsLevelErrors `graphql:"errors" json:"errors,omitempty"`
 }
 
 func (p *IdResponsePayload) Mutate(client *Client, m interface{}, v PayloadVariables) error {
@@ -86,6 +86,10 @@ func FormatErrors(errs []OpsLevelErrors) error {
 func NewID(id string) *graphql.ID {
 	output := graphql.ID(id)
 	return &output
+}
+
+func NewString(v string) graphql.String {
+	return graphql.String(v)
 }
 
 func NewInt(i int) *int {

--- a/group.go
+++ b/group.go
@@ -164,9 +164,7 @@ func (client *Client) DeleteGroupWithAlias(alias string) error {
 		Payload ResourceDeletePayload `graphql:"groupDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
-		"input": IdentifierInput{
-			Alias: graphql.String(alias),
-		},
+		"input": *NewIdentifier(alias),
 	}
 	if err := client.Mutate(&m, v); err != nil {
 		return err
@@ -179,9 +177,7 @@ func (client *Client) DeleteGroup(id graphql.ID) error {
 		Payload ResourceDeletePayload `graphql:"groupDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
-		"input": IdentifierInput{
-			Id: id,
-		},
+		"input": *NewIdentifier(id.(string)),
 	}
 	if err := client.Mutate(&m, v); err != nil {
 		return err

--- a/group.go
+++ b/group.go
@@ -4,26 +4,9 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
-type GroupCreateInput struct {
-	Description string            `json:"description,omitempty"`
-	Members     []MemberInput     `json:"members,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Parent      IdentifierInput   `json:"parent,omitempty"`
-	Teams       []IdentifierInput `json:"teams,omitempty"`
-}
-
 type GroupId struct {
 	Alias string     `json:"alias,omitempty"`
 	Id    graphql.ID `json:"id"`
-}
-
-type GroupUpdateInput struct {
-	Alias       string            `json:"alias,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Members     []MemberInput     `json:"members,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Parent      IdentifierInput   `json:"parent,omitempty"`
-	Teams       []IdentifierInput `json:"teams,omitempty"`
 }
 
 type Group struct {
@@ -51,9 +34,17 @@ type GroupConnection struct {
 	TotalCount graphql.Int
 }
 
+type GroupInput struct {
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Parent      *IdentifierInput  `json:"parent,omitempty"`
+	Members     []MemberInput     `json:"members,omitempty"`
+	Teams       []IdentifierInput `json:"teams,omitempty"`
+}
+
 //#region Create
 
-func (client *Client) CreateGroup(input GroupCreateInput) (*Group, error) {
+func (client *Client) CreateGroup(input GroupInput) (*Group, error) {
 	var m struct {
 		Payload struct {
 			Group  Group
@@ -147,7 +138,7 @@ func (client *Client) ListGroups() ([]Group, error) {
 
 //#region Update
 
-func (client *Client) UpdateGroup(id IdentifierInput, input GroupUpdateInput) (*Group, error) {
+func (client *Client) UpdateGroup(id IdentifierInput, input GroupInput) (*Group, error) {
 	var m struct {
 		Payload struct {
 			Group  Group
@@ -170,15 +161,11 @@ func (client *Client) UpdateGroup(id IdentifierInput, input GroupUpdateInput) (*
 
 func (client *Client) DeleteGroupWithAlias(alias string) error {
 	var m struct {
-		Payload struct {
-			Id     graphql.ID       `graphql:"deletedId"`
-			Alias  graphql.String   `graphql:"deletedAlias"`
-			Errors []OpsLevelErrors `graphql:"errors"`
-		} `graphql:"groupDelete(input: $input)"`
+		Payload ResourceDeletePayload `graphql:"groupDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
-		"input": ResourceDeletePayload{
-			Alias: alias,
+		"input": IdentifierInput{
+			Alias: graphql.String(alias),
 		},
 	}
 	if err := client.Mutate(&m, v); err != nil {
@@ -189,14 +176,10 @@ func (client *Client) DeleteGroupWithAlias(alias string) error {
 
 func (client *Client) DeleteGroup(id graphql.ID) error {
 	var m struct {
-		Payload struct {
-			Id     graphql.ID       `graphql:"deletedId"`
-			Alias  graphql.String   `graphql:"deletedAlias"`
-			Errors []OpsLevelErrors `graphql:"errors"`
-		} `graphql:"groupDelete(input: $input)"`
+		Payload ResourceDeletePayload `graphql:"groupDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
-		"input": ResourceDeletePayload{
+		"input": IdentifierInput{
 			Id: id,
 		},
 	}

--- a/group.go
+++ b/group.go
@@ -147,14 +147,15 @@ func (client *Client) ListGroups() ([]Group, error) {
 
 //#region Update
 
-func (client *Client) UpdateGroup(input GroupUpdateInput) (*Group, error) {
+func (client *Client) UpdateGroup(id IdentifierInput, input GroupUpdateInput) (*Group, error) {
 	var m struct {
 		Payload struct {
 			Group  Group
 			Errors []OpsLevelErrors
-		} `graphql:"groupUpdate(input: $input)"`
+		} `graphql:"groupUpdate(group: $group, input: $input)"`
 	}
 	v := PayloadVariables{
+		"group": id,
 		"input": input,
 	}
 	if err := client.Mutate(&m, v); err != nil {

--- a/group.go
+++ b/group.go
@@ -35,11 +35,11 @@ type GroupConnection struct {
 }
 
 type GroupInput struct {
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Parent      *IdentifierInput  `json:"parent,omitempty"`
-	Members     []MemberInput     `json:"members,omitempty"`
-	Teams       []IdentifierInput `json:"teams,omitempty"`
+	Name        string             `json:"name,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Parent      *IdentifierInput   `json:"parent,omitempty"`
+	Members     *[]MemberInput     `json:"members,omitempty"`
+	Teams       *[]IdentifierInput `json:"teams,omitempty"`
 }
 
 //#region Create

--- a/group.go
+++ b/group.go
@@ -138,7 +138,7 @@ func (client *Client) ListGroups() ([]Group, error) {
 
 //#region Update
 
-func (client *Client) UpdateGroup(id IdentifierInput, input GroupInput) (*Group, error) {
+func (client *Client) UpdateGroup(identifier string, input GroupInput) (*Group, error) {
 	var m struct {
 		Payload struct {
 			Group  Group
@@ -146,7 +146,7 @@ func (client *Client) UpdateGroup(id IdentifierInput, input GroupInput) (*Group,
 		} `graphql:"groupUpdate(group: $group, input: $input)"`
 	}
 	v := PayloadVariables{
-		"group": id,
+		"group": *NewIdentifier(identifier),
 		"input": input,
 	}
 	if err := client.Mutate(&m, v); err != nil {

--- a/group_test.go
+++ b/group_test.go
@@ -94,7 +94,7 @@ func TestUpdateGroup(t *testing.T) {
 		{Alias: "platform"},
 	}
 	// Act
-	result, err := client.UpdateGroup(opslevel.IdentifierInput{Id: "Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTI"}, opslevel.GroupInput{
+	result, err := client.UpdateGroup("Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTI", opslevel.GroupInput{
 		Description: "This is the first test group",
 		Members:     &members,
 		Parent:      opslevel.NewIdentifier("test_group_2"),

--- a/group_test.go
+++ b/group_test.go
@@ -12,7 +12,7 @@ func TestCreateGroup(t *testing.T) {
 	client := ATestClient(t, "group/create")
 	// Act
 	members := []opslevel.MemberInput{
-		opslevel.MemberInput{Email: "edgar+test@opslevel.com"},
+		{Email: "edgar+test@opslevel.com"},
 	}
 	result, err := client.CreateGroup(opslevel.GroupInput{
 		Name:        "platform",
@@ -20,7 +20,7 @@ func TestCreateGroup(t *testing.T) {
 		Members:     members,
 		Parent:      &opslevel.IdentifierInput{Alias: "test_group_1"},
 		Teams: []opslevel.IdentifierInput{
-			opslevel.IdentifierInput{Alias: "platform"},
+			{Alias: "platform"},
 		},
 	})
 	// Assert
@@ -86,7 +86,7 @@ func TestUpdateGroup(t *testing.T) {
 	// Arrange
 	client := ATestClient(t, "group/update")
 	members := []opslevel.MemberInput{
-		opslevel.MemberInput{Email: "edgar+test@opslevel.com"},
+		{Email: "edgar+test@opslevel.com"},
 	}
 	// Act
 	result, err := client.UpdateGroup(opslevel.IdentifierInput{Id: "Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTI"}, opslevel.GroupInput{

--- a/group_test.go
+++ b/group_test.go
@@ -14,11 +14,11 @@ func TestCreateGroup(t *testing.T) {
 	members := []opslevel.MemberInput{
 		opslevel.MemberInput{Email: "edgar+test@opslevel.com"},
 	}
-	result, err := client.CreateGroup(opslevel.GroupCreateInput{
+	result, err := client.CreateGroup(opslevel.GroupInput{
 		Name:        "platform",
 		Description: "Another test group",
 		Members:     members,
-		Parent:      opslevel.IdentifierInput{Alias: "test_group_1"},
+		Parent:      &opslevel.IdentifierInput{Alias: "test_group_1"},
 		Teams: []opslevel.IdentifierInput{
 			opslevel.IdentifierInput{Alias: "platform"},
 		},
@@ -89,13 +89,12 @@ func TestUpdateGroup(t *testing.T) {
 		opslevel.MemberInput{Email: "edgar+test@opslevel.com"},
 	}
 	// Act
-	result, err := client.UpdateGroup(opslevel.GroupUpdateInput{
-		Alias:       "test_group_1",
+	result, err := client.UpdateGroup(opslevel.IdentifierInput{Id: "Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTI"}, opslevel.GroupInput{
 		Description: "This is the first test group",
 		Members:     members,
-		Parent:      opslevel.IdentifierInput{Alias: "test_group_2"},
+		Parent:      &opslevel.IdentifierInput{Alias: "test_group_2"},
 		Teams: []opslevel.IdentifierInput{
-			opslevel.IdentifierInput{Alias: "platform"},
+			{Alias: "platform"},
 		},
 	})
 	// Assert

--- a/group_test.go
+++ b/group_test.go
@@ -10,18 +10,20 @@ import (
 func TestCreateGroup(t *testing.T) {
 	// Arrange
 	client := ATestClient(t, "group/create")
-	// Act
 	members := []opslevel.MemberInput{
 		{Email: "edgar+test@opslevel.com"},
 	}
+	teams := []opslevel.IdentifierInput{
+		{Alias: "platform"},
+	}
+	// Act
+
 	result, err := client.CreateGroup(opslevel.GroupInput{
 		Name:        "platform",
 		Description: "Another test group",
-		Members:     members,
-		Parent:      &opslevel.IdentifierInput{Alias: "test_group_1"},
-		Teams: []opslevel.IdentifierInput{
-			{Alias: "platform"},
-		},
+		Members:     &members,
+		Parent:      opslevel.NewIdentifier("test_group_1"),
+		Teams:       &teams,
 	})
 	// Assert
 	autopilot.Ok(t, err)
@@ -88,14 +90,15 @@ func TestUpdateGroup(t *testing.T) {
 	members := []opslevel.MemberInput{
 		{Email: "edgar+test@opslevel.com"},
 	}
+	teams := []opslevel.IdentifierInput{
+		{Alias: "platform"},
+	}
 	// Act
 	result, err := client.UpdateGroup(opslevel.IdentifierInput{Id: "Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTI"}, opslevel.GroupInput{
 		Description: "This is the first test group",
-		Members:     members,
-		Parent:      &opslevel.IdentifierInput{Alias: "test_group_2"},
-		Teams: []opslevel.IdentifierInput{
-			{Alias: "platform"},
-		},
+		Members:     &members,
+		Parent:      opslevel.NewIdentifier("test_group_2"),
+		Teams:       &teams,
 	})
 	// Assert
 	autopilot.Ok(t, err)

--- a/testdata/fixtures/group/create_request.json
+++ b/testdata/fixtures/group/create_request.json
@@ -1,5 +1,5 @@
 {
-  "query":"mutation($input:GroupCreateInput!){groupCreate(input: $input){group{alias,id,description,htmlUrl,name,parent{alias,id}},errors{message,path}}}",
+  "query":"mutation($input:GroupInput!){groupCreate(input: $input){group{alias,id,description,htmlUrl,name,parent{alias,id}},errors{message,path}}}",
   "variables":{
       "input":{
         "name": "platform",

--- a/testdata/fixtures/group/delete_request.json
+++ b/testdata/fixtures/group/delete_request.json
@@ -1,1 +1,1 @@
-{"query":"mutation($input:ResourceDeletePayload!){groupDelete(input: $input){deletedId,deletedAlias,errors{message,path}}}","variables":{"input":{"id":"Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTc"}}}
+{"query":"mutation($input:IdentifierInput!){groupDelete(resource: $input){deletedAlias,deletedId,errors{message,path}}}","variables":{"input":{"id":"Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTc"}}}

--- a/testdata/fixtures/group/delete_with_alias_request.json
+++ b/testdata/fixtures/group/delete_with_alias_request.json
@@ -1,1 +1,1 @@
-{"query":"mutation($input:ResourceDeletePayload!){groupDelete(input: $input){deletedId,deletedAlias,errors{message,path}}}","variables":{"input":{"alias":"platform"}}}
+{"query":"mutation($input:IdentifierInput!){groupDelete(resource: $input){deletedAlias,deletedId,errors{message,path}}}","variables":{"input":{"alias":"platform"}}}

--- a/testdata/fixtures/group/update_request.json
+++ b/testdata/fixtures/group/update_request.json
@@ -1,8 +1,10 @@
 {
-    "query":"mutation($input:GroupUpdateInput!){groupUpdate(input: $input){group{alias,id,description,htmlUrl,name,parent{alias,id}},errors{message,path}}}",
+    "query":"mutation($group:IdentifierInput!$input:GroupInput!){groupUpdate(group: $group, input: $input){group{alias,id,description,htmlUrl,name,parent{alias,id}},errors{message,path}}}",
     "variables":{
+        "group": {
+            "id":"Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMTI"
+        },
         "input":{
-            "alias":"test_group_1",
             "description":"This is the first test group",
             "members": [
                 {


### PR DESCRIPTION
The method did not work as built because the `groupUpdate` mutation uses that new format for taking that identifier input.

@eochoa260 can you fix the test fixtures in this branch?