### PR TITLE
Add support for Custom Actions Trigger Definitions entity type

### DIFF
--- a/.changes/unreleased/Feature-20230515-100806.yaml
+++ b/.changes/unreleased/Feature-20230515-100806.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add CustomActions TriggerDefinition EntityType support
+time: 2023-05-15T10:08:06.331639-04:00

--- a/actions.go
+++ b/actions.go
@@ -38,6 +38,7 @@ type CustomActionsTriggerDefinition struct {
 	Timestamps             Timestamps                                      `graphql:"timestamps"`
 	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `graphql:"accessControl"`
 	ResponseTemplate       string                                          `graphql:"responseTemplate"`
+	EntityType             CustomActionsEntityTypeEnum                     `graphql:"entityType"`
 }
 
 type CustomActionsExternalActionsConnection struct {
@@ -85,6 +86,7 @@ type CustomActionsTriggerDefinitionCreateInput struct {
 	Published              *bool                                           `json:"published,omitempty"`
 	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `json:"accessControl"`
 	ResponseTemplate       string                                          `json:"responseTemplate"`
+	EntityType             CustomActionsEntityTypeEnum                     `json:"entityType"`
 }
 
 type CustomActionsTriggerDefinitionUpdateInput struct {
@@ -100,6 +102,7 @@ type CustomActionsTriggerDefinitionUpdateInput struct {
 	Published              *bool                                           `json:"published,omitempty"`
 	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `json:"accessControl,omitempty"`
 	ResponseTemplate       *string                                         `json:"responseTemplate,omitempty"`
+	EntityType             CustomActionsEntityTypeEnum                     `json:"entityType,omitempty"`
 }
 
 func (client *Client) CreateWebhookAction(input CustomActionsWebhookActionCreateInput) (*CustomActionsExternalAction, error) {
@@ -192,6 +195,9 @@ func (client *Client) CreateTriggerDefinition(input CustomActionsTriggerDefiniti
 	}
 	if input.AccessControl == "" {
 		input.AccessControl = CustomActionsTriggerDefinitionAccessControlEnumEveryone
+	}
+	if input.EntityType == "" {
+		input.EntityType = CustomActionsEntityTypeEnumService
 	}
 	v := PayloadVariables{
 		"input": input,

--- a/actions_test.go
+++ b/actions_test.go
@@ -1,9 +1,10 @@
 package opslevel_test
 
 import (
+	"testing"
+
 	ol "github.com/opslevel/opslevel-go/v2023"
 	"github.com/rocktavious/autopilot/v2022"
-	"testing"
 )
 
 func TestCreateWebhookAction(t *testing.T) {
@@ -170,7 +171,7 @@ func TestCreateTriggerDefinition(t *testing.T) {
 	//Arrange
 	request := `{"query":
 		"mutation TriggerDefinitionCreate($input:CustomActionsTriggerDefinitionCreateInput!){customActionsTriggerDefinitionCreate(input: $input){triggerDefinition{{ template "custom_actions_trigger_request" }},errors{message,path}}}",
-		"variables":{"input":{"actionId":"123456789", "description":"Disables the Deploy Freeze","filterId":"987654321","manualInputsDefinition":"", "name":"Deploy Rollback","ownerId":"123456789", "accessControl": "everyone", "responseTemplate": ""}}
+		"variables":{"input":{"actionId":"123456789", "description":"Disables the Deploy Freeze","entityType":"SERVICE","filterId":"987654321","manualInputsDefinition":"", "name":"Deploy Rollback","ownerId":"123456789", "accessControl": "everyone", "responseTemplate": ""}}
 	}`
 	response := `{"data": {"customActionsTriggerDefinitionCreate": {
      "triggerDefinition": {{ template "custom_action_trigger1" }},
@@ -214,7 +215,7 @@ func TestGetTriggerDefinition(t *testing.T) {
 func TestListTriggerDefinitions(t *testing.T) {
 	//Arrange
 	requests := []TestRequest{
-		{`{"query": "query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{action{aliases,id},aliases,description,filter{id,name},id,manualInputsDefinition,name,owner{alias,id},published,timestamps{createdAt,updatedAt},accessControl,responseTemplate},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
+		{`{"query": "query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{action{aliases,id},aliases,description,filter{id,name},id,manualInputsDefinition,name,owner{alias,id},published,timestamps{createdAt,updatedAt},accessControl,responseTemplate,entityType},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
 			{{ template "pagination_initial_query_variables" }}
 			}`,
 			`{
@@ -232,7 +233,7 @@ func TestListTriggerDefinitions(t *testing.T) {
 							{{ template "pagination_initial_pageInfo_response" }},
 							"totalCount": 2
 						  }}}}`},
-		{`{"query": "query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{action{aliases,id},aliases,description,filter{id,name},id,manualInputsDefinition,name,owner{alias,id},published,timestamps{createdAt,updatedAt},accessControl,responseTemplate},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
+		{`{"query": "query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{action{aliases,id},aliases,description,filter{id,name},id,manualInputsDefinition,name,owner{alias,id},published,timestamps{createdAt,updatedAt},accessControl,responseTemplate,entityType},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
 			{{ template "pagination_second_query_variables" }}
 			}`,
 			`{

--- a/actions_test.go
+++ b/actions_test.go
@@ -192,6 +192,32 @@ func TestCreateTriggerDefinition(t *testing.T) {
 	autopilot.Equals(t, "Release", trigger.Name)
 }
 
+func TestCreateTriggerDefinitionWithGlobalEntityType(t *testing.T) {
+	//Arrange
+	request := `{"query":
+		"mutation TriggerDefinitionCreate($input:CustomActionsTriggerDefinitionCreateInput!){customActionsTriggerDefinitionCreate(input: $input){triggerDefinition{{ template "custom_actions_trigger_request" }},errors{message,path}}}",
+		"variables":{"input":{"actionId":"123456789", "description":"Disables the Deploy Freeze","entityType":"GLOBAL","filterId":"987654321","manualInputsDefinition":"", "name":"Deploy Rollback","ownerId":"123456789", "accessControl": "everyone", "responseTemplate": ""}}
+	}`
+	response := `{"data": {"customActionsTriggerDefinitionCreate": {
+     "triggerDefinition": {{ template "custom_action_trigger1" }},
+     "errors": []
+ }}}`
+
+	client := ABetterTestClient(t, "custom_actions/create_trigger_with_global_entity", request, response)
+	// Act
+	trigger, err := client.CreateTriggerDefinition(ol.CustomActionsTriggerDefinitionCreateInput{
+		Name:        "Deploy Rollback",
+		Description: ol.NewString("Disables the Deploy Freeze"),
+		Action:      "123456789",
+		Owner:       "123456789",
+		Filter:      ol.NewID("987654321"),
+		EntityType:  "GLOBAL",
+	})
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Release", trigger.Name)
+}
+
 func TestGetTriggerDefinition(t *testing.T) {
 	//Arrange
 	request := `{"query":

--- a/testdata/templates/custom_actions.tpl
+++ b/testdata/templates/custom_actions.tpl
@@ -103,7 +103,7 @@
     }
 {{ end }}
 {{- define "custom_actions_request" }}{aliases,id,description,liquidTemplate,name,... on CustomActionsWebhookAction{headers,httpMethod,webhookUrl}}{{ end }}
-{{- define "custom_actions_trigger_request" }}{action{aliases,id},aliases,description,filter{id,name},id,manualInputsDefinition,name,owner{alias,id},published,timestamps{createdAt,updatedAt},accessControl,responseTemplate}{{ end }}
+{{- define "custom_actions_trigger_request" }}{action{aliases,id},aliases,description,filter{id,name},id,manualInputsDefinition,name,owner{alias,id},published,timestamps{createdAt,updatedAt},accessControl,responseTemplate,entityType}{{ end }}
 {{- define "custom_action1" }}{
     "aliases": [],
     "description": null,
@@ -136,6 +136,7 @@
     },
     "aliases": [],
     "description": "Disables the Deploy Freeze",
+    "entityType": "SERVICE",
     "filter": {
       "id": "987654321",
       "name": "Uses Ruby and Deploys Frozen"


### PR DESCRIPTION
OpsLevel added supported for Actions on the [Self Service page](https://docs.opslevel.com/docs/getting-started-with-custom-actions#using-actions-on-the-self-service-page) and this support needs to be added to the OpsLevel go client.