### PR TITLE
check resourceType string against enums

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -65,35 +65,35 @@ type TagDeleteInput struct {
 	Id ID `json:"id"`
 }
 
-func (client *Client) GetTaggableResource(resourceType TaggableResource, identifier string) (TaggableResourceInterface, error) {
+func (client *Client) GetTaggableResource(resourceType string, identifier string) (TaggableResourceInterface, error) {
 	var err error
 	var taggableResource TaggableResourceInterface
 
 	switch resourceType {
-	case TaggableResourceService:
+	case string(TaggableResourceService):
 		if IsID(identifier) {
 			taggableResource, err = client.GetService(ID(identifier))
 		} else {
 			taggableResource, err = client.GetServiceWithAlias(identifier)
 		}
-	case TaggableResourceRepository:
+	case string(TaggableResourceRepository):
 		if IsID(identifier) {
 			taggableResource, err = client.GetRepository(ID(identifier))
 		} else {
 			taggableResource, err = client.GetRepositoryWithAlias(identifier)
 		}
-	case TaggableResourceTeam:
+	case string(TaggableResourceTeam):
 		if IsID(identifier) {
 			taggableResource, err = client.GetTeam(ID(identifier))
 		} else {
 			taggableResource, err = client.GetTeamWithAlias(identifier)
 		}
-	case TaggableResourceDomain:
+	case string(TaggableResourceDomain):
 		taggableResource, err = client.GetDomain(identifier)
-	case TaggableResourceSystem:
+	case string(TaggableResourceSystem):
 		taggableResource, err = client.GetSystem(identifier)
 	default:
-		return nil, fmt.Errorf("not a taggable resource type: %s" + string(resourceType))
+		return nil, fmt.Errorf("not a taggable resource type: %s" + resourceType)
 	}
 
 	if err != nil {

--- a/tags.go
+++ b/tags.go
@@ -92,6 +92,10 @@ func (client *Client) GetTaggableResource(resourceType string, identifier string
 		taggableResource, err = client.GetDomain(identifier)
 	case string(TaggableResourceSystem):
 		taggableResource, err = client.GetSystem(identifier)
+	case string(TaggableResourceInfrastructureresource):
+		taggableResource, err = client.GetInfrastructure(identifier)
+	case string(TaggableResourceUser):
+		taggableResource, err = client.GetUser(identifier)
 	default:
 		return nil, fmt.Errorf("not a taggable resource type: %s" + resourceType)
 	}


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/104

## Changelog

- [ ] Adapt `resourceType` to be a string so that CLI can use it for arbitrary input rather than adding another map
- [ ] Make User, Infrastructureresource implement `TaggableResourceInterface`

## Tophatting

See CLI: https://github.com/OpsLevel/cli/pull/182