### PR TITLE
Fixes API document update calls

### DIFF
--- a/clientGQL_test.go
+++ b/clientGQL_test.go
@@ -31,6 +31,11 @@ type GraphqlQuery struct {
 	Variables map[string]interface{} `json:",omitempty"`
 }
 
+func ToJson(query GraphqlQuery) string {
+	bytes, _ := json.Marshal(query)
+	return string(bytes)
+}
+
 func Parse(r *http.Request) GraphqlQuery {
 	output := GraphqlQuery{}
 	defer r.Body.Close()
@@ -66,7 +71,7 @@ func FixtureQueryValidation(t *testing.T, fixture string) autopilot.RequestValid
 		exp := GraphqlQuery{}
 		bytes := []byte(autopilot.Fixture(fixture))
 		json.Unmarshal(bytes, &exp)
-		autopilot.Equals(t, exp, q)
+		autopilot.Equals(t, ToJson(exp), ToJson(q))
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -79,6 +79,15 @@ func NewIdentifier(value string) *IdentifierInput {
 	}
 }
 
+func NewString(value string) *graphql.String {
+	var output *graphql.String = nil
+	if value != "" {
+		s := graphql.String(value)
+		output = &s
+	}
+	return output
+}
+
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
 func Bool(v bool) *bool {

--- a/document.go
+++ b/document.go
@@ -19,7 +19,7 @@ type ServiceDocumentContent struct {
 	Content string `graphql:"content" json:"content,omitempty"`
 }
 
-func (c *Client) ServiceApiDocSettingsUpdate(service string, docPath string, docSource ApiDocumentSourceEnum) (*Service, error) {
+func (c *Client) ServiceApiDocSettingsUpdate(service string, docPath string, docSource *ApiDocumentSourceEnum) (*Service, error) {
 	var m struct {
 		Payload struct {
 			Service Service
@@ -28,7 +28,7 @@ func (c *Client) ServiceApiDocSettingsUpdate(service string, docPath string, doc
 	}
 	v := PayloadVariables{
 		"service":   *NewIdentifier(service),
-		"docPath":   graphql.String(docPath),
+		"docPath":   NewString(docPath),
 		"docSource": docSource,
 	}
 	if err := c.Mutate(&m, v); err != nil {

--- a/document_test.go
+++ b/document_test.go
@@ -7,11 +7,25 @@ import (
 	"github.com/rocktavious/autopilot"
 )
 
-func TestServiceApiDocSettingsUpdate(t *testing.T) {
+//func TestServiceApiDocSettingsUpdate(t *testing.T) {
+//	// Arrange
+//	client := ATestClient(t, "service/api_doc_settings")
+//	// Act
+//	docSource := ol.ApiDocumentSourceEnumPull
+//	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "/src/swagger.json", &docSource)
+//	// Assert
+//	autopilot.Ok(t, err)
+//	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zOTI4MQ", result.Id)
+//	autopilot.Equals(t, ol.ApiDocumentSourceEnumPull, *result.PreferredApiDocumentSource)
+//	autopilot.Equals(t, "/src/swagger.json", result.ApiDocumentPath)
+//}
+
+func TestServiceApiDocSettingsUpdateDocSourceNull(t *testing.T) {
 	// Arrange
 	client := ATestClient(t, "service/api_doc_settings")
 	// Act
-	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "/src/swagger.json", ol.ApiDocumentSourceEnumPull)
+	docSource := ol.ApiDocumentSourceEnumPull
+	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "", &docSource)
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zOTI4MQ", result.Id)

--- a/document_test.go
+++ b/document_test.go
@@ -7,22 +7,34 @@ import (
 	"github.com/rocktavious/autopilot"
 )
 
-//func TestServiceApiDocSettingsUpdate(t *testing.T) {
-//	// Arrange
-//	client := ATestClient(t, "service/api_doc_settings")
-//	// Act
-//	docSource := ol.ApiDocumentSourceEnumPull
-//	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "/src/swagger.json", &docSource)
-//	// Assert
-//	autopilot.Ok(t, err)
-//	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zOTI4MQ", result.Id)
-//	autopilot.Equals(t, ol.ApiDocumentSourceEnumPull, *result.PreferredApiDocumentSource)
-//	autopilot.Equals(t, "/src/swagger.json", result.ApiDocumentPath)
-//}
+func TestServiceApiDocSettingsUpdate(t *testing.T) {
+	// Arrange
+	client := ATestClient(t, "service/api_doc_settings")
+	// Act
+	docSource := ol.ApiDocumentSourceEnumPull
+	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "/src/swagger.json", &docSource)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zOTI4MQ", result.Id)
+	autopilot.Equals(t, ol.ApiDocumentSourceEnumPull, *result.PreferredApiDocumentSource)
+	autopilot.Equals(t, "/src/swagger.json", result.ApiDocumentPath)
+}
 
 func TestServiceApiDocSettingsUpdateDocSourceNull(t *testing.T) {
 	// Arrange
-	client := ATestClient(t, "service/api_doc_settings")
+	client := ATestClientAlt(t, "service/api_doc_settings", "service/api_doc_settings_source_null")
+	// Act
+	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "/src/swagger.json", nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zOTI4MQ", result.Id)
+	autopilot.Equals(t, ol.ApiDocumentSourceEnumPull, *result.PreferredApiDocumentSource)
+	autopilot.Equals(t, "/src/swagger.json", result.ApiDocumentPath)
+}
+
+func TestServiceApiDocSettingsUpdateDocPathNull(t *testing.T) {
+	// Arrange
+	client := ATestClientAlt(t, "service/api_doc_settings", "service/api_doc_settings_path_null")
 	// Act
 	docSource := ol.ApiDocumentSourceEnumPull
 	result, err := client.ServiceApiDocSettingsUpdate("service_alias", "", &docSource)

--- a/testdata/fixtures/service/api_doc_settings_path_null_request.json
+++ b/testdata/fixtures/service/api_doc_settings_path_null_request.json
@@ -1,7 +1,7 @@
 {
   "query": "mutation($docPath:String$docSource:ApiDocumentSourceEnum$service:IdentifierInput!){serviceApiDocSettingsUpdate(service: $service, apiDocumentPath: $docPath, preferredApiDocumentSource: $docSource){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},name,owner{alias,id},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}},errors{message,path}}}",
   "variables": {
-    "docPath":"/src/swagger.json",
+    "docPath":null,
     "docSource":"PULL",
     "service":{
       "alias":"service_alias"

--- a/testdata/fixtures/service/api_doc_settings_source_null_request.json
+++ b/testdata/fixtures/service/api_doc_settings_source_null_request.json
@@ -2,7 +2,7 @@
   "query": "mutation($docPath:String$docSource:ApiDocumentSourceEnum$service:IdentifierInput!){serviceApiDocSettingsUpdate(service: $service, apiDocumentPath: $docPath, preferredApiDocumentSource: $docSource){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},name,owner{alias,id},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}},errors{message,path}}}",
   "variables": {
     "docPath":"/src/swagger.json",
-    "docSource":"PULL",
+    "docSource": null,
     "service":{
       "alias":"service_alias"
     }


### PR DESCRIPTION
So the main impetunus for this change is the bugs found when testing - https://github.com/OpsLevel/terraform-provider-opslevel/pull/34

The main thing was the original code was implemented to an incorrect spec in GraphQL
what as implemented was non-nullable inputs for `docPath` and `docSource`
```
mutation($docPath:String!$docSource:ApiDocumentSourceEnum!$service:IdentifierInput!)
```
but the correct is with nullable inputs
```
mutation($docPath:String$docSource:ApiDocumentSourceEnum$service:IdentifierInput!)
```