### PR TITLE
add linting to test CI workflow, add task setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
           task setup
           task lint
           task test
-          grep -v "/enum.go" coverage.out > coverage.txt
       - name: Upload Coverage
         run: |-
           bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,17 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.21"
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Tests
         run: |-
-          go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
-          cat coverage.out | grep -v "/enum.go" > coverage.txt
+          task setup
+          task lint
+          task test
+          grep -v "/enum.go" coverage.out > coverage.txt
       - name: Upload Coverage
         run: |-
           bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 .DS_Store
+coverage.out
+coverage.txt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,17 +9,6 @@ tasks:
       - go generate
       - gofumpt -w .
 
-  install-gofumpt:
-    desc: go install "gofumpt" and set GOBIN if not set
-    silent: true
-    vars:
-      IS_GOFUMPT_INSTALLED:
-        sh: which gofumpt > /dev/null || echo "1"
-    cmds:
-      - test -z "{{.IS_GOFUMPT_INSTALLED}}" || echo "Installing gofumpt..."
-      - test -z "{{.IS_GOFUMPT_INSTALLED}}" || go install mvdan.cc/gofumpt@latest
-      - test -n $(go env GOBIN) || go env -w GOBIN=$(go env GOPATH)/bin
-
   lint:
     desc: Formatting and linting
     deps: [install-gofumpt]
@@ -36,8 +25,43 @@ tasks:
       - go mod tidy
       - golangci-lint run --fix
 
+  setup:
+    desc: Setup linter, formatter, etc. for local testing and CI
+    cmds:
+      - task: install-gofumpt
+      - task: install-golangci
+
   test:
     desc: Run tests
     cmds:
-      - go test -v -cover -race ./... {{ .CLI_ARGS }}
+      - go test -race -coverprofile=coverage.out -covermode=atomic -v ./... {{ .CLI_ARGS }}
     silent: true
+
+  # internal (not directly called) tasks
+
+  install-go-tool:
+    internal: true
+    silent: true
+    vars:
+      IS_TOOL_INSTALLED:
+        sh: which {{.GO_TOOL}} > /dev/null || echo "1"
+    cmds:
+      - test -z "{{.IS_TOOL_INSTALLED}}" || echo "Installing {{.GO_TOOL}}..."
+      - test -z "{{.IS_TOOL_INSTALLED}}" || go install {{.GO_TOOL_PATH}}
+      - test -n $(go env GOBIN) || go env -w GOBIN=$(go env GOPATH)/bin
+    requires:
+      vars: [GO_TOOL, GO_TOOL_PATH]
+
+  install-gofumpt:
+    desc: go install "gofumpt" and set GOBIN if not set
+    silent: true
+    cmds:
+      - task: install-go-tool
+        vars: { GO_TOOL: "gofumpt", GO_TOOL_PATH: "mvdan.cc/gofumpt@latest" }
+
+  install-golangci:
+    desc: go install "golangci-lint" and set GOBIN if not set
+    silent: true
+    cmds:
+      - task: install-go-tool
+        vars: { GO_TOOL: "golangci-lint", GO_TOOL_PATH: "github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2" }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,7 @@ tasks:
     desc: Run tests
     cmds:
       - go test -race -coverprofile=coverage.out -covermode=atomic -v ./... {{ .CLI_ARGS }}
+      - grep -v "/enum.go" coverage.out > coverage.txt
     silent: true
 
   # internal (not directly called) tasks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,4 +65,4 @@ tasks:
     silent: true
     cmds:
       - task: install-go-tool
-        vars: { GO_TOOL: "golangci-lint", GO_TOOL_PATH: "github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2" }
+        vars: { GO_TOOL: "golangci-lint", GO_TOOL_PATH: "github.com/golangci/golangci-lint/cmd/golangci-lint@latest" }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,7 +29,7 @@ tasks:
     desc: Setup linter, formatter, etc. for local testing and CI
     cmds:
       - task: install-gofumpt
-      - task: install-golangci
+      - task: install-golangci-lint
 
   test:
     desc: Run tests
@@ -60,7 +60,7 @@ tasks:
       - task: install-go-tool
         vars: { GO_TOOL: "gofumpt", GO_TOOL_PATH: "mvdan.cc/gofumpt@latest" }
 
-  install-golangci:
+  install-golangci-lint:
     desc: go install "golangci-lint" and set GOBIN if not set
     silent: true
     cmds:


### PR DESCRIPTION
Add `task setup` as a generic local development task.
- This setups up `gofumpt` and `golangci-lint` locally and in CI pipelines
- This also serves as a place to add new tools when introduced

`task lint` added to CI 