### PR TITLE
backout the new relic integration fragment

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -40,7 +40,7 @@ func TestCache(t *testing.T) {
 		Response:  `{"data":{"account":{ "filters":{ "nodes":[{{ template "filter_1" }}] } }}}`,
 	}
 	testRequestSeven := TestRequest{
-		Request:   `"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"`,
+		Request:   `"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"`,
 		Variables: `"variables":{ "after": "", "first": 100 }`,
 		Response:  `{"data":{"account":{ "integrations":{ "nodes":[{{ template "integration_1" }}] } }}}`,
 	}

--- a/integration.go
+++ b/integration.go
@@ -20,8 +20,8 @@ type Integration struct {
 	CreatedAt   iso8601.Time `graphql:"createdAt"`
 	InstalledAt iso8601.Time `graphql:"installedAt"`
 
-	AWSIntegrationFragment      `graphql:"... on AwsIntegration"`
-	NewRelicIntegrationFragment `graphql:"... on NewRelicIntegration"`
+	AWSIntegrationFragment `graphql:"... on AwsIntegration"`
+	//NewRelicIntegrationFragment `graphql:"... on NewRelicIntegration"`
 }
 
 type AWSIntegrationFragment struct {

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateAWSIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}",
+	"query": "mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},errors{message,path}}}",
 	"variables":{
 		"input": {
 			"iamRole": "arn:aws:iam::XXXX:role/aws-integration-role",
@@ -50,49 +50,49 @@ func TestCreateAWSIntegration(t *testing.T) {
 	autopilot.Equals(t, "AWS - XXXX", result.Name)
 }
 
-func TestCreateNewRelicIntegration(t *testing.T) {
-	// Arrange
-	request := `{
-		"query": "mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}",
-		"variables": {
-			"input": {
-				"apiKey": "123456789",
-				"baseUrl": "https://api.newrelic.com/graphql",
-				"accountKey": "XXXX"
-			}
-		}
-	}`
-	response := `{"data": {
-	"newRelicIntegrationCreate": {
-		"integration": {
-			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
-			"name": "New Relic - XXXX",
-			"type": "new_relic",
-			"createdAt": "2023-04-26T16:25:29.574450Z",
-			"installedAt": "2023-04-26T16:25:28.541124Z",
-			"accountKey": "XXXX",
-			"baseUrl": "https://api.newrelic.com/graphql"
-		},
-		"errors": []
-	}
-}}`
-	client := ABetterTestClient(t, "integration/create_new_relic", request, response)
-	// Act
-	result, err := client.CreateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
-		ApiKey:     opslevel.NewString("123456789"),
-		BaseUrl:    opslevel.NewString("https://api.newrelic.com/graphql"),
-		AccountKey: opslevel.NewString("XXXX"),
-	})
-	// Assert
-	autopilot.Equals(t, nil, err)
-	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
-	autopilot.Equals(t, "New Relic - XXXX", result.Name)
-}
+//func TestCreateNewRelicIntegration(t *testing.T) {
+//	// Arrange
+//	request := `{
+//		"query": "mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}",
+//		"variables": {
+//			"input": {
+//				"apiKey": "123456789",
+//				"baseUrl": "https://api.newrelic.com/graphql",
+//				"accountKey": "XXXX"
+//			}
+//		}
+//	}`
+//	response := `{"data": {
+//	"newRelicIntegrationCreate": {
+//		"integration": {
+//			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+//			"name": "New Relic - XXXX",
+//			"type": "new_relic",
+//			"createdAt": "2023-04-26T16:25:29.574450Z",
+//			"installedAt": "2023-04-26T16:25:28.541124Z",
+//			"accountKey": "XXXX",
+//			"baseUrl": "https://api.newrelic.com/graphql"
+//		},
+//		"errors": []
+//	}
+//}}`
+//	client := ABetterTestClient(t, "integration/create_new_relic", request, response)
+//	// Act
+//	result, err := client.CreateIntegrationNewRelic(opslevel.NewRelicIntegrationInput{
+//		ApiKey:     opslevel.NewString("123456789"),
+//		BaseUrl:    opslevel.NewString("https://api.newrelic.com/graphql"),
+//		AccountKey: opslevel.NewString("XXXX"),
+//	})
+//	// Assert
+//	autopilot.Equals(t, nil, err)
+//	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
+//	autopilot.Equals(t, "New Relic - XXXX", result.Name)
+//}
 
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}}}}",
+	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}}}}",
 	"variables":{
 		"id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDEf"
     }
@@ -118,7 +118,7 @@ func TestGetIntegration(t *testing.T) {
 func TestGetMissingIntegraion(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}}}}",
+	"query": "query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}}}}",
 	"variables":{
 		"id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDEf"
     }
@@ -138,12 +138,12 @@ func TestGetMissingIntegraion(t *testing.T) {
 func TestListIntegrations(t *testing.T) {
 	// Arrange
 	testRequestOne := TestRequest{
-		Request:   `"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"`,
+		Request:   `"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"`,
 		Variables: `{{ template "pagination_initial_query_variables" }}`,
 		Response:  `{ "data": { "account": { "integrations": { "nodes": [ { {{ template "deploy_integration_response" }} }, { {{ template "payload_integration_response" }} } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 2 }}}}`,
 	}
 	testRequestTwo := TestRequest{
-		Request:   `"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"`,
+		Request:   `"query": "query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}"`,
 		Variables: `{{ template "pagination_second_query_variables" }}`,
 		Response:  `{ "data": { "account": { "integrations": { "nodes": [ { {{ template "kubernetes_integration_response" }} } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
 	}
@@ -163,7 +163,7 @@ func TestListIntegrations(t *testing.T) {
 func TestUpdateAWSIntegration(t *testing.T) {
 	// Arrange
 	request := `{
-	"query": "mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}",
+	"query": "mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys}},errors{message,path}}}",
 	"variables":{
 		"integration": {
 			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
@@ -205,48 +205,48 @@ func TestUpdateAWSIntegration(t *testing.T) {
 	autopilot.Equals(t, "Dev2", result.Name)
 }
 
-func TestUpdateNewRelicIntegration(t *testing.T) {
-	// Arrange
-	request := `{
-	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}",
-	"variables":{
-		"resource": {
-			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
-		},
-		"input": {
-			"baseUrl": "https://api-test.newrelic.com/graphql"
-		}
-	}
-}`
-
-	response := `{"data": {
-		"newRelicIntegrationUpdate": {
-			"integration": {
-			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
-			"name": "New Relic - XXXX",
-			"type": "new_relic",
-			"createdAt": "2023-04-26T16:25:29.574450Z",
-			"installedAt": "2023-04-26T16:25:28.541124Z",
-			"accountKey": "XXXX",
-			"baseUrl": "https://api-test.newrelic.com/graphql"
-		},
-		"errors": []
-	}
-}}`
-
-	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
-	// Act
-	result, err := client.UpdateIntegrationNewRelic(
-		"Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
-		opslevel.NewRelicIntegrationInput{
-			BaseUrl: opslevel.NewString("https://api-test.newrelic.com/graphql"),
-		},
-	)
-	// Assert
-	autopilot.Equals(t, nil, err)
-	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
-	autopilot.Equals(t, "https://api-test.newrelic.com/graphql", result.BaseUrl)
-}
+//func TestUpdateNewRelicIntegration(t *testing.T) {
+//	// Arrange
+//	request := `{
+//	"query": "mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}",
+//	"variables":{
+//		"resource": {
+//			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+//		},
+//		"input": {
+//			"baseUrl": "https://api-test.newrelic.com/graphql"
+//		}
+//	}
+//}`
+//
+//	response := `{"data": {
+//		"newRelicIntegrationUpdate": {
+//			"integration": {
+//			"id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+//			"name": "New Relic - XXXX",
+//			"type": "new_relic",
+//			"createdAt": "2023-04-26T16:25:29.574450Z",
+//			"installedAt": "2023-04-26T16:25:28.541124Z",
+//			"accountKey": "XXXX",
+//			"baseUrl": "https://api-test.newrelic.com/graphql"
+//		},
+//		"errors": []
+//	}
+//}}`
+//
+//	client := ABetterTestClient(t, "integration/update_new_relic", request, response)
+//	// Act
+//	result, err := client.UpdateIntegrationNewRelic(
+//		"Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+//		opslevel.NewRelicIntegrationInput{
+//			BaseUrl: opslevel.NewString("https://api-test.newrelic.com/graphql"),
+//		},
+//	)
+//	// Assert
+//	autopilot.Equals(t, nil, err)
+//	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(result.Id))
+//	autopilot.Equals(t, "https://api-test.newrelic.com/graphql", result.BaseUrl)
+//}
 
 func TestDeleteIntegration(t *testing.T) {
 	// Arrange


### PR DESCRIPTION
## Issues

More context can be found here - https://jk-labs.slack.com/archives/C01G8VB8ZCY/p1696967424643479

TLDR: An engineer who no longer works here added a fragment for a non-public API and this caused a bug with the Terraform provider when making AWS integrations.

Long term i think this integration API was suppose to be made public but it works differently from the AWS integration mutation (but it actually works the more correct way) so we'll need to get the catalog team to update the AWS mutations to work correctly & make the needed new relic mutations public if we want this back in.

For now this stages this change incase that doesn't get fixed.

