### PR TITLE
Infra and User resources support tags

### DIFF
--- a/.changes/unreleased/Feature-20231003-095027.yaml
+++ b/.changes/unreleased/Feature-20231003-095027.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add tags support for user and infrastructure resources
+time: 2023-10-03T09:50:27.854-05:00

--- a/infra.go
+++ b/infra.go
@@ -89,7 +89,7 @@ func (i *InfrastructureResource) GetTags(client *Client, variables *PayloadVaria
 	}
 	(*variables)["infrastructureResource"] = *NewIdentifier(string(i.Id))
 
-	if err := client.Query(&q, *variables, WithName("InfrastructureResourceTagsList")); err != nil {
+	if err := client.Query(&q, *variables, WithName("InfrastructureResourceTags")); err != nil {
 		return nil, err
 	}
 	for q.Account.InfrastructureResource.Tags.PageInfo.HasNextPage {

--- a/infra.go
+++ b/infra.go
@@ -1,6 +1,9 @@
 package opslevel
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 type InfrastructureResourceSchema struct {
 	Type   string `json:"type"`
@@ -68,6 +71,51 @@ type InfraInput struct {
 	Owner    *ID                 `json:"owner" yaml:"owner"`
 	Provider *InfraProviderInput `json:"provider" yaml:"provider"`
 	Data     map[string]any      `json:"data" yaml:"data"`
+}
+
+func (i *InfrastructureResource) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {
+	var q struct {
+		Account struct {
+			InfrastructureResource struct {
+				Tags TagConnection `graphql:"tags(after: $after, first: $first)"`
+			} `graphql:"infrastructureResource(input: $infrastructureResource)"`
+		}
+	}
+	if i.Id == "" {
+		return nil, fmt.Errorf("Unable to get Tags, invalid domain id: '%s'", i.Id)
+	}
+	if variables == nil {
+		variables = client.InitialPageVariablesPointer()
+	}
+	(*variables)["infrastructureResource"] = *NewIdentifier(string(i.Id))
+
+	if err := client.Query(&q, *variables, WithName("InfrastructureResourceTagsList")); err != nil {
+		return nil, err
+	}
+	for q.Account.InfrastructureResource.Tags.PageInfo.HasNextPage {
+		(*variables)["after"] = q.Account.InfrastructureResource.Tags.PageInfo.End
+		resp, err := i.GetTags(client, variables)
+		if err != nil {
+			return nil, err
+		}
+		// Add unique tags only
+		for _, resp := range resp.Nodes {
+			if !slices.Contains[[]Tag, Tag](q.Account.InfrastructureResource.Tags.Nodes, resp) {
+				q.Account.InfrastructureResource.Tags.Nodes = append(q.Account.InfrastructureResource.Tags.Nodes, resp)
+			}
+		}
+		q.Account.InfrastructureResource.Tags.PageInfo = resp.PageInfo
+		q.Account.InfrastructureResource.Tags.TotalCount += resp.TotalCount
+	}
+	return &q.Account.InfrastructureResource.Tags, nil
+}
+
+func (i *InfrastructureResource) ResourceId() ID {
+	return *NewID(i.Id)
+}
+
+func (i *InfrastructureResource) ResourceType() TaggableResource {
+	return TaggableResourceInfrastructureresource
 }
 
 func (client *Client) CreateInfrastructure(input InfraInput) (*InfrastructureResource, error) {

--- a/infra.go
+++ b/infra.go
@@ -82,7 +82,7 @@ func (i *InfrastructureResource) GetTags(client *Client, variables *PayloadVaria
 		}
 	}
 	if i.Id == "" {
-		return nil, fmt.Errorf("Unable to get Tags, invalid domain id: '%s'", i.Id)
+		return nil, fmt.Errorf("Unable to get Tags, invalid InfrastructureResource id: '%s'", i.Id)
 	}
 	if variables == nil {
 		variables = client.InitialPageVariablesPointer()

--- a/infra_test.go
+++ b/infra_test.go
@@ -245,3 +245,88 @@ func TestDeleteInfra(t *testing.T) {
 	// Assert
 	autopilot.Equals(t, nil, err)
 }
+
+func TestGetInfrastructureResourceTags(t *testing.T) {
+	// Arrange
+	requests := []TestRequest{
+		{
+			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResources(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+            "variables": {
+                {{ template "first_page_variables" }},
+                "infrastructureResource": {"id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}
+            }
+            }`,
+			`{
+                  "data": {
+                    "account": {
+                      "infrastructureResource": {
+                        "tags": {
+                          "nodes": [
+                            {
+                              "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIw",
+                              "key": "abc",
+                              "value": "abc"
+                            },
+                            {
+                              "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIx",
+                              "key": "db",
+                              "value": "mongoqqqq"
+                            },
+                            {
+                              "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIy",
+                              "key": "db",
+                              "value": "prod"
+                            }
+                          ],
+                          {{ template "pagination_initial_pageInfo_response" }},
+                          "totalCount": 3
+                        }
+                      }
+                    }
+                  }
+                }`,
+		},
+		{
+			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResources(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+            "variables": {
+                {{ template "second_page_variables" }},
+                "infrastructureResource": {"id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}
+            }
+            }`,
+			`{
+                  "data": {
+                    "account": {
+                      "infrastructureResource": {
+                        "tags": {
+                          "nodes": [
+                            {
+                              "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIz",
+                              "key": "env",
+                              "value": "staging"
+                            }
+                          ],
+                          {{ template "pagination_second_pageInfo_response" }},
+                          "totalCount": 1
+                        }
+                      }
+                    }
+                  }
+                }`,
+		},
+	}
+	client := APaginatedTestClient(t, "infrastructureResource/tags", requests...)
+	// Act
+	infra := opslevel.InfrastructureResource{Id: "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}
+	resp, err := infra.GetTags(client, nil)
+	autopilot.Ok(t, err)
+	result := resp.Nodes
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 4, resp.TotalCount)
+	autopilot.Equals(t, "abc", result[0].Key)
+	autopilot.Equals(t, "abc", result[0].Value)
+	autopilot.Equals(t, "db", result[2].Key)
+	autopilot.Equals(t, "prod", result[2].Value)
+	autopilot.Equals(t, "env", result[3].Key)
+	autopilot.Equals(t, "staging", result[3].Value)
+}

--- a/infra_test.go
+++ b/infra_test.go
@@ -250,7 +250,7 @@ func TestGetInfrastructureResourceTags(t *testing.T) {
 	// Arrange
 	requests := []TestRequest{
 		{
-			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResource(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+			`{"query": "query InfrastructureResourceTags($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResource(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
             "variables": {
                 {{ template "first_page_variables" }},
                 "infrastructureResource": {"id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}
@@ -287,7 +287,7 @@ func TestGetInfrastructureResourceTags(t *testing.T) {
                 }`,
 		},
 		{
-			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResource(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+			`{"query": "query InfrastructureResourceTags($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResource(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
             "variables": {
                 {{ template "second_page_variables" }},
                 "infrastructureResource": {"id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}

--- a/infra_test.go
+++ b/infra_test.go
@@ -250,7 +250,7 @@ func TestGetInfrastructureResourceTags(t *testing.T) {
 	// Arrange
 	requests := []TestRequest{
 		{
-			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResources(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResource(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
             "variables": {
                 {{ template "first_page_variables" }},
                 "infrastructureResource": {"id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}
@@ -287,7 +287,7 @@ func TestGetInfrastructureResourceTags(t *testing.T) {
                 }`,
 		},
 		{
-			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResources(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+			`{"query": "query InfrastructureResourceTagsList($after:String!$first:Int!$infrastructureResource:IdentifierInput!){account{infrastructureResource(input: $infrastructureResource){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
             "variables": {
                 {{ template "second_page_variables" }},
                 "infrastructureResource": {"id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMTA5ODc"}

--- a/tags.go
+++ b/tags.go
@@ -90,8 +90,12 @@ func (client *Client) GetTaggableResource(resourceType TaggableResource, identif
 		}
 	case TaggableResourceDomain:
 		taggableResource, err = client.GetDomain(identifier)
+	case TaggableResourceInfrastructureresource:
+		taggableResource, err = client.GetInfrastructure(identifier)
 	case TaggableResourceSystem:
 		taggableResource, err = client.GetSystem(identifier)
+	case TaggableResourceUser:
+		taggableResource, err = client.GetUser(identifier)
 	default:
 		return nil, fmt.Errorf("not a taggable resource type: %s" + string(resourceType))
 	}

--- a/user.go
+++ b/user.go
@@ -70,7 +70,7 @@ func (u *UserId) GetTags(client *Client, variables *PayloadVariables) (*TagConne
 		}
 	}
 	if u.Id == "" {
-		return nil, fmt.Errorf("Unable to get Tags, invalid team id: '%s'", u.Id)
+		return nil, fmt.Errorf("Unable to get Tags, invalid User id: '%s'", u.Id)
 	}
 	if variables == nil {
 		variables = client.InitialPageVariablesPointer()

--- a/user_test.go
+++ b/user_test.go
@@ -249,3 +249,91 @@ func TestDeleteUserDoesNotExist(t *testing.T) {
 	- 'user' User with email 'not-found@opslevel.com' does not exist on this account
 `, err.Error())
 }
+
+func TestGetUserTags(t *testing.T) {
+	// Arrange
+	requests := []TestRequest{
+		{
+			`{"query": "query UserTagsList($after:String!$first:Int!$user:ID!){account{user(id: $user){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+            "variables": {
+              {{ template "first_page_variables" }},
+              "user": "{{ template "id1"}}"
+            }}`,
+			`{
+        "data": {
+          "account": {
+            "user": {
+              "tags": {
+                "nodes": [
+                  {
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIw",
+                    "key": "user-tag-1",
+                    "value": "user-value-1"
+                  },
+                  {
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIx",
+                    "key": "user-tag-2",
+                    "value": "user-value-2"
+                  },
+                  {
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIy",
+                    "key": "db",
+                    "value": "prod"
+                  }
+                ],
+                {{ template "pagination_initial_pageInfo_response" }},
+                "totalCount": 3
+              }
+            }
+          }
+        }
+      }`,
+		},
+		{
+			`{"query": "query UserTagsList($after:String!$first:Int!$user:ID!){account{user(id: $user){tags(after: $after, first: $first){nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}}",
+            "variables": {
+                {{ template "second_page_variables" }},
+                "user": "{{ template "id1"}}"
+            }
+            }`,
+			`{
+        "data": {
+          "account": {
+            "user": {
+              "tags": {
+                "nodes": [
+                {
+                  "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzEwODIz",
+                  "key": "captain",
+                  "value": "tuna"
+                }
+                ],
+                {{ template "pagination_second_pageInfo_response" }},
+                "totalCount": 1
+              }
+          }
+          }}}`,
+		},
+	}
+	client := APaginatedTestClient(t, "user/tags", requests...)
+	// Act
+	user := ol.User{
+		UserId: ol.UserId{
+			Id: "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+		},
+	}
+	resp, err := user.GetTags(client, nil)
+	autopilot.Ok(t, err)
+	result := resp.Nodes
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 4, resp.TotalCount)
+	autopilot.Equals(t, "user-tag-1", result[0].Key)
+	autopilot.Equals(t, "user-value-1", result[0].Value)
+	autopilot.Equals(t, "user-tag-2", result[1].Key)
+	autopilot.Equals(t, "user-value-2", result[1].Value)
+	autopilot.Equals(t, "db", result[2].Key)
+	autopilot.Equals(t, "prod", result[2].Value)
+	autopilot.Equals(t, "captain", result[3].Key)
+	autopilot.Equals(t, "tuna", result[3].Value)
+}


### PR DESCRIPTION
## Issues

[#104 ](https://github.com/OpsLevel/team-platform/issues/104)

## Changelog

Add tags support for `User` and `InfrastructureResource` and tests for each.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### opslevel-go
Run `task test | grep -e '\(TestGetInfrastructureResourceTags\|TestGetUserTags\)'`

### opslevel CLI
After setting submodule to this branch
```
# Create User tag
opslevel create tag --type=user Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ user-key user-value
created tag for Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ: Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx

# List single User tag
opslevel list tag --type=user Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx",
    "key": "user-key",
    "value": "user-value"
  }
]

# Update User tag
opslevel update tag Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx user-key fancy-value
{
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx",
    "key": "user-key",
    "value": "fancy-value"
}

# Create second User tag
opslevel create tag --type=user Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ neat-key neat-value
created tag for Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ: Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NjE5

# List multiple User tags
opslevel list tag --type=user Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ
[
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NjE5",
    "key": "neat-key",
    "value": "neat-value"
  },
  {
    "id": "Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx",
    "key": "user-key",
    "value": "fancy-value"
  }
]

# Delete both User tags
opslevel delete tag Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx
deleted a tag: Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NTgx

opslevel delete tag Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NjE5
deleted a tag: Z2lkOi8vb3BzbGV2ZWwvVGFnLzYxMjU5NjE5

# List User tags (empty)
opslevel list tag --type=user Z2lkOi8vb3BzbGV2ZWwvVXNlci8yMDk4NQ
[ ]
```
