### PR TITLE
Add Create/Update for New Relic Integrations

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -57,7 +57,7 @@ func TestCache(t *testing.T) {
                     "nodes":[{{ template "filter_1" }}]
                 }
             }}}`},
-		{`{"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
+		{`{"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
 			"variables":{
                 "after": "",
                 "first": 100

--- a/integration.go
+++ b/integration.go
@@ -51,7 +51,7 @@ type AWSIntegrationInput struct {
 }
 
 type NewRelicIntegrationInput struct {
-	Id   								*string 	`json:"id,omitempty"`
+	Id   								ID     		`json:"id,omitempty"`
 	Alias   						*string		`json:"alias,omitempty"`
 	ApiKey							*string		`json:"apiKey,omitempty"`
 	BaseUrl							*string		`json:"baseUrl,omitempty"`

--- a/integration.go
+++ b/integration.go
@@ -19,7 +19,7 @@ type Integration struct {
 	CreatedAt   iso8601.Time `graphql:"createdAt"`
 	InstalledAt iso8601.Time `graphql:"installedAt"`
 
-	AWSIntegrationFragment `graphql:"... on AwsIntegration"`
+	AWSIntegrationFragment      `graphql:"... on AwsIntegration"`
 	NewRelicIntegrationFragment `graphql:"... on NewRelicIntegration"`
 }
 
@@ -31,34 +31,34 @@ type AWSIntegrationFragment struct {
 }
 
 type NewRelicIntegrationFragment struct {
-	ApiKey							string   `graphql:"apiKey"`
-	BaseUrl							string   `graphql:"baseUrl"`
-	AccountKey					string 	 `graphql:"accountKey"`
+	ApiKey     string `graphql:"apiKey"`
+	BaseUrl    string `graphql:"baseUrl"`
+	AccountKey string `graphql:"accountKey"`
 }
 
 type IntegrationConnection struct {
-	Nodes								[]Integration
-	PageInfo						PageInfo
-	TotalCount					int
+	Nodes      []Integration
+	PageInfo   PageInfo
+	TotalCount int
 }
 
 type AWSIntegrationInput struct {
-	Name                 *string	`json:"name,omitempty"`
-	IAMRole              *string	`json:"iamRole,omitempty"`
-	ExternalID           *string	`json:"externalId,omitempty"`
-	OwnershipTagOverride *bool		`json:"awsTagsOverrideOwnership,omitempty"`
-	OwnershipTagKeys     []string	`json:"ownershipTagKeys"`
+	Name                 *string  `json:"name,omitempty"`
+	IAMRole              *string  `json:"iamRole,omitempty"`
+	ExternalID           *string  `json:"externalId,omitempty"`
+	OwnershipTagOverride *bool    `json:"awsTagsOverrideOwnership,omitempty"`
+	OwnershipTagKeys     []string `json:"ownershipTagKeys"`
 }
 
 type NewRelicIntegrationInput struct {
-	Id   								ID     		`json:"id,omitempty"`
-	Alias   						*string		`json:"alias,omitempty"`
-	ApiKey							*string		`json:"apiKey,omitempty"`
-	BaseUrl							*string		`json:"baseUrl,omitempty"`
-	AccountKey					*string		`json:"accountKey,omitempty"`
+	Id         ID      `json:"id,omitempty"`
+	Alias      *string `json:"alias,omitempty"`
+	ApiKey     *string `json:"apiKey,omitempty"`
+	BaseUrl    *string `json:"baseUrl,omitempty"`
+	AccountKey *string `json:"accountKey,omitempty"`
 }
 
-func (s AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
+func (s AWSIntegrationInput) GetGraphQLType() string      { return "AwsIntegrationInput" }
 func (s NewRelicIntegrationInput) GetGraphQLType() string { return "NewRelicIntegrationInput" }
 
 func (self *IntegrationId) Alias() string {
@@ -172,7 +172,7 @@ func (client *Client) UpdateIntegrationNewRelic(input NewRelicIntegrationInput) 
 		} `graphql:"newRelicIntegrationUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
-		"input":       input,
+		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)

--- a/integration.go
+++ b/integration.go
@@ -33,7 +33,7 @@ type AWSIntegrationFragment struct {
 type NewRelicIntegrationFragment struct {
 	ApiKey              string   `graphql:"apiKey"`
 	BaseUrl           	string   `graphql:"baseUrl"`
-	AccountKey     		string 	 `graphql:"accountKey"`
+	AccountKey     		  string 	 `graphql:"accountKey"`
 }
 
 type IntegrationConnection struct {
@@ -50,10 +50,16 @@ type AWSIntegrationInput struct {
 	OwnershipTagKeys     []string `json:"ownershipTagKeys"`
 }
 
+type IntegrationInput struct {
+	Id   								*string     `json:"id,omitempty"`
+	Alias   						*string     `json:"alias,omitempty"`
+}
+
 type NewRelicIntegrationInput struct {
-	ApiKey           	*string  `json:"apiKey,omitempty"`
-	BaseUrl 			*string  `json:"baseUrl,omitempty"`
-	AccountKey     		*string  `json:"accountKey,omitempty"`
+	Integration 			IntegrationInput  `graphql:"integration"`
+	ApiKey           	*string  					`json:"apiKey,omitempty"`
+	BaseUrl 					*string  					`json:"baseUrl,omitempty"`
+	AccountKey     		*string  					`json:"accountKey,omitempty"`
 }
 
 func (s AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
@@ -90,6 +96,7 @@ func (client *Client) CreateIntegrationNewRelic(input NewRelicIntegrationInput) 
 			Errors      []OpsLevelErrors
 		} `graphql:"newRelicIntegrationCreate(input: $input)"`
 	}
+
 	v := PayloadVariables{
 		"input": input,
 	}
@@ -161,15 +168,14 @@ func (client *Client) UpdateIntegrationAWS(identifier string, input AWSIntegrati
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) UpdateIntegrationNewRelic(identifier string, input NewRelicIntegrationInput) (*Integration, error) {
+func (client *Client) UpdateIntegrationNewRelic(input NewRelicIntegrationInput) (*Integration, error) {
 	var m struct {
 		Payload struct {
 			Integration *Integration
 			Errors      []OpsLevelErrors
-		} `graphql:"newRelicIntegrationUpdate(integration: $integration input: $input)"`
+		} `graphql:"newRelicIntegrationUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
-		"integration": *NewIdentifier(identifier),
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))

--- a/integration.go
+++ b/integration.go
@@ -51,8 +51,6 @@ type AWSIntegrationInput struct {
 }
 
 type NewRelicIntegrationInput struct {
-	Id         ID      `json:"id,omitempty"`
-	Alias      *string `json:"alias,omitempty"`
 	ApiKey     *string `json:"apiKey,omitempty"`
 	BaseUrl    *string `json:"baseUrl,omitempty"`
 	AccountKey *string `json:"accountKey,omitempty"`
@@ -164,15 +162,16 @@ func (client *Client) UpdateIntegrationAWS(identifier string, input AWSIntegrati
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) UpdateIntegrationNewRelic(input NewRelicIntegrationInput) (*Integration, error) {
+func (client *Client) UpdateIntegrationNewRelic(resource IdentifierInput, input NewRelicIntegrationInput) (*Integration, error) {
 	var m struct {
 		Payload struct {
 			Integration *Integration
 			Errors      []OpsLevelErrors
-		} `graphql:"newRelicIntegrationUpdate(input: $input)"`
+		} `graphql:"newRelicIntegrationUpdate(input: $input resource: $resource)"`
 	}
 	v := PayloadVariables{
-		"input": input,
+		"resource": resource,
+		"input":    input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)

--- a/integration.go
+++ b/integration.go
@@ -162,7 +162,7 @@ func (client *Client) UpdateIntegrationAWS(identifier string, input AWSIntegrati
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) UpdateIntegrationNewRelic(resource IdentifierInput, input NewRelicIntegrationInput) (*Integration, error) {
+func (client *Client) UpdateIntegrationNewRelic(identifier string, input NewRelicIntegrationInput) (*Integration, error) {
 	var m struct {
 		Payload struct {
 			Integration *Integration
@@ -170,7 +170,7 @@ func (client *Client) UpdateIntegrationNewRelic(resource IdentifierInput, input 
 		} `graphql:"newRelicIntegrationUpdate(input: $input resource: $resource)"`
 	}
 	v := PayloadVariables{
-		"resource": resource,
+		"resource":  *NewIdentifier(identifier),
 		"input":    input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))

--- a/integration.go
+++ b/integration.go
@@ -20,6 +20,7 @@ type Integration struct {
 	InstalledAt iso8601.Time `graphql:"installedAt"`
 
 	AWSIntegrationFragment `graphql:"... on AwsIntegration"`
+	NewRelicIntegrationFragment `graphql:"... on NewRelicIntegration"`
 }
 
 type AWSIntegrationFragment struct {
@@ -27,6 +28,12 @@ type AWSIntegrationFragment struct {
 	ExternalID           string   `graphql:"externalId"`
 	OwnershipTagOverride bool     `graphql:"awsTagsOverrideOwnership"`
 	OwnershipTagKeys     []string `graphql:"ownershipTagKeys"`
+}
+
+type NewRelicIntegrationFragment struct {
+	ApiKey              string   `graphql:"apiKey"`
+	BaseUrl           	string   `graphql:"baseUrl"`
+	AccountKey     		string 	 `graphql:"accountKey"`
 }
 
 type IntegrationConnection struct {
@@ -43,7 +50,14 @@ type AWSIntegrationInput struct {
 	OwnershipTagKeys     []string `json:"ownershipTagKeys"`
 }
 
+type NewRelicIntegrationInput struct {
+	ApiKey           	*string  `json:"apiKey,omitempty"`
+	BaseUrl 			*string  `json:"baseUrl,omitempty"`
+	AccountKey     		*string  `json:"accountKey,omitempty"`
+}
+
 func (s AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
+func (s NewRelicIntegrationInput) GetGraphQLType() string { return "NewRelicIntegrationInput" }
 
 func (self *IntegrationId) Alias() string {
 	return fmt.Sprintf("%s-%s", slug.Make(self.Type), slug.Make(self.Name))
@@ -66,6 +80,20 @@ func (client *Client) CreateIntegrationAWS(input AWSIntegrationInput) (*Integrat
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("AWSIntegrationCreate"))
+	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) CreateIntegrationNewRelic(input NewRelicIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload struct {
+			Integration *Integration
+			Errors      []OpsLevelErrors
+		} `graphql:"newRelicIntegrationCreate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("NewRelicIntegrationCreate"))
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
@@ -130,6 +158,21 @@ func (client *Client) UpdateIntegrationAWS(identifier string, input AWSIntegrati
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("AWSIntegrationUpdate"))
+	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) UpdateIntegrationNewRelic(identifier string, input NewRelicIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload struct {
+			Integration *Integration
+			Errors      []OpsLevelErrors
+		} `graphql:"newRelicIntegrationUpdate(integration: $integration input: $input)"`
+	}
+	v := PayloadVariables{
+		"integration": *NewIdentifier(identifier),
+		"input":       input,
+	}
+	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 

--- a/integration.go
+++ b/integration.go
@@ -31,35 +31,31 @@ type AWSIntegrationFragment struct {
 }
 
 type NewRelicIntegrationFragment struct {
-	ApiKey              string   `graphql:"apiKey"`
-	BaseUrl           	string   `graphql:"baseUrl"`
-	AccountKey     		  string 	 `graphql:"accountKey"`
+	ApiKey							string   `graphql:"apiKey"`
+	BaseUrl							string   `graphql:"baseUrl"`
+	AccountKey					string 	 `graphql:"accountKey"`
 }
 
 type IntegrationConnection struct {
-	Nodes      []Integration
-	PageInfo   PageInfo
-	TotalCount int
+	Nodes								[]Integration
+	PageInfo						PageInfo
+	TotalCount					int
 }
 
 type AWSIntegrationInput struct {
-	Name                 *string  `json:"name,omitempty"`
-	IAMRole              *string  `json:"iamRole,omitempty"`
-	ExternalID           *string  `json:"externalId,omitempty"`
-	OwnershipTagOverride *bool    `json:"awsTagsOverrideOwnership,omitempty"`
-	OwnershipTagKeys     []string `json:"ownershipTagKeys"`
-}
-
-type IntegrationInput struct {
-	Id   								*string     `json:"id,omitempty"`
-	Alias   						*string     `json:"alias,omitempty"`
+	Name                 *string	`json:"name,omitempty"`
+	IAMRole              *string	`json:"iamRole,omitempty"`
+	ExternalID           *string	`json:"externalId,omitempty"`
+	OwnershipTagOverride *bool		`json:"awsTagsOverrideOwnership,omitempty"`
+	OwnershipTagKeys     []string	`json:"ownershipTagKeys"`
 }
 
 type NewRelicIntegrationInput struct {
-	Integration 			IntegrationInput  `graphql:"integration"`
-	ApiKey           	*string  					`json:"apiKey,omitempty"`
-	BaseUrl 					*string  					`json:"baseUrl,omitempty"`
-	AccountKey     		*string  					`json:"accountKey,omitempty"`
+	Id   								*string 	`json:"id,omitempty"`
+	Alias   						*string		`json:"alias,omitempty"`
+	ApiKey							*string		`json:"apiKey,omitempty"`
+	BaseUrl							*string		`json:"baseUrl,omitempty"`
+	AccountKey					*string		`json:"accountKey,omitempty"`
 }
 
 func (s AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }

--- a/integration_test.go
+++ b/integration_test.go
@@ -79,8 +79,8 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 	client := ABetterTestClient(t, "integration/create_new_relic", request, response)
 	// Act
 	result, err := client.CreateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
-		ApiKey:		opslevel.NewString("123456789"),
-		BaseUrl: 	opslevel.NewString("https://api.newrelic.com/graphql"),
+		ApiKey:     opslevel.NewString("123456789"),
+		BaseUrl:    opslevel.NewString("https://api.newrelic.com/graphql"),
 		AccountKey: opslevel.NewString("XXXX"),
 	})
 	// Assert
@@ -260,8 +260,8 @@ func TestUpdateNewRelicIntegration(t *testing.T) {
 	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
 	// Act
 	result, err := client.UpdateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
-		BaseUrl:	opslevel.NewString("https://api-test.newrelic.com/graphql"),
-		Id: opslevel.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
+		BaseUrl: opslevel.NewString("https://api-test.newrelic.com/graphql"),
+		Id:      opslevel.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -49,6 +49,46 @@ func TestCreateAWSIntegration(t *testing.T) {
 	autopilot.Equals(t, "AWS - XXXX", result.Name)
 }
 
+func TestCreateNewRelicIntegration(t *testing.T) {
+	// Arrange
+	request := `{
+	"query": "mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
+	"variables":{
+		"input": {
+			"apiKey": "123456789",
+			"baseUrl": "https://api.newrelic.com/graphql",
+			"accountKey": "XXXX"
+		}
+    }
+}`
+	response := `{"data": {
+	"newRelicIntegrationCreate": {
+		"integration": {
+			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+			"name": "New Relic - XXXX",
+			"type": "new_relic",
+			"createdAt": "2023-04-26T16:25:29.574450Z",
+			"installedAt": "2023-04-26T16:25:28.541124Z",
+			"apiKey": "123456789",
+			"accountKey": "XXXX",
+			"baseUrl": "https://api.newrelic.com/graphql"
+		},
+		"errors": []
+	}
+}}`
+	client := ABetterTestClient(t, "integration/create_new_relic", request, response)
+	// Act
+	result, err := client.CreateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
+		ApiKey:    opslevel.NewString("123456789"),
+		BaseUrl: opslevel.NewString("https://api.newrelic.com/graphql"),
+		AccountKey: opslevel.NewString("XXXX"),
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
+	autopilot.Equals(t, "New Relic - XXXX", result.Name)
+}
+
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	request := `{
@@ -187,6 +227,44 @@ func TestUpdateAWSIntegration(t *testing.T) {
 	autopilot.Equals(t, nil, err)
 	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
 	autopilot.Equals(t, "Dev2", result.Name)
+}
+
+func TestUpdateNewRelicIntegration(t *testing.T) {
+	// Arrange
+	request := `{
+	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$integration:IdentifierInput!){newRelicIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
+		"integration": {
+			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+		},
+		"input": {
+			"baseUrl": "https://api-test.newrelic.com/graphql"
+		}
+	}
+}`
+	response := `{"data": {
+		"newRelicIntegrationUpdate": {
+			"integration": {
+			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+			"name": "New Relic - XXXX",
+			"type": "new_relic",
+			"createdAt": "2023-04-26T16:25:29.574450Z",
+			"installedAt": "2023-04-26T16:25:28.541124Z",
+			"apiKey": "123456789",
+			"accountKey": "XXXX",
+			"baseUrl": "https://api-test.newrelic.com/graphql"
+		},
+		"errors": []
+	}
+}}`
+	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
+	// Act
+	result, err := client.UpdateIntegrationNewRelic("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", opslevel.NewRelicIntegrationInput{
+		BaseUrl:       opslevel.NewString("https://api-test.newrelic.com/graphql"),
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
+	autopilot.Equals(t, "https://api-test.newrelic.com/graphql", result.BaseUrl)
 }
 
 func TestDeleteIntegration(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -10,7 +10,7 @@ import (
 func TestCreateAWSIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},errors{message,path}}}",
+	"query": "mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
 	"variables":{
 		"input": {
 			"iamRole": "arn:aws:iam::XXXX:role/aws-integration-role",
@@ -52,15 +52,16 @@ func TestCreateAWSIntegration(t *testing.T) {
 func TestCreateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
-	"variables":{
-		"input": {
-			"apiKey": "123456789",
-			"baseUrl": "https://api.newrelic.com/graphql",
-			"accountKey": "XXXX"
+		"query": "mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
+		"variables": {
+			"input": {
+				"integration": {},
+				"apiKey": "123456789",
+				"baseUrl": "https://api.newrelic.com/graphql",
+				"accountKey": "XXXX"
+			}
 		}
-    }
-}`
+	}`
 	response := `{"data": {
 	"newRelicIntegrationCreate": {
 		"integration": {
@@ -79,8 +80,8 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 	client := ABetterTestClient(t, "integration/create_new_relic", request, response)
 	// Act
 	result, err := client.CreateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
-		ApiKey:    opslevel.NewString("123456789"),
-		BaseUrl: opslevel.NewString("https://api.newrelic.com/graphql"),
+		ApiKey:		opslevel.NewString("123456789"),
+		BaseUrl: 	opslevel.NewString("https://api.newrelic.com/graphql"),
 		AccountKey: opslevel.NewString("XXXX"),
 	})
 	// Assert
@@ -92,7 +93,7 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}}}}",
+	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}}}}",
 	"variables":{
 		"id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDEf"
     }
@@ -118,7 +119,7 @@ func TestGetIntegration(t *testing.T) {
 func TestGetMissingIntegraion(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}}}}",
+	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}}}}",
 	"variables":{
 		"id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDEf"
     }
@@ -138,7 +139,7 @@ func TestGetMissingIntegraion(t *testing.T) {
 func TestListIntegrations(t *testing.T) {
 	// Arrange
 	requests := []TestRequest{
-		{`{"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
+		{`{"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
 			{{ template "pagination_initial_query_variables" }}
 			}`,
 			`{
@@ -150,13 +151,13 @@ func TestListIntegrations(t *testing.T) {
 									{{ template "deploy_integration_response" }}
 								},
 								{
-									{{ template "payload_integration_response" }} 
+									{{ template "payload_integration_response" }}
 								}
 							],
 							{{ template "pagination_initial_pageInfo_response" }},
 							"totalCount": 2
 					}}}}`},
-		{`{"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
+		{`{"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}",
 			{{ template "pagination_second_query_variables" }}
 			}`,
 			`{
@@ -187,7 +188,7 @@ func TestListIntegrations(t *testing.T) {
 func TestUpdateAWSIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},errors{message,path}}}",
+	"query": "mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
 	"variables":{
 		"integration": {
 			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
@@ -231,16 +232,19 @@ func TestUpdateAWSIntegration(t *testing.T) {
 
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
+
 	request := `{
-	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$integration:IdentifierInput!){newRelicIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
-		"integration": {
-			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
-		},
+	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!){newRelicIntegrationUpdate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
+	"variables":{
 		"input": {
+			"integration": {
+				"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+			},
 			"baseUrl": "https://api-test.newrelic.com/graphql"
 		}
 	}
 }`
+
 	response := `{"data": {
 		"newRelicIntegrationUpdate": {
 			"integration": {
@@ -256,10 +260,15 @@ func TestUpdateNewRelicIntegration(t *testing.T) {
 		"errors": []
 	}
 }}`
+
 	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
 	// Act
-	result, err := client.UpdateIntegrationNewRelic("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", opslevel.NewRelicIntegrationInput{
-		BaseUrl:       opslevel.NewString("https://api-test.newrelic.com/graphql"),
+	integrationInput := opslevel.IntegrationInput{
+		Id: opslevel.NewString("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
+	}
+	result, err := client.UpdateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
+		BaseUrl:	opslevel.NewString("https://api-test.newrelic.com/graphql"),
+		Integration: integrationInput,
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -261,7 +261,7 @@ func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Act
 	result, err := client.UpdateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
 		BaseUrl:	opslevel.NewString("https://api-test.newrelic.com/graphql"),
-		Id: opslevel.NewString("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
+		Id: opslevel.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -232,14 +232,16 @@ func TestUpdateAWSIntegration(t *testing.T) {
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-		"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!){newRelicIntegrationUpdate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
-		"variables":{
-			"input": {
-				"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
-				"baseUrl": "https://api-test.newrelic.com/graphql"
-			}
+	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
+	"variables":{
+		"resource": {
+			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+		},
+		"input": {
+			"baseUrl": "https://api-test.newrelic.com/graphql"
 		}
-	}`
+	}
+}`
 
 	response := `{"data": {
 		"newRelicIntegrationUpdate": {
@@ -259,10 +261,12 @@ func TestUpdateNewRelicIntegration(t *testing.T) {
 
 	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
 	// Act
-	result, err := client.UpdateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
-		BaseUrl: opslevel.NewString("https://api-test.newrelic.com/graphql"),
-		Id:      opslevel.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
-	})
+	result, err := client.UpdateIntegrationNewRelic(
+		opslevel.IdentifierInput{Id: "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"},
+		opslevel.NewRelicIntegrationInput{
+			BaseUrl: opslevel.NewString("https://api-test.newrelic.com/graphql"),
+		},
+	)
 	// Assert
 	autopilot.Equals(t, nil, err)
 	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))

--- a/integration_test.go
+++ b/integration_test.go
@@ -262,7 +262,7 @@ func TestUpdateNewRelicIntegration(t *testing.T) {
 	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
 	// Act
 	result, err := client.UpdateIntegrationNewRelic(
-		opslevel.IdentifierInput{Id: "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"},
+		"Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
 		opslevel.NewRelicIntegrationInput{
 			BaseUrl: opslevel.NewString("https://api-test.newrelic.com/graphql"),
 		},

--- a/integration_test.go
+++ b/integration_test.go
@@ -55,7 +55,6 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 		"query": "mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
 		"variables": {
 			"input": {
-				"integration": {},
 				"apiKey": "123456789",
 				"baseUrl": "https://api.newrelic.com/graphql",
 				"accountKey": "XXXX"
@@ -232,18 +231,15 @@ func TestUpdateAWSIntegration(t *testing.T) {
 
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
-
 	request := `{
-	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!){newRelicIntegrationUpdate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
-	"variables":{
-		"input": {
-			"integration": {
-				"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
-			},
-			"baseUrl": "https://api-test.newrelic.com/graphql"
+		"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!){newRelicIntegrationUpdate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{apiKey,baseUrl,accountKey}},errors{message,path}}}",
+		"variables":{
+			"input": {
+				"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+				"baseUrl": "https://api-test.newrelic.com/graphql"
+			}
 		}
-	}
-}`
+	}`
 
 	response := `{"data": {
 		"newRelicIntegrationUpdate": {
@@ -263,12 +259,9 @@ func TestUpdateNewRelicIntegration(t *testing.T) {
 
 	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
 	// Act
-	integrationInput := opslevel.IntegrationInput{
-		Id: opslevel.NewString("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
-	}
 	result, err := client.UpdateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
 		BaseUrl:	opslevel.NewString("https://api-test.newrelic.com/graphql"),
-		Integration: integrationInput,
+		Id: opslevel.NewString("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"),
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)


### PR DESCRIPTION
- Added a new NewRelicIntegration struct 
- Added new functions to allow Create and Update actions for New Relic using GraphQL 
    - `CreateIntegrationNewRelic` uses GraphQL `newRelicIntegrationCreate`
   - `UpdateIntegrationNewRelic` uses GraphQL `newRelicIntegrationUpdate`
   
[Gitlab Ticket](https://gitlab.com/jklabsinc/OpsLevel/-/issues/7418)