### PR TITLE
Fix client library to respect `Retry-After`header

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 
 type ClientSettings struct {
 	url      string
+	token    string
 	timeout  time.Duration
 	retries  int
 	headers  map[string]string
@@ -21,6 +22,7 @@ type Option func(*ClientSettings)
 func newClientSettings(options ...Option) *ClientSettings {
 	settings := &ClientSettings{
 		url:     "https://app.opslevel.com",
+		token:   os.Getenv("OPSLEVEL_API_TOKEN"),
 		timeout: time.Second * 10,
 		retries: 10,
 
@@ -38,7 +40,7 @@ func newClientSettings(options ...Option) *ClientSettings {
 
 func SetAPIToken(apiToken string) Option {
 	return func(c *ClientSettings) {
-		os.Setenv("OPSLEVEL_API_TOKEN", apiToken)
+		c.token = apiToken
 	}
 }
 

--- a/clientGQL.go
+++ b/clientGQL.go
@@ -3,13 +3,11 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/hasura/go-graphql-client"
 	"net/http"
 	"os"
 	"strings"
-
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/hasura/go-graphql-client"
-	"golang.org/x/oauth2"
 )
 
 type Client struct {
@@ -26,20 +24,11 @@ func NewClient(apiToken string, options ...Option) *Client {
 func NewGQLClient(options ...Option) *Client {
 	settings := newClientSettings(options...)
 
-	httpToken := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("OPSLEVEL_API_TOKEN"), TokenType: "Bearer"},
-	)
-
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = settings.retries
 	retryClient.Logger = nil
 
 	standardClient := retryClient.StandardClient()
-	standardClient.Timeout = settings.timeout
-	standardClient.Transport = &oauth2.Transport{
-		Source: httpToken,
-		Base:   standardClient.Transport,
-	}
 	var url string
 	if strings.Contains(settings.url, "/LOCAL_TESTING/") {
 		url = settings.url
@@ -47,8 +36,10 @@ func NewGQLClient(options ...Option) *Client {
 		url = fmt.Sprintf("%s/graphql", settings.url)
 	}
 
+	auth := fmt.Sprintf("Bearer %s", settings.token)
 	modifier := graphql.RequestModifier(
 		func(r *http.Request) {
+			r.Header.Add("Authorization", auth)
 			for key, value := range settings.headers {
 				r.Header.Add(key, value)
 			}

--- a/clientGQL.go
+++ b/clientGQL.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hasura/go-graphql-client"
 	"net/http"
-	"os"
 	"strings"
 )
 


### PR DESCRIPTION
Investigation based on client side rate limiting.

This PR does 2 things:
- Make the handling of the API token more sane by passing it through the ClientSettings
- Remove the OAuth HTTP client wrapper and hardcoded timeout which is inadvertently messing with go-retryablehttp Backoff and Retry strategies.

This fully delegates the retry and backoff to the go-retryablehttp so they actually work properly and testing shows that when the server gives back the headers for `Retry-After` the client properly retries and errors stop happening.

This was tested using this script

```sh
go build -o ./cli
chmod +x  ./cli
  for i in `seq 1 30`; do
    for i in `seq 1 200`; do
      ./cli graphql -q='query Raw{ account { id } }' &
    done;
  sleep 5
  done;
```

Prior to this change we see errors in the output but after this change we don't see errors in the output ever.