### PR TITLE
update ParentTeam field type in Team struct

### DIFF
--- a/team.go
+++ b/team.go
@@ -78,7 +78,7 @@ type TeamCreateInput struct {
 	Responsibilities string           `json:"responsibilities,omitempty"`
 	Group            *IdentifierInput `json:"group"`
 	Contacts         *[]ContactInput  `json:"contacts,omitempty"`
-	ParentTeam       *IdentifierInput `json:"parentTeam,omitempty"`
+	ParentTeam       *IdentifierInput `json:"parentTeam"`
 }
 
 type TeamUpdateInput struct {
@@ -88,7 +88,7 @@ type TeamUpdateInput struct {
 	ManagerEmail     string           `json:"managerEmail,omitempty"`
 	Group            *IdentifierInput `json:"group"`
 	Responsibilities string           `json:"responsibilities,omitempty"`
-	ParentTeam       *IdentifierInput `json:"parentTeam,omitempty"`
+	ParentTeam       *IdentifierInput `json:"parentTeam"`
 }
 
 type TeamDeleteInput struct {

--- a/team.go
+++ b/team.go
@@ -54,7 +54,7 @@ type Team struct {
 	Manager          User
 	Members          *UserConnection
 	Name             string
-	ParentTeam       *TeamId
+	ParentTeam       TeamId
 	Responsibilities string
 	Tags             *TagConnection
 }


### PR DESCRIPTION
## Issues

## Changelog

Found this bug while using this feature in the terraform provider.
Dropped `omitempty` from json struct tag to enable removal of parentTeam in terraform provider.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A fixed a type in an unused new feature

## Tophatting

`task test` still passes all tests
