### PR TITLE
add variable templater utility

### DIFF
--- a/clientGQL_test.go
+++ b/clientGQL_test.go
@@ -20,6 +20,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var (
+	dataTemplater = NewTestDataTemplater()
+	id1           = ol.ID(dataTemplater.ParseValue("id1"))
+	id2           = ol.ID(dataTemplater.ParseValue("id2"))
+	id3           = ol.ID(dataTemplater.ParseValue("id3"))
+)
+
 func TestMain(m *testing.M) {
 	output := zerolog.ConsoleWriter{Out: os.Stderr}
 	log.Logger = log.Output(output)
@@ -118,6 +125,10 @@ func NewTestDataTemplater(templateDirs ...string) *TestDataTemplater {
 
 type TestDataTemplater struct {
 	rootTemplate *template.Template
+}
+
+func (t *TestDataTemplater) ParseValue(value string) string {
+	return t.ParseTemplatedString(`{{ template "` + value + `" }}`)
 }
 
 func (t *TestDataTemplater) ParseTemplatedString(contents string) string {

--- a/dependencies_test.go
+++ b/dependencies_test.go
@@ -25,9 +25,9 @@ func TestCreateServiceDependency(t *testing.T) {
 	})
 	// Assert
 	autopilot.Ok(t, err)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"), result.Id)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vOTg3NjU0MzIxMTIzNDU2Nzg5"), result.Service.Id)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTkyODM3NDY1NTY0NzM4Mjkx"), result.DependsOn.Id)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, id2, result.Service.Id)
+	autopilot.Equals(t, id3, result.DependsOn.Id)
 	autopilot.Equals(t, "An example description", result.Notes)
 }
 
@@ -35,12 +35,12 @@ func TestGetServiceDependencies(t *testing.T) {
 	// Arrange
 	testRequestOne := NewTestRequest(
 		`"query ServiceDependenciesList($after:String!$first:Int!$service:ID!){account{service(id: $service){dependencies(after: $after, first: $first){edges{id,locked,node{id,aliases},notes},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}}"`,
-		`{ {{ template "first_page_variables" }}, "service": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx" }`,
+		`{ {{ template "first_page_variables" }}, "service": "{{ template "id1" }}" }`,
 		`{"data": {"account": { "service": { "dependencies": { "edges": [ {{ template "serviceDependencyEdge_1" }}, {{ template "serviceDependencyEdge_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}}`,
 	)
 	testRequestTwo := NewTestRequest(
 		`"query ServiceDependenciesList($after:String!$first:Int!$service:ID!){account{service(id: $service){dependencies(after: $after, first: $first){edges{id,locked,node{id,aliases},notes},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}}"`,
-		`{ {{ template "second_page_variables" }}, "service": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx" }`,
+		`{ {{ template "second_page_variables" }}, "service": "{{ template "id1" }}" }`,
 		`{"data": {"account": { "service": { "dependencies": { "edges": [ {{ template "serviceDependencyEdge_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}}`,
 	)
 	requests := []TestRequest{testRequestOne, testRequestTwo}
@@ -49,27 +49,27 @@ func TestGetServiceDependencies(t *testing.T) {
 	// Act
 	resource := ol.Service{
 		ServiceId: ol.ServiceId{
-			Id: "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+			Id: id1,
 		},
 	}
 	resp, err := resource.GetDependencies(client, nil)
 	result := resp.Edges
 	// Assert
 	autopilot.Ok(t, err)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"), result[0].Id)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTkyODM3NDY1NTY0NzM4Mjkx"), result[2].Id)
+	autopilot.Equals(t, id1, result[0].Id)
+	autopilot.Equals(t, id3, result[2].Id)
 }
 
 func TestGetServiceDependents(t *testing.T) {
 	// Arrange
 	testRequestOne := NewTestRequest(
 		`"query ServiceDependentsList($after:String!$first:Int!$service:ID!){account{service(id: $service){dependents(after: $after, first: $first){edges{id,locked,node{id,aliases},notes},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}}"`,
-		`{ {{ template "first_page_variables" }}, "service": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx" }`,
+		`{ {{ template "first_page_variables" }}, "service": "{{ template "id1" }}" }`,
 		`{"data": {"account": { "service": { "dependents": { "edges": [ {{ template "serviceDependencyEdge_1" }}, {{ template "serviceDependencyEdge_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}}`,
 	)
 	testRequestTwo := NewTestRequest(
 		`"query ServiceDependentsList($after:String!$first:Int!$service:ID!){account{service(id: $service){dependents(after: $after, first: $first){edges{id,locked,node{id,aliases},notes},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}}"`,
-		`{ {{ template "second_page_variables" }}, "service": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx" }`,
+		`{ {{ template "second_page_variables" }}, "service": "{{ template "id1" }}" }`,
 		`{"data": {"account": { "service": { "dependents": { "edges": [ {{ template "serviceDependencyEdge_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}}`,
 	)
 	requests := []TestRequest{testRequestOne, testRequestTwo}
@@ -78,15 +78,15 @@ func TestGetServiceDependents(t *testing.T) {
 	// Act
 	resource := ol.Service{
 		ServiceId: ol.ServiceId{
-			Id: "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+			Id: id1,
 		},
 	}
 	resp, err := resource.GetDependents(client, nil)
 	result := resp.Edges
 	// Assert
 	autopilot.Ok(t, err)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"), result[0].Id)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTkyODM3NDY1NTY0NzM4Mjkx"), result[2].Id)
+	autopilot.Equals(t, id1, result[0].Id)
+	autopilot.Equals(t, id3, result[2].Id)
 }
 
 func TestDeleteServiceDependency(t *testing.T) {
@@ -98,7 +98,7 @@ func TestDeleteServiceDependency(t *testing.T) {
 	)
 	client := BestTestClient(t, "serviceDependencyDelete", testRequest)
 	// Act
-	err := client.DeleteServiceDependency("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx")
+	err := client.DeleteServiceDependency(id1)
 	// Assert
 	autopilot.Ok(t, err)
 }

--- a/tools_test.go
+++ b/tools_test.go
@@ -19,12 +19,12 @@ func TestCreateTool(t *testing.T) {
 	result, err := client.CreateTool(ol.ToolCreateInput{
 		Category:    ol.ToolCategoryOther,
 		DisplayName: "example",
-		ServiceId:   "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+		ServiceId:   id1,
 		Url:         "https://example.com",
 	})
 	// Assert
 	autopilot.Ok(t, err)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"), result.Service.Id)
+	autopilot.Equals(t, id1, result.Service.Id)
 	autopilot.Equals(t, ol.ToolCategoryOther, result.Category)
 	autopilot.Equals(t, "Example", result.DisplayName)
 	autopilot.Equals(t, "https://example.com", result.Url)
@@ -40,7 +40,7 @@ func TestUpdateTool(t *testing.T) {
 	client := BestTestClient(t, "toolUpdate", testRequest)
 	// Act
 	result, err := client.UpdateTool(ol.ToolUpdateInput{
-		Id:       "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx",
+		Id:       id1,
 		Category: ol.ToolCategoryDeployment,
 	})
 	// Assert
@@ -58,7 +58,7 @@ func TestDeleteTool(t *testing.T) {
 	)
 	client := BestTestClient(t, "toolDelete", testRequest)
 	// Act
-	err := client.DeleteTool("Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx")
+	err := client.DeleteTool(id1)
 	// Assert
 	autopilot.Ok(t, err)
 }


### PR DESCRIPTION
## Issues

[#108](https://github.com/OpsLevel/team-platform/issues/108)

## Changelog

Add utility function to templatize test data, for example `"id1"` specifically.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A testing only chnage

## Tophatting

`task test` passes all tests
