### PR TITLE
bugfix level update input

### DIFF
--- a/.changes/unreleased/Refactor-20220915-211113.yaml
+++ b/.changes/unreleased/Refactor-20220915-211113.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: 'BREAKING: change signature of LevelUpdateInput so that mutation works and description
+  can be set to empty string'
+time: 2022-09-15T21:11:13.227105-05:00

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/common.go
+++ b/common.go
@@ -79,6 +79,11 @@ func NewIdentifier(value string) *IdentifierInput {
 	}
 }
 
+func NewEmptyString() *graphql.String {
+	s := graphql.String("")
+	return &s
+}
+
 func NewString(value string) *graphql.String {
 	var output *graphql.String = nil
 	if value != "" {

--- a/level.go
+++ b/level.go
@@ -28,8 +28,8 @@ type LevelCreateInput struct {
 
 type LevelUpdateInput struct {
 	Id          graphql.ID `json:"id"`
-	Name        string     `json:"name"`
-	Description string     `json:"description,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Description *string    `json:"description"`
 }
 
 type LevelDeleteInput struct {

--- a/level.go
+++ b/level.go
@@ -27,9 +27,9 @@ type LevelCreateInput struct {
 }
 
 type LevelUpdateInput struct {
-	Id          graphql.ID `json:"id"`
-	Name        string     `json:"name,omitempty"`
-	Description *string    `json:"description"`
+	Id          graphql.ID      `json:"id"`
+	Name        graphql.String  `json:"name,omitempty"`
+	Description *graphql.String `json:"description,omitempty"`
 }
 
 type LevelDeleteInput struct {

--- a/level_test.go
+++ b/level_test.go
@@ -50,18 +50,62 @@ func TestListRubricLevels(t *testing.T) {
 	autopilot.Equals(t, "Bronze", result[1].Name)
 }
 
-func TestUpdateRubricLevels(t *testing.T) {
+func TestUpdateRubricLevel(t *testing.T) {
 	// Arrange
 	client := ATestClient(t, "rubric/level/update")
 	// Act
 	result, _ := client.UpdateLevel(ol.LevelUpdateInput{
-		Id:          ol.NewID("Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDgw"),
-		Name:        "Kyle",
-		Description: "Updated By Kyle",
+		Id:          ol.NewID("MTIzNDU2Nzg5MTIzNDU2Nzg5"),
+		Name:        "Example",
+		Description: ol.NewString("An example description"),
 	})
 	// Assert
-	autopilot.Equals(t, "kyle", result.Alias)
-	autopilot.Equals(t, "Updated By Kyle", result.Description)
+	autopilot.Equals(t, "example", result.Alias)
+	autopilot.Equals(t, "Example", result.Name)
+	autopilot.Equals(t, "An example description", result.Description)
+}
+
+func TestUpdateRubricLevelNoName(t *testing.T) {
+	// Arrange
+	client := ATestClientAlt(t, "rubric/level/update", "rubric/level/update_noname")
+	// Act
+	result, _ := client.UpdateLevel(ol.LevelUpdateInput{
+		Id:          ol.NewID("MTIzNDU2Nzg5MTIzNDU2Nzg5"),
+		Description: ol.NewString("An example description"),
+	})
+	// Assert
+	autopilot.Equals(t, "example", result.Alias)
+	autopilot.Equals(t, "Example", result.Name)
+	autopilot.Equals(t, "An example description", result.Description)
+}
+
+func TestUpdateRubricLevelEmptyDescription(t *testing.T) {
+	// Arrange
+	client := ATestClientAlt(t, "rubric/level/update", "rubric/level/update_emptydescription")
+	// Act
+	result, _ := client.UpdateLevel(ol.LevelUpdateInput{
+		Id:          ol.NewID("MTIzNDU2Nzg5MTIzNDU2Nzg5"),
+		Name:        "Example",
+		Description: ol.NewEmptyString(),
+	})
+	// Assert
+	autopilot.Equals(t, "example", result.Alias)
+	autopilot.Equals(t, "Example", result.Name)
+	autopilot.Equals(t, "An example description", result.Description)
+}
+
+func TestUpdateRubricLevelNoDescription(t *testing.T) {
+	// Arrange
+	client := ATestClientAlt(t, "rubric/level/update", "rubric/level/update_nodescription")
+	// Act
+	result, _ := client.UpdateLevel(ol.LevelUpdateInput{
+		Id:   ol.NewID("MTIzNDU2Nzg5MTIzNDU2Nzg5"),
+		Name: "Example",
+	})
+	// Assert
+	autopilot.Equals(t, "example", result.Alias)
+	autopilot.Equals(t, "Example", result.Name)
+	autopilot.Equals(t, "An example description", result.Description)
 }
 
 func TestDeleteRubricLevels(t *testing.T) {

--- a/testdata/fixtures/rubric/level/update_emptydescription_request.json
+++ b/testdata/fixtures/rubric/level/update_emptydescription_request.json
@@ -1,0 +1,10 @@
+{
+  "query": "{{ template "level_mutation.tpl" }}",
+  "variables": {
+    "input": {
+      "id": "{{ template "id1" }}",
+      "name": "{{ template "name1" }}",
+      "description": ""
+    }
+  }
+}

--- a/testdata/fixtures/rubric/level/update_nodescription_request.json
+++ b/testdata/fixtures/rubric/level/update_nodescription_request.json
@@ -3,8 +3,7 @@
     "variables": {
       "input": {
         "id": "{{ template "id1" }}",
-        "name": "{{ template "name1" }}",
-        "description": "{{ template "description" }}"
+        "name": "{{ template "name1" }}"
       }
     }
   }

--- a/testdata/fixtures/rubric/level/update_noname_request.json
+++ b/testdata/fixtures/rubric/level/update_noname_request.json
@@ -3,7 +3,6 @@
     "variables": {
       "input": {
         "id": "{{ template "id1" }}",
-        "name": "{{ template "name1" }}",
         "description": "{{ template "description" }}"
       }
     }

--- a/testdata/fixtures/rubric/level/update_response.json
+++ b/testdata/fixtures/rubric/level/update_response.json
@@ -1,13 +1,7 @@
 {
     "data": {
       "levelUpdate": {
-        "level": {
-          "alias": "kyle",
-          "description": "Updated By Kyle",
-          "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDgw",
-          "index": 4,
-          "name": "Kyle"
-        },
+        "level": {{ template "level.tpl" }},
         "errors": []
       }
     }

--- a/testdata/templates/common.tpl
+++ b/testdata/templates/common.tpl
@@ -1,5 +1,7 @@
 {{- define "alias1" }}example{{ end }}
 {{- define "alias2" }}example_2{{ end }}
+{{- define "name1" }}Example{{ end }}
+{{- define "name2" }}Example 2{{ end }}
 {{- define "id1" }}MTIzNDU2Nzg5MTIzNDU2Nzg5{{ end }}
 {{- define "id2" }}OTg3NjU0MzIxOTg3NjU0MzIx{{ end }}
 {{- define "eid1" }}NzQxODUyOTYzNzQxODUyOTYz{{ end }}

--- a/testdata/templates/rubric/level.tpl
+++ b/testdata/templates/rubric/level.tpl
@@ -1,0 +1,7 @@
+{
+    "alias": "{{ template "alias1" }}",
+    "description": "{{ template "description" }}",
+    "id": "{{ template "id1" }}",
+    "index": 4,
+    "name": "{{ template "name1" }}"
+}

--- a/testdata/templates/rubric/level_mutation.tpl
+++ b/testdata/templates/rubric/level_mutation.tpl
@@ -1,15 +1,1 @@
-mutation ($input: LevelUpdateInput!) {
-  levelUpdate(input: $input) {
-    level {
-      alias
-      description
-      id
-      index
-      name
-    }
-    errors {
-      message
-      path
-    }
-  }
-}
+mutation($input:LevelUpdateInput!){levelUpdate(input: $input){level{alias,description,id,index,name},errors{message,path}}}

--- a/testdata/templates/rubric/level_mutation.tpl
+++ b/testdata/templates/rubric/level_mutation.tpl
@@ -1,0 +1,15 @@
+mutation ($input: LevelUpdateInput!) {
+  levelUpdate(input: $input) {
+    level {
+      alias
+      description
+      id
+      index
+      name
+    }
+    errors {
+      message
+      path
+    }
+  }
+}


### PR DESCRIPTION
This fixes 2 bugs with LevelUpdateInput mutation:
- The update was never able to work without setting Name
- The update was never able to set the description to and empty string

This will then lead to a change in the Terraform provider (and likely the CLI)