### PR TITLE
Adding New Relic as a new AlertSource Enum

### DIFF
--- a/.changes/unreleased/Feature-20230608-102218.yaml
+++ b/.changes/unreleased/Feature-20230608-102218.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for new Alert Source Type - New Relic
+time: 2023-06-08T10:22:18.59278-04:00

--- a/enum.go
+++ b/enum.go
@@ -29,6 +29,7 @@ const (
 	AlertSourceTypeEnumDatadog   AlertSourceTypeEnum = "datadog"   // A Datadog alert source (aka monitor).
 	AlertSourceTypeEnumOpsgenie  AlertSourceTypeEnum = "opsgenie"  // An Opsgenie alert source (aka service).
 	AlertSourceTypeEnumPagerduty AlertSourceTypeEnum = "pagerduty" // A PagerDuty alert source (aka service).
+	AlertSourceTypeEnumNewRelic   AlertSourceTypeEnum = "new_relic"   // A New Relic alert source (aka monitor).
 )
 
 // All AlertSourceTypeEnum as []string
@@ -36,6 +37,7 @@ var AllAlertSourceTypeEnum = []string{
 	string(AlertSourceTypeEnumDatadog),
 	string(AlertSourceTypeEnumOpsgenie),
 	string(AlertSourceTypeEnumPagerduty),
+	string(AlertSourceTypeEnumNewRelic),
 }
 
 // AliasOwnerTypeEnum represents the owner type an alias is assigned to.


### PR DESCRIPTION
[Ticket](https://gitlab.com/jklabsinc/OpsLevel/-/issues/7418)

Add a new AlertSource enum type for New Relic `new_relic`