### PR TITLE
Db/add taskfile and lint fixes

### DIFF
--- a/.changes/unreleased/Feature-20230706-091356.yaml
+++ b/.changes/unreleased/Feature-20230706-091356.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add Taskfile for high level tasks
+time: 2023-07-06T09:13:56.725199-05:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,24 @@
+# https://taskfile.dev/
+
+version: '3'
+
+tasks:
+  lint:
+    desc: Formatting and linting
+    cmds:
+      - gofmt -d .
+      - go vet ./...
+      - golangci-lint run
+
+  lintfix:
+    desc: Fix formatting and linting
+    cmds:
+      - gofmt -w .
+      - go vet ./...
+      - golangci-lint run --fix
+
+  test:
+    desc: Run tests
+    cmds:
+      - go test -v ./... {{ .CLI_ARGS }}
+    silent: true

--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func SetAPIToken(apiToken string) Option {
 
 func SetURL(url string) Option {
 	return func(c *ClientSettings) {
-		c.url = fmt.Sprintf("%s", strings.TrimRight(url, "/"))
+		c.url = strings.TrimRight(url, "/")
 	}
 }
 

--- a/clientGQL_test.go
+++ b/clientGQL_test.go
@@ -44,7 +44,9 @@ func GraphQLQueryTemplate(request string) autopilot.GraphqlQuery {
 	exp := autopilot.GraphqlQuery{
 		Variables: nil,
 	}
-	json.Unmarshal([]byte(Templated(request)), &exp)
+	if err := json.Unmarshal([]byte(Templated(request)), &exp); err != nil {
+		panic(err)
+	}
 	return exp
 }
 

--- a/enum.go
+++ b/enum.go
@@ -29,7 +29,7 @@ const (
 	AlertSourceTypeEnumDatadog   AlertSourceTypeEnum = "datadog"   // A Datadog alert source (aka monitor).
 	AlertSourceTypeEnumOpsgenie  AlertSourceTypeEnum = "opsgenie"  // An Opsgenie alert source (aka service).
 	AlertSourceTypeEnumPagerduty AlertSourceTypeEnum = "pagerduty" // A PagerDuty alert source (aka service).
-	AlertSourceTypeEnumNewRelic   AlertSourceTypeEnum = "new_relic"   // A New Relic alert source (aka monitor).
+	AlertSourceTypeEnumNewRelic  AlertSourceTypeEnum = "new_relic" // A New Relic alert source (aka monitor).
 )
 
 // All AlertSourceTypeEnum as []string
@@ -301,7 +301,7 @@ const (
 )
 
 // All ServiceOwnershipContactType as []string
-var AllServiceOwnershipCheckContactType = []string {
+var AllServiceOwnershipCheckContactType = []string{
 	string(ServiceOwnershipCheckContactTypeAny),
 	string(ServiceOwnershipCheckContactTypeSlack),
 	string(ServiceOwnershipCheckContactTypeSlackHandle),

--- a/integration.go
+++ b/integration.go
@@ -169,7 +169,7 @@ func (client *Client) UpdateIntegrationNewRelic(identifier string, input NewReli
 		} `graphql:"newRelicIntegrationUpdate(input: $input resource: $resource)"`
 	}
 	v := PayloadVariables{
-		"resource":  *NewIdentifier(identifier),
+		"resource": *NewIdentifier(identifier),
 		"input":    input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))

--- a/level.go
+++ b/level.go
@@ -53,9 +53,7 @@ func (conn *LevelConnection) Hydrate(client *Client) error {
 		if err := client.Query(&q, v); err != nil {
 			return err
 		}
-		for _, item := range q.Account.Rubric.Levels.Nodes {
-			conn.Nodes = append(conn.Nodes, item)
-		}
+		conn.Nodes = append(conn.Nodes, q.Account.Rubric.Levels.Nodes...)
 	}
 	return nil
 }

--- a/team.go
+++ b/team.go
@@ -14,7 +14,7 @@ type Contact struct {
 
 type ContactInput struct {
 	Type        ContactType `json:"type"`
-	DisplayName string      `json:"displayName,omitEmpty"`
+	DisplayName string      `json:"displayName,omitempty"`
 	Address     string      `json:"address"`
 }
 


### PR DESCRIPTION
Add Taskfile.yml to perform `task lint`, `task lintfix`, and `task test`.

Running these pointed out a few minor fixes that were needed and formatted some parts of the code.