### PR TITLE
expand the definition of a runner job to include files

### DIFF
--- a/job.go
+++ b/job.go
@@ -80,6 +80,11 @@ type RunnerJobVariable struct {
 	Value     string `json:"value"`
 }
 
+type RunnerJobFile struct {
+	Name     string `json:"name"`
+	Contents string `json:"contents"`
+}
+
 type RunnerJob struct {
 	Commands  []string             `json:"commands"`
 	Id        graphql.ID           `json:"id"`
@@ -87,6 +92,7 @@ type RunnerJob struct {
 	Outcome   RunnerJobOutcomeEnum `json:"outcome"`
 	Status    RunnerJobStatusEnum  `json:"status"`
 	Variables []RunnerJobVariable  `json:"variables"`
+	Files     []RunnerJobFile      `json:"files"`
 }
 
 func (j *RunnerJob) Number() string {

--- a/testdata/fixtures/job/get_pending_request.json
+++ b/testdata/fixtures/job/get_pending_request.json
@@ -1,4 +1,4 @@
 {
-    "query": "mutation($id:ID!$token:ID){runnerGetPendingJob(runnerId: $id lastUpdateToken: $token){runnerJob{commands,id,image,outcome,status,variables{key,sensitive,value}},lastUpdateToken,errors{message,path}}}",
+    "query": "mutation($id:ID!$token:ID){runnerGetPendingJob(runnerId: $id lastUpdateToken: $token){runnerJob{commands,id,image,outcome,status,variables{key,sensitive,value},files{name,contents}},lastUpdateToken,errors{message,path}}}",
     "variables": {"id":"1234567890", "token":  "1234"}
 }


### PR DESCRIPTION
This adds a new section the JobRun so that files can be injected to the container at runtime.

This changes the mutation to look like
```graphql
mutation ($id: ID!, $token: ID) {
  runnerGetPendingJob(runnerId: $id, lastUpdateToken: $token) {
    runnerJob {
      commands
      id
      image
      outcome
      status
      variables {
        key
        sensitive
        value
      }
      files {
        name
        contents
      }
    }
    lastUpdateToken
    errors {
      message
      path
    }
  }
}
```

here is an example yaml of a JobRun definition that would marshal into this.
```yaml
image: alpine/curl
commands:
  - /opslevel/check.sh
variables:
  - key: Secret
    value: "World!"
    sensitive: true
files:
  - name: check.sh
    contents: |
      #! /usr/bin/env sh
      echo "Hello World"
      sleep 5
      echo ${Secret}
```