### PR TITLE
add tags to response only if unique

### DIFF
--- a/.changes/unreleased/Bugfix-20230927-111040.yaml
+++ b/.changes/unreleased/Bugfix-20230927-111040.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: filter duplicate tags in query response
+time: 2023-09-27T11:10:40.940673-05:00

--- a/domain.go
+++ b/domain.go
@@ -1,6 +1,9 @@
 package opslevel
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 type DomainId Identifier
 
@@ -97,7 +100,12 @@ func (s *DomainId) Tags(client *Client, variables *PayloadVariables) (*TagConnec
 		if err != nil {
 			return nil, err
 		}
-		q.Account.Domain.Tags.Nodes = append(q.Account.Domain.Tags.Nodes, resp.Nodes...)
+		// Add unique tags only
+		for _, resp := range resp.Nodes {
+			if !slices.Contains[[]Tag, Tag](q.Account.Domain.Tags.Nodes, resp) {
+				q.Account.Domain.Tags.Nodes = append(q.Account.Domain.Tags.Nodes, resp)
+			}
+		}
 		q.Account.Domain.Tags.PageInfo = resp.PageInfo
 		q.Account.Domain.Tags.TotalCount += resp.TotalCount
 	}

--- a/repository.go
+++ b/repository.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/relvacode/iso8601"
 )
@@ -207,7 +208,12 @@ func (r *Repository) GetTags(client *Client, variables *PayloadVariables) (*TagC
 	if r.Tags == nil {
 		r.Tags = &TagConnection{}
 	}
-	r.Tags.Nodes = append(r.Tags.Nodes, q.Account.Repository.Tags.Nodes...)
+	// Add unique tags only
+	for _, tagNode := range q.Account.Repository.Tags.Nodes {
+		if !slices.Contains[[]Tag, Tag](r.Tags.Nodes, tagNode) {
+			r.Tags.Nodes = append(r.Tags.Nodes, tagNode)
+		}
+	}
 	r.Tags.PageInfo = q.Account.Repository.Tags.PageInfo
 	r.Tags.TotalCount += q.Account.Repository.Tags.TotalCount
 	for r.Tags.PageInfo.HasNextPage {

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hasura/go-graphql-client"
@@ -172,10 +173,14 @@ func (s *Service) GetTags(client *Client, variables *PayloadVariables) (*TagConn
 		return nil, err
 	}
 	if s.Tags == nil {
-		tags := TagConnection{}
-		s.Tags = &tags
+		s.Tags = &TagConnection{}
 	}
-	s.Tags.Nodes = append(s.Tags.Nodes, q.Account.Service.Tags.Nodes...)
+	// Add unique tags only
+	for _, resp := range q.Account.Service.Tags.Nodes {
+		if !slices.Contains[[]Tag, Tag](s.Tags.Nodes, resp) {
+			s.Tags.Nodes = append(s.Tags.Nodes, resp)
+		}
+	}
 	s.Tags.PageInfo = q.Account.Service.Tags.PageInfo
 	s.Tags.TotalCount += q.Account.Service.Tags.TotalCount
 	for s.Tags.PageInfo.HasNextPage {

--- a/system.go
+++ b/system.go
@@ -1,6 +1,9 @@
 package opslevel
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 type SystemId Identifier
 
@@ -99,7 +102,12 @@ func (s *SystemId) Tags(client *Client, variables *PayloadVariables) (*TagConnec
 		if err != nil {
 			return nil, err
 		}
-		q.Account.System.Tags.Nodes = append(q.Account.System.Tags.Nodes, resp.Nodes...)
+		// Add unique tags only
+		for _, resp := range resp.Nodes {
+			if !slices.Contains[[]Tag, Tag](q.Account.System.Tags.Nodes, resp) {
+				q.Account.System.Tags.Nodes = append(q.Account.System.Tags.Nodes, resp)
+			}
+		}
 		q.Account.System.Tags.PageInfo = resp.PageInfo
 		q.Account.System.Tags.TotalCount += resp.TotalCount
 	}

--- a/team.go
+++ b/team.go
@@ -3,6 +3,7 @@ package opslevel
 import (
 	"fmt"
 	"html"
+	"slices"
 )
 
 type Contact struct {
@@ -198,10 +199,14 @@ func (t *Team) GetTags(client *Client, variables *PayloadVariables) (*TagConnect
 		return nil, err
 	}
 	if t.Tags == nil {
-		tags := TagConnection{}
-		t.Tags = &tags
+		t.Tags = &TagConnection{}
 	}
-	t.Tags.Nodes = append(t.Tags.Nodes, q.Account.Team.Tags.Nodes...)
+	// Add unique tags only
+	for _, tagNode := range q.Account.Team.Tags.Nodes {
+		if !slices.Contains[[]Tag, Tag](t.Tags.Nodes, tagNode) {
+			t.Tags.Nodes = append(t.Tags.Nodes, tagNode)
+		}
+	}
 	t.Tags.PageInfo = q.Account.Team.Tags.PageInfo
 	t.Tags.TotalCount += q.Account.Team.Tags.TotalCount
 	for t.Tags.PageInfo.HasNextPage {


### PR DESCRIPTION
## Issues

#258 

## Changelog

In source code defining each "taggable resource", check if a `Tag` already exists before adding it to the `[]Tag` that would be returned - via the `slices` package.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Before fix
```
opslevel list tag --type=service Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk3

[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwNjMyMTgw",
    "key": "test-key",
    "value": "test-value"
  },
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwNjMyMTgw",
    "key": "test-key",
    "value": "test-value"
  }
]
```

### After fix
```
opslevel list tag --type=service Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk3

[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYwNjMyMTgw",
    "key": "test-key",
    "value": "test-value"
  }
]
```
