### PR TITLE
Db/add taggable resource interface

### DIFF
--- a/.changes/unreleased/Feature-20230921-092515.yaml
+++ b/.changes/unreleased/Feature-20230921-092515.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add interface for taggable resources
+time: 2023-09-21T09:25:15.839769-05:00

--- a/repository.go
+++ b/repository.go
@@ -106,6 +106,32 @@ type ServiceRepositoryUpdateInput struct {
 	DisplayName   string `json:"displayName,omitempty"`
 }
 
+func (r *Repository) GetTag(tagId ID, client *Client) *Tag {
+	if r == nil {
+		return nil
+	}
+	tags, err := r.GetTags(client, nil)
+	if err != nil {
+		fmt.Println(fmt.Errorf("Error getting tags: %s", err))
+		return nil
+	}
+	for _, tag := range tags.Nodes {
+		if tag.Id == tagId {
+			return &tag
+		}
+	}
+	fmt.Println(fmt.Errorf("Error getting tags: %s", err))
+	return nil
+}
+
+func (r *Repository) ResourceId() ID {
+	return r.Id
+}
+
+func (r *Repository) ResourceType() TaggableResource {
+	return TaggableResourceRepository
+}
+
 func (r *Repository) GetService(service ID, directory string) *ServiceRepository {
 	for _, edge := range r.Services.Edges {
 		for _, connection := range edge.ServiceRepositories {

--- a/tags.go
+++ b/tags.go
@@ -7,6 +7,12 @@ const (
 	TagOwnerRepository TagOwner = "Repository"
 )
 
+type TaggableResourceInterface interface {
+	GetTag(ID) (*Tag, *Client)
+	ResourceId() ID
+	ResourceType() TaggableResource
+}
+
 type Tag struct {
 	Id    ID     `json:"id"`
 	Key   string `json:"key"`


### PR DESCRIPTION
Draft for now:
We expected similar behaviors and traits from these [TaggableResource](https://github.com/OpsLevel/opslevel-go/blob/main/enum.go#L710-L716)s. 

Putting these in a `TaggableResourceInterface` interface simplifies:
- Getting the specific type of the TaggableResource
- Getting the resource ID that the tag belongs to
- Getting the specific tag ID from the list of tags belonging to the TaggableResource