### PR TITLE
Add support for RunnerJobOutcomeEnum.podTimeout

### DIFF
--- a/.changes/unreleased/Feature-20220719-110636.yaml
+++ b/.changes/unreleased/Feature-20220719-110636.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for PodTimeout as a runner job outcome
+time: 2022-07-19T11:06:36.055171-04:00

--- a/gen.go
+++ b/gen.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main
@@ -15,7 +16,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/opslevel/opslevel-go"
+	"github.com/opslevel/opslevel-go/v2022"
 	"github.com/shurcooL/graphql/ident"
 )
 

--- a/job.go
+++ b/job.go
@@ -15,6 +15,7 @@ const (
 	RunnerJobOutcomeEnumSuccess          RunnerJobOutcomeEnum = "success"           // Job succeded the execution.
 	RunnerJobOutcomeEnumQueueTimeout     RunnerJobOutcomeEnum = "queue_timeout"     // Job was not assigned to a runner for too long.
 	RunnerJobOutcomeEnumExecutionTimeout RunnerJobOutcomeEnum = "execution_timeout" // Job run took too long to complete, and was marked as failed.
+	RunnerJobOutcomeEnumPodTimeout       RunnerJobOutcomeEnum = "pod_timeout"       // A pod could not be scheduled for the job in time.
 )
 
 // All RunnerJobOutcomeEnum as []string
@@ -26,6 +27,7 @@ func AllRunnerJobOutcomeEnum() []string {
 		string(RunnerJobOutcomeEnumSuccess),
 		string(RunnerJobOutcomeEnumQueueTimeout),
 		string(RunnerJobOutcomeEnumExecutionTimeout),
+		string(RunnerJobOutcomeEnumPodTimeout),
 	}
 }
 


### PR DESCRIPTION
This adds support for `RunnerJobOutcomeEnum.podTimeout` in the OpsLevel GraphQL API.

This is dependant on an upstream change for it to be supported by the private API