### PR TITLE
add AffectsOverallServiceLevels field to Scorecard and ScorecardInput

### DIFF
--- a/.changes/unreleased/Feature-20231020-143907.yaml
+++ b/.changes/unreleased/Feature-20231020-143907.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add AffectsOverallServiceLevels field to Scorecard and ScorecardInput
+time: 2023-10-20T14:39:07.227791-05:00

--- a/common.go
+++ b/common.go
@@ -47,9 +47,7 @@ func NewString(value string) *string {
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
 func Bool(v bool) *bool {
-	p := new(bool)
-	*p = v
-	return p
+	return &v
 }
 
 func HandleErrors(err error, errs []OpsLevelErrors) error {

--- a/scorecards.go
+++ b/scorecards.go
@@ -12,13 +12,14 @@ type ScorecardId struct {
 type Scorecard struct {
 	ScorecardId
 
-	Description   string      `graphql:"description"` // optional
-	Filter        Filter      `graphql:"filter"`      // optional
-	Name          string      `graphql:"name"`
-	Owner         EntityOwner `graphql:"owner"`
-	PassingChecks int         `graphql:"passingChecks"`
-	ServiceCount  int         `graphql:"serviceCount"`
-	ChecksCount   int         `graphql:"totalChecks"`
+	AffectsOverallServiceLevels bool        `graphql:"affectsOverallServiceLevels"`
+	Description                 string      `graphql:"description"` // optional
+	Filter                      Filter      `graphql:"filter"`      // optional
+	Name                        string      `graphql:"name"`
+	Owner                       EntityOwner `graphql:"owner"`
+	PassingChecks               int         `graphql:"passingChecks"`
+	ServiceCount                int         `graphql:"serviceCount"`
+	ChecksCount                 int         `graphql:"totalChecks"`
 }
 
 type ScorecardConnection struct {
@@ -28,10 +29,11 @@ type ScorecardConnection struct {
 }
 
 type ScorecardInput struct {
-	Name        string  `graphql:"name" json:"name"`
-	Description *string `graphql:"description" json:"description,omitempty"`
-	OwnerId     ID      `graphql:"ownerId" json:"ownerId"`
-	FilterId    *ID     `graphql:"filterId" json:"filterId,omitempty"`
+	AffectsOverallServiceLevels *bool   `graphql:"affectsOverallServiceLevels" json:"affectsOverallServiceLevels,omitempty"`
+	Name                        string  `graphql:"name" json:"name"`
+	Description                 *string `graphql:"description" json:"description,omitempty"`
+	OwnerId                     ID      `graphql:"ownerId" json:"ownerId"`
+	FilterId                    *ID     `graphql:"filterId" json:"filterId,omitempty"`
 }
 
 func (client *Client) CreateScorecard(input ScorecardInput) (*Scorecard, error) {

--- a/scorecards_test.go
+++ b/scorecards_test.go
@@ -26,10 +26,11 @@ func TestCreateScorecard(t *testing.T) {
 
 	client := BestTestClient(t, "scorecards/create_scorecard", testRequest)
 	sc, err := client.CreateScorecard(ol.ScorecardInput{
-		Name:        name,
-		Description: &description,
-		OwnerId:     *fakeOwnerId,
-		FilterId:    fakeFilterId,
+		Name:                        name,
+		Description:                 &description,
+		OwnerId:                     *fakeOwnerId,
+		FilterId:                    fakeFilterId,
+		AffectsOverallServiceLevels: ol.Bool(true),
 	})
 
 	autopilot.Ok(t, err)
@@ -37,6 +38,33 @@ func TestCreateScorecard(t *testing.T) {
 	autopilot.Equals(t, description, sc.Description)
 	autopilot.Equals(t, *fakeOwnerId, sc.Owner.Id())
 	autopilot.Equals(t, *fakeFilterId, sc.Filter.Id)
+	autopilot.Equals(t, true, sc.AffectsOverallServiceLevels)
+}
+
+func TestCreateScorecardDoesNotAffectServiceLevels(t *testing.T) {
+	testRequest := NewTestRequest(
+		`{{ template "scorecard_create_request" }}`,
+		`{{ template "scorecard_create_request_vars_affects_service_levels_false" }}`,
+		`{{ template "scorecard_create_response_affects_service_levels_false" }}`,
+	)
+	name := "new scorecard"
+	description := "a new scorecard with an attached filter id"
+
+	client := BestTestClient(t, "scorecards/create_scorecard_not_affects_service_levels", testRequest)
+	sc, err := client.CreateScorecard(ol.ScorecardInput{
+		Name:                        name,
+		Description:                 &description,
+		OwnerId:                     *fakeOwnerId,
+		FilterId:                    fakeFilterId,
+		AffectsOverallServiceLevels: ol.Bool(false),
+	})
+
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, name, sc.Name)
+	autopilot.Equals(t, description, sc.Description)
+	autopilot.Equals(t, *fakeOwnerId, sc.Owner.Id())
+	autopilot.Equals(t, *fakeFilterId, sc.Filter.Id)
+	autopilot.Equals(t, false, sc.AffectsOverallServiceLevels)
 }
 
 func TestUpdateScorecard(t *testing.T) {
@@ -63,6 +91,7 @@ func TestUpdateScorecard(t *testing.T) {
 	autopilot.Equals(t, description, sc.Description)
 	autopilot.Equals(t, *newOwnerId, sc.Owner.Id())
 	autopilot.Equals(t, *newFilterId, sc.Filter.Id)
+	autopilot.Equals(t, false, sc.AffectsOverallServiceLevels)
 }
 
 func TestDeleteScorecard(t *testing.T) {

--- a/testdata/templates/scorecards.tpl
+++ b/testdata/templates/scorecards.tpl
@@ -1,17 +1,25 @@
 {{- define "scorecard_create_request" }}
-"mutation ScorecardCreate($input:ScorecardInput!){scorecardCreate(input: $input){scorecard{aliases,id,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
+"mutation ScorecardCreate($input:ScorecardInput!){scorecardCreate(input: $input){scorecard{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
 {{ end }}
 
 {{- define "scorecard_create_request_vars" }}
-{"input":{"description":"a new scorecard with an attached filter id","name":"new scorecard","ownerId":"Z2lkOi8vMTIzNDU2Nzg5Cg==","filterId":"Z2lkOi8vMTIzNDU2MTIzCg=="}}
+{"input":{"affectsOverallServiceLevels":true,"description":"a new scorecard with an attached filter id","name":"new scorecard","ownerId":"Z2lkOi8vMTIzNDU2Nzg5Cg==","filterId":"Z2lkOi8vMTIzNDU2MTIzCg=="}}
+{{ end }}
+
+{{- define "scorecard_create_request_vars_affects_service_levels_false" }}
+{"input":{"affectsOverallServiceLevels":false,"description":"a new scorecard with an attached filter id","name":"new scorecard","ownerId":"Z2lkOi8vMTIzNDU2Nzg5Cg==","filterId":"Z2lkOi8vMTIzNDU2MTIzCg=="}}
 {{ end }}
 
 {{- define "scorecard_create_response" }}{
-    "data":{"scorecardCreate":{"scorecard":{"description":"a new scorecard with an attached filter id","filter":{"connective":null,"htmlUrl":"https://app.opslevel.com/filters/123456123","id":"Z2lkOi8vMTIzNDU2MTIzCg==","name":"some filter","predicates":[]},"name":"new scorecard","owner":{"id":"Z2lkOi8vMTIzNDU2Nzg5Cg=="}},"errors":[]}}
+    "data":{"scorecardCreate":{"scorecard":{"affectsOverallServiceLevels":true,"description":"a new scorecard with an attached filter id","filter":{"connective":null,"htmlUrl":"https://app.opslevel.com/filters/123456123","id":"Z2lkOi8vMTIzNDU2MTIzCg==","name":"some filter","predicates":[]},"name":"new scorecard","owner":{"id":"Z2lkOi8vMTIzNDU2Nzg5Cg=="}},"errors":[]}}
+}{{ end }}
+
+{{- define "scorecard_create_response_affects_service_levels_false" }}{
+    "data":{"scorecardCreate":{"scorecard":{"affectsOverallServiceLevels":false,"description":"a new scorecard with an attached filter id","filter":{"connective":null,"htmlUrl":"https://app.opslevel.com/filters/123456123","id":"Z2lkOi8vMTIzNDU2MTIzCg==","name":"some filter","predicates":[]},"name":"new scorecard","owner":{"id":"Z2lkOi8vMTIzNDU2Nzg5Cg=="}},"errors":[]}}
 }{{ end }}
 
 {{- define "scorecard_update_request" }}
-"mutation ScorecardUpdate($input:ScorecardInput!$scorecard:IdentifierInput!){scorecardUpdate(scorecard: $scorecard, input: $input){scorecard{aliases,id,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
+"mutation ScorecardUpdate($input:ScorecardInput!$scorecard:IdentifierInput!){scorecardUpdate(scorecard: $scorecard, input: $input){scorecard{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
 {{ end }}
 
 {{- define "scorecard_update_request_vars" }}
@@ -35,7 +43,7 @@
 }{{ end }}
 
 {{- define "scorecard_get_request" }}
-"query ScorecardGet($input:IdentifierInput!){account{scorecard(input: $input){aliases,id,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks}}}"
+"query ScorecardGet($input:IdentifierInput!){account{scorecard(input: $input){aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks}}}"
 {{ end }}
 
 {{- define "scorecard_get_request_vars" }}
@@ -46,7 +54,7 @@
     "data":{"account":{"scorecard":{"aliases":["existing_scorecard"],"id":"Z2lkOi8vMTIzNDU2Nzg5MTAK","description":"hello there!","filter":{"connective":null,"htmlUrl":"https://app.opslevel.com/filters/123456123","id":"Z2lkOi8vMTIzNDU2MTIzCg==","name":"some filter","predicates":[]},"name":"fetched scorecard","owner":{"id":"Z2lkOi8vMTIzNDU2Nzg5Cg=="},"passingChecks":10,"serviceCount":20,"totalChecks":30}}}
 }{{ end }}
 
-{{- define "scorecard_list_query" }}query ScorecardsList($after:String!$first:Int!){account{scorecards(after: $after, first: $first){nodes{aliases,id,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}{{ end }}
+{{- define "scorecard_list_query" }}query ScorecardsList($after:String!$first:Int!){account{scorecards(after: $after, first: $first){nodes{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}{{ end }}
 
 {{- define "scorecard_1_response" }}
     "id":"Z2lkOi8vMTExMTExMTEK",


### PR DESCRIPTION
## Issues

[#71](https://github.com/OpsLevel/team-platform/issues/71)

## Changelog

Add `AffectsOverallServiceLevels` field to `Scorecard` and `ScorecardInput` structs

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` passes all tests
