### PR TITLE
Add nested filter support and change graphql client

### DIFF
--- a/.changes/unreleased/Feature-20230726-144153.yaml
+++ b/.changes/unreleased/Feature-20230726-144153.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: As a user, I can configure nested filters
+time: 2023-07-26T14:41:53.475416-04:00

--- a/.changes/unreleased/Feature-20230726-144207.yaml
+++ b/.changes/unreleased/Feature-20230726-144207.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Install newer graphql dependency
+time: 2023-07-26T14:42:07.055089-04:00

--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ func GetTeams(client *opslevel.Client) (map[string]opslevel.Team, error) {
 
 # Advanced Usage
 
-The client also exposes functions `Query` and `Mutate` for doing custom query or mutations.  We are running ontop of this [go graphql library](https://github.com/shurcooL/graphql) so you can read up on how to define go structures that represent a query or mutation there but examples of each can be found [here](examples/).
+The client also exposes functions `Query` and `Mutate` for doing custom query or mutations.  We are running ontop of this [go graphql library](https://github.com/hasura/go-graphql-client) so you can read up on how to define go structures that represent a query or mutation there but examples of each can be found [here](examples/).

--- a/filters_test.go
+++ b/filters_test.go
@@ -52,6 +52,55 @@ func TestCreateFilter(t *testing.T) {
 	autopilot.Equals(t, ol.PredicateTypeEnumEquals, result.Predicates[0].Type)
 }
 
+func TestCreateFilterNested(t *testing.T) {
+	// Arrange
+	request := `{
+    "query": "mutation FilterCreate($input:FilterCreateInput!){filterCreate(input: $input){filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value}},errors{message,path}}}",
+	"variables":{
+		"input": {
+			{{ template "create_filter_nested_input" }}
+		}
+    }
+}`
+	response := `{"data": {
+	"filterCreate": {
+		"filter": {
+			{{ template "create_filter_nested_response" }}
+		},
+		"errors": []
+	}
+}}`
+
+	client := ABetterTestClient(t, "filter/create_nested", request, response)
+	// Act
+	result, err := client.CreateFilter(ol.FilterCreateInput{
+		Name:       "Self deployed or Rails",
+		Connective: ol.ConnectiveEnumOr,
+		Predicates: []ol.FilterPredicate{
+			{
+				Key:   ol.PredicateKeyEnumFilterID,
+				Type:  ol.PredicateTypeEnumMatches,
+				Value: "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg",
+			},
+			{
+				Key:   ol.PredicateKeyEnumFilterID,
+				Type:  ol.PredicateTypeEnumMatches,
+				Value: "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjQ",
+			},
+		},
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, "Self deployed or Rails", result.Name)
+	autopilot.Equals(t, ol.ConnectiveEnumOr, result.Connective)
+	autopilot.Equals(t, ol.PredicateKeyEnumFilterID, result.Predicates[0].Key)
+	autopilot.Equals(t, ol.PredicateTypeEnumMatches, result.Predicates[0].Type)
+	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg", result.Predicates[0].Value)
+	autopilot.Equals(t, ol.PredicateKeyEnumFilterID, result.Predicates[1].Key)
+	autopilot.Equals(t, ol.PredicateTypeEnumMatches, result.Predicates[1].Type)
+	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjQ", result.Predicates[1].Value)
+}
+
 func TestGetFilter(t *testing.T) {
 	// Arrange
 	request := `{

--- a/filters_test.go
+++ b/filters_test.go
@@ -242,6 +242,55 @@ func TestUpdateFilter(t *testing.T) {
 	autopilot.Equals(t, ol.PredicateKeyEnumTierIndex, result.Predicates[0].Key)
 }
 
+func TestUpdateFilterNested(t *testing.T) {
+	// Arrange
+	request := `{
+    "query": "mutation FilterUpdate($input:FilterUpdateInput!){filterUpdate(input: $input){filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value}},errors{message,path}}}",
+	"variables":{
+		"input": {
+			{{ template "update_filter_nested_input" }}
+		}
+    }
+}`
+	response := `{"data": {
+	"filterUpdate": {
+		"filter": {
+			{{ template "update_filter_nested_response" }}
+		},
+		"errors": []
+	}
+}}`
+	client := ABetterTestClient(t, "filter/update_nested", request, response)
+	// Act
+	result, err := client.UpdateFilter(ol.FilterUpdateInput{
+		Id:         "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzIzNDY",
+		Name:       "Tier 1-2 not deployed by us",
+		Connective: ol.ConnectiveEnumAnd,
+		Predicates: []ol.FilterPredicate{
+			{
+				Key:   ol.PredicateKeyEnumFilterID,
+				Type:  ol.PredicateTypeEnumDoesNotMatch,
+				Value: "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg",
+			},
+			{
+				Key:   ol.PredicateKeyEnumFilterID,
+				Type:  ol.PredicateTypeEnumMatches,
+				Value: "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjY",
+			},
+		},
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, "Tier 1-2 not deployed by us", result.Name)
+	autopilot.Equals(t, ol.ConnectiveEnumAnd, result.Connective)
+	autopilot.Equals(t, ol.PredicateKeyEnumFilterID, result.Predicates[0].Key)
+	autopilot.Equals(t, ol.PredicateTypeEnumDoesNotMatch, result.Predicates[0].Type)
+	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg", result.Predicates[0].Value)
+	autopilot.Equals(t, ol.PredicateKeyEnumFilterID, result.Predicates[1].Key)
+	autopilot.Equals(t, ol.PredicateTypeEnumMatches, result.Predicates[1].Type)
+	autopilot.Equals(t, "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjY", result.Predicates[1].Value)
+}
+
 func TestDeleteFilter(t *testing.T) {
 	// Arrange
 	request := `{

--- a/gen.go
+++ b/gen.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/hasura/go-graphql-client/ident"
 	"github.com/opslevel/opslevel-go/v2023"
-	"github.com/shurcooL/graphql/ident"
 )
 
 type GraphQLSchema struct {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
-	github.com/klauspost/compress v1.15.14 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.15.14 h1:i7WCKDToww0wA+9qrUZ1xOjp218vfFo3nTU6UHp+gOc=
 github.com/klauspost/compress v1.15.14/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=

--- a/testdata/templates/filters.tpl
+++ b/testdata/templates/filters.tpl
@@ -70,3 +70,40 @@
     }
   ]
 {{ end }}
+
+{{- define "create_filter_nested_input" }}
+"name": "Self deployed or Rails",
+"predicates": [
+  {
+    "key": "filter_id",
+    "type": "matches",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg"
+  },
+  {
+    "key": "filter_id",
+    "type": "matches",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjQ"
+  }
+],
+"connective": "or"
+{{ end }}
+{{- define "create_filter_nested_response" }}
+"connective": "or",
+"htmlUrl": "https://app.opslevel.com/filters/2346",
+"id": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzIzNDY",
+"name": "Self deployed or Rails",
+"predicates": [
+  {
+    "key": "filter_id",
+    "keyData": null,
+    "type": "matches",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg"
+  },
+  {
+    "key": "filter_id",
+    "keyData": null,
+    "type": "matches",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjQ"
+  }
+]
+{{ end }}

--- a/testdata/templates/filters.tpl
+++ b/testdata/templates/filters.tpl
@@ -107,3 +107,40 @@
   }
 ]
 {{ end }}
+{{- define "update_filter_nested_input" }}
+"id": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzIzNDY",
+"name": "Tier 1-2 not deployed by us",
+"predicates": [
+  {
+    "key": "filter_id",
+    "type": "does_not_match",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg"
+  },
+  {
+    "key": "filter_id",
+    "type": "matches",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjY"
+  }
+],
+"connective": "and"
+{{ end }}
+{{- define "update_filter_nested_response" }}
+"connective": "and",
+"htmlUrl": "https://app.opslevel.com/filters/2346",
+"id": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzIzNDY",
+"name": "Tier 1-2 not deployed by us",
+"predicates": [
+  {
+    "key": "filter_id",
+    "keyData": null,
+    "type": "does_not_match",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNTg"
+  },
+  {
+    "key": "filter_id",
+    "keyData": null,
+    "type": "matches",
+    "value": "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEyNjY"
+  }
+]
+{{ end }}


### PR DESCRIPTION
## Add nested filter support

Allow handling of filters that call other filters (i.e. "nested filters") using `and`/`or` conditions.

The list, delete, get operations should work the same way for nested filters, so no updates were made there.

Validated no changes were needed to filters.go, tested the new create/update queries live using graphiql.

## Changelog

1. Added test to create a nested filter (plus add template file for this)
1. Added test to update a nested filter (plus add template file for this)
1. Replaced https://github.com/shurcooL/graphql/ with https://github.com/hasura/go-graphql-client which added 1 dependency.