### PR TITLE
Fixes for the CLI

### DIFF
--- a/infra.go
+++ b/infra.go
@@ -14,13 +14,13 @@ type InfrastructureResourceSchemaConnection struct {
 }
 
 type InfrastructureResource struct {
-	Id          string      `json:"id"`
-	Aliases     []string    `json:"aliases"`
-	Name        string      `json:"name"`
-	Type        string      `json:"type" graphql:"type @include(if: $all)"`
-	Owner       EntityOwner `json:"owner" graphql:"owner @include(if: $all)"`
-	OwnerLocked bool        `json:"ownerLocked" graphql:"ownerLocked @include(if: $all)"`
-	Data        JSON        `json:"data" scalar:"true" graphql:"data @include(if: $all)"`
+	Id          string         `json:"id"`
+	Aliases     []string       `json:"aliases"`
+	Name        string         `json:"name"`
+	Type        string         `json:"type" graphql:"type @include(if: $all)"`
+	Owner       EntityOwner    `json:"owner" graphql:"owner @include(if: $all)"`
+	OwnerLocked bool           `json:"ownerLocked" graphql:"ownerLocked @include(if: $all)"`
+	Data        map[string]any `json:"data" scalar:"true" graphql:"data @include(if: $all)"`
 }
 
 type InfrastructureResourceConnection struct {
@@ -30,21 +30,21 @@ type InfrastructureResourceConnection struct {
 }
 
 type InfrastructureResourceSchemaInput struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 }
 
 type InfrastructureResourceProviderInput struct {
-	AccountName  string `json:"accountName"`
-	ExternalURL  string `json:"externalUrl"`
-	ProviderName string `json:"providerName"`
+	AccountName  string `json:"accountName" yaml:"accountName"`
+	ExternalURL  string `json:"externalUrl" yaml:"externalUrl"`
+	ProviderName string `json:"providerName" yaml:"providerName"`
 }
 
 type InfrastructureResourceInput struct {
-	Type         *string                              `json:"providerResourceType,omitempty"`
+	Type         *string                              `json:"providerResourceType,omitempty" yaml:"providerResourceType"`
 	Schema       *InfrastructureResourceSchemaInput   `json:"schema,omitempty"`
-	ProviderData *InfrastructureResourceProviderInput `json:"providerData,omitempty"`
-	Owner        *ID                                  `json:"ownerId,omitempty"`
-	Data         JSON                                 `json:"data,omitempty" scalar:"true"`
+	ProviderData *InfrastructureResourceProviderInput `json:"providerData,omitempty" yaml:"providerData"`
+	Owner        *ID                                  `json:"ownerId,omitempty" yaml:"owner"`
+	Data         map[string]any                       `json:"data,omitempty" yaml:"data"`
 }
 
 func (client *Client) CreateInfrastructure(input InfrastructureResourceInput) (*InfrastructureResource, error) {

--- a/infra_test.go
+++ b/infra_test.go
@@ -9,13 +9,15 @@ import (
 
 func TestCreateInfra(t *testing.T) {
 	// Arrange
+	// TODO: the data field is broken it should be like this - JSON type is not implemented properly in the API
+	// "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}",
 	request := `{
 	"query": "mutation InfrastructureResourceCreate($all:Boolean!$input:InfrastructureResourceInput!){infrastructureResourceCreate(input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all)},warnings{message},errors{message,path}}}",
   "variables":{
     "all": true,
     "input": {
       "ownerId":"Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
-      "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}",
+      "data": {"endpoint":"https://google.com","engine":"BigQuery","name":"my-big-query","replica":false},
       "providerData": {
         "accountName": "Dev - 123456789",
         "externalUrl": "https://google.com",
@@ -188,6 +190,8 @@ func TestListInfra(t *testing.T) {
 
 func TestUpdateInfra(t *testing.T) {
 	// Arrange
+	// TODO: the data field is broken it should be like this - JSON type is not implemented properly in the API
+	// "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}",
 	request := `{
 	"query": "mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all)},warnings{message},errors{message,path}}}",
   "variables":{
@@ -195,7 +199,7 @@ func TestUpdateInfra(t *testing.T) {
     "identifier": {"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"},
     "input": {
       "ownerId":"Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
-      "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}"
+      "data": {"endpoint":"https://google.com","engine":"BigQuery","name":"my-big-query","replica":false}
     }
 }
 }`


### PR DESCRIPTION
These are the things i needed to fix after putting opslevel-go into use in the CLI.  I was able to perform all the CLI commands then:
```
opslevel list infra-schemas
opslevel get infra-schemas Database
opslevel create infra
opslevel list infra
opslevel get infra XXXXX
opslevel update infra
opsleve delete infra XXXX
```