### PR TITLE
remove create, update Groups. deprecate Group field in Teams

### DIFF
--- a/.changes/unreleased/Deprecated-20231101-083924.yaml
+++ b/.changes/unreleased/Deprecated-20231101-083924.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: Groups are deprecated in favor of Team hierarchies
+time: 2023-11-01T08:39:24.151927-05:00

--- a/.changes/unreleased/Removed-20231101-083703.yaml
+++ b/.changes/unreleased/Removed-20231101-083703.yaml
@@ -1,0 +1,4 @@
+kind: Removed
+body: GroupInput and EntityOwnerGroup structs, CreateGroup and UpdateGroup client
+  methods, Group field from TeamCreateInput and TeamUpdateInput structs
+time: 2023-11-01T08:37:03.11188-05:00

--- a/domain_test.go
+++ b/domain_test.go
@@ -10,7 +10,7 @@ import (
 func TestDomainCreate(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation DomainCreate($input:DomainInput!){domainCreate(input:$input){domain{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},errors{message,path}}}"`,
+		`"mutation DomainCreate($input:DomainInput!){domainCreate(input:$input){domain{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},errors{message,path}}}"`,
 		`{"input": { "name": "platform-test", "description": "Domain created for testing.", "ownerId": "{{ template "id1_string" }}", "note": "additional note about platform-test domain" }}`,
 		`{"data": {"domainCreate": {"domain": {{ template "domain1_response" }} }}}`,
 	)
@@ -33,12 +33,12 @@ func TestDomainCreate(t *testing.T) {
 func TestDomainGetSystems(t *testing.T) {
 	// Arrange
 	testRequestOne := NewTestRequest(
-		`"query DomainChildSystemsList($after:String!$domain:IdentifierInput!$first:Int!){account{domain(input: $domain){childSystems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}}"`,
+		`"query DomainChildSystemsList($after:String!$domain:IdentifierInput!$first:Int!){account{domain(input: $domain){childSystems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}}"`,
 		`{ {{ template "first_page_variables" }}, "domain": { {{ template "id2" }} } }`,
 		`{ "data": { "account": { "domain": { "childSystems": { "nodes": [ {{ template "system1_response" }}, {{ template "system2_response" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}}`,
 	)
 	testRequestTwo := NewTestRequest(
-		`"query DomainChildSystemsList($after:String!$domain:IdentifierInput!$first:Int!){account{domain(input: $domain){childSystems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}}"`,
+		`"query DomainChildSystemsList($after:String!$domain:IdentifierInput!$first:Int!){account{domain(input: $domain){childSystems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}}"`,
 		`{ {{ template "second_page_variables" }}, "domain": { {{ template "id2" }} } }`,
 		`{ "data": { "account": { "domain": { "childSystems": { "nodes": [ {{ template "system3_response" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}}`,
 	)
@@ -94,7 +94,7 @@ func TestDomainGetTags(t *testing.T) {
 func TestDomainAssignSystem(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation DomainAssignSystem($childSystems:[IdentifierInput!]!$domain:IdentifierInput!){domainChildAssign(domain:$domain, childSystems:$childSystems){domain{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},errors{message,path}}}"`,
+		`"mutation DomainAssignSystem($childSystems:[IdentifierInput!]!$domain:IdentifierInput!){domainChildAssign(domain:$domain, childSystems:$childSystems){domain{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},errors{message,path}}}"`,
 		`{"domain":{ {{ template "id1" }} }, "childSystems": [ { {{ template "id3" }} } ] }`,
 		`{"data": {"domainChildAssign": {"domain": {{ template "domain1_response" }} }}}`,
 	)
@@ -114,7 +114,7 @@ func TestDomainAssignSystem(t *testing.T) {
 func TestDomainGetId(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"query DomainGet($input:IdentifierInput!){account{domain(input: $input){id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note}}}"`,
+		`"query DomainGet($input:IdentifierInput!){account{domain(input: $input){id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note}}}"`,
 		`{"input": { {{ template "id1" }} }}`,
 		`{"data": {"account": {"domain": {{ template "domain1_response" }} }}}`,
 	)
@@ -130,7 +130,7 @@ func TestDomainGetId(t *testing.T) {
 func TestDomainGetAlias(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"query DomainGet($input:IdentifierInput!){account{domain(input: $input){id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note}}}"`,
+		`"query DomainGet($input:IdentifierInput!){account{domain(input: $input){id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note}}}"`,
 		`{"input": {"alias": "my-domain" }}`,
 		`{"data": {"account": {"domain": {{ template "domain1_response" }} }}}`,
 	)
@@ -146,12 +146,12 @@ func TestDomainGetAlias(t *testing.T) {
 func TestDomainList(t *testing.T) {
 	// Arrange
 	testRequestOne := NewTestRequest(
-		`"query DomainsList($after:String!$first:Int!){account{domains(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},{{ template "pagination_request" }}}}}"`,
+		`"query DomainsList($after:String!$first:Int!){account{domains(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},{{ template "pagination_request" }}}}}"`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "domains": { "nodes": [ {{ template "domain1_response" }}, {{ template "domain2_response" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := NewTestRequest(
-		`"query DomainsList($after:String!$first:Int!){account{domains(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},{{ template "pagination_request" }}}}}"`,
+		`"query DomainsList($after:String!$first:Int!){account{domains(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},{{ template "pagination_request" }}}}}"`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "domains": { "nodes": [ {{ template "domain3_response" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
@@ -172,7 +172,7 @@ func TestDomainList(t *testing.T) {
 func TestDomainUpdate(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation DomainUpdate($domain:IdentifierInput!$input:DomainInput!){domainUpdate(domain:$domain,input:$input){domain{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},errors{message,path}}}"`,
+		`"mutation DomainUpdate($domain:IdentifierInput!$input:DomainInput!){domainUpdate(domain:$domain,input:$input){domain{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},errors{message,path}}}"`,
 		`{"domain": { {{ template "id1" }} }, "input": {"name": "platform-test-4", "description":"Domain created for testing.", "ownerId":"{{ template "id3_string" }}", "note": "Please delete me" }}`,
 		`{"data": {"domainUpdate": {"domain": {{ template "domain1_response" }} }}}`,
 	)

--- a/group.go
+++ b/group.go
@@ -17,40 +17,10 @@ type Group struct {
 	Parent      GroupId `json:"parent,omitempty"`
 }
 
-// type SubgroupConnection struct {
-// 	nodes      []GroupId
-// 	PageInfo   PageInfo
-// 	TotalCount graphql.Int
-// }
-
 type GroupConnection struct {
 	Nodes      []Group
 	PageInfo   PageInfo
 	TotalCount int
-}
-
-type GroupInput struct {
-	Name        string             `json:"name,omitempty"`
-	Description string             `json:"description,omitempty"`
-	Parent      *IdentifierInput   `json:"parent"`
-	Members     *[]MemberInput     `json:"members,omitempty"`
-	Teams       *[]IdentifierInput `json:"teams,omitempty"`
-}
-
-//#region Create
-
-func (client *Client) CreateGroup(input GroupInput) (*Group, error) {
-	var m struct {
-		Payload struct {
-			Group  Group
-			Errors []OpsLevelErrors
-		} `graphql:"groupCreate(input: $input)"`
-	}
-	v := PayloadVariables{
-		"input": input,
-	}
-	err := client.Mutate(&m, v, WithName("GroupCreate"))
-	return &m.Payload.Group, HandleErrors(err, m.Payload.Errors)
 }
 
 //#endregion
@@ -293,25 +263,6 @@ func (g *Group) Members(client *Client, variables *PayloadVariables) (*UserConne
 		q.Account.Group.Members.TotalCount += resp.TotalCount
 	}
 	return &q.Account.Group.Members, nil
-}
-
-//#endregion
-
-//#region Update
-
-func (client *Client) UpdateGroup(identifier string, input GroupInput) (*Group, error) {
-	var m struct {
-		Payload struct {
-			Group  Group
-			Errors []OpsLevelErrors
-		} `graphql:"groupUpdate(group: $group, input: $input)"`
-	}
-	v := PayloadVariables{
-		"group": *NewIdentifier(identifier),
-		"input": input,
-	}
-	err := client.Mutate(&m, v, WithName("GroupUpdate"))
-	return &m.Payload.Group, HandleErrors(err, m.Payload.Errors)
 }
 
 //#endregion

--- a/group_test.go
+++ b/group_test.go
@@ -18,31 +18,6 @@ func getGroupWithAliasTestClient(t *testing.T) *ol.Client {
 	return getGroupWithAliasClient
 }
 
-func TestCreateGroup(t *testing.T) {
-	// Arrange
-	client := ATestClient(t, "group/create")
-	members := []ol.MemberInput{
-		{Email: "edgar+test@opslevel.com"},
-	}
-	teams := []ol.IdentifierInput{
-		{Alias: "platform"},
-	}
-	// Act
-
-	result, err := client.CreateGroup(ol.GroupInput{
-		Name:        "platform",
-		Description: "Another test group",
-		Members:     &members,
-		Parent:      ol.NewIdentifier("test_group_1"),
-		Teams:       &teams,
-	})
-	// Assert
-	autopilot.Ok(t, err)
-	autopilot.Equals(t, "platform", result.Name)
-	autopilot.Equals(t, "Another test group", result.Description)
-	autopilot.Equals(t, "test_group_1", result.Parent.Alias)
-}
-
 func TestDeleteGroup(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
@@ -342,27 +317,4 @@ func TestMembers(t *testing.T) {
 	autopilot.Equals(t, 3, resp.TotalCount)
 	autopilot.Equals(t, "kyle@opslevel.com", result[0].Email)
 	autopilot.Equals(t, "Matthew Brahms", result[2].Name)
-}
-
-func TestUpdateGroup(t *testing.T) {
-	// Arrange
-	client := ATestClient(t, "group/update")
-	members := []ol.MemberInput{
-		{Email: "edgar+test@opslevel.com"},
-	}
-	teams := []ol.IdentifierInput{
-		{Alias: "platform"},
-	}
-	// Act
-	result, err := client.UpdateGroup(string(id4), ol.GroupInput{
-		Description: "This is the first test group",
-		Members:     &members,
-		Parent:      ol.NewIdentifier("test_group_2"),
-		Teams:       &teams,
-	})
-	// Assert
-	autopilot.Ok(t, err)
-	autopilot.Equals(t, "test_group_1", result.Name)
-	autopilot.Equals(t, "This is the first test group", result.Description)
-	autopilot.Equals(t, "test_group_2", result.Parent.Alias)
 }

--- a/infra_test.go
+++ b/infra_test.go
@@ -10,7 +10,7 @@ import (
 func TestCreateInfra(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation InfrastructureResourceCreate($all:Boolean!$input:InfrastructureResourceInput!){infrastructureResourceCreate(input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}"`,
+		`"mutation InfrastructureResourceCreate($all:Boolean!$input:InfrastructureResourceInput!){infrastructureResourceCreate(input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}"`,
 		`{
     "all": true,
     "input": {
@@ -59,7 +59,7 @@ func TestCreateInfra(t *testing.T) {
 func TestGetInfra(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}"`,
+		`"query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}"`,
 		`{"all": true, "input":{ {{ template "id1" }} }}`,
 		`{"data": { "account": { "infrastructureResource": {{ template "infra_1" }} }}}`,
 	)
@@ -101,12 +101,12 @@ func TestListInfraSchemas(t *testing.T) {
 func TestListInfra(t *testing.T) {
 	// Arrange
 	testRequestOne := NewTestRequest(
-		`"query IntegrationList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}"`,
+		`"query IntegrationList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}"`,
 		`{ "after": "", "all": true, "first": 100 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_1" }}, {{ template "infra_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := NewTestRequest(
-		`"query IntegrationList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}"`,
+		`"query IntegrationList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}"`,
 		`{ "after": "OA", "all": true, "first": 100 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
@@ -126,7 +126,7 @@ func TestListInfra(t *testing.T) {
 func TestUpdateInfra(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}"`,
+		`"mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}"`,
 		`{"all": true, "identifier": { {{ template "id1" }}}, "input": { "ownerId": "{{ template "id1_string" }}", "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}" }}`,
 		`{"data": { "infrastructureResourceUpdate": { "infrastructureResource": {{ template "infra_1" }}, "warnings": [], "errors": [] }}}`,
 	)

--- a/owner.go
+++ b/owner.go
@@ -1,41 +1,20 @@
 package opslevel
 
-type EntityOwnerGroup struct {
-	Alias string `json:"alias,omitempty" graphql:"groupAlias:alias"`
-	Id    ID     `json:"id"`
-}
-
 type EntityOwnerTeam struct {
 	Alias string `json:"alias,omitempty" graphql:"teamAlias:alias"`
 	Id    ID     `json:"id"`
 }
 
 type EntityOwner struct {
-	OnGroup EntityOwnerGroup `graphql:"... on Group"`
-	OnTeam  EntityOwnerTeam  `graphql:"... on Team"`
+	OnTeam EntityOwnerTeam `graphql:"... on Team"`
 }
 
 func (s *EntityOwner) Alias() string {
-	if s.OnGroup.Id == "" {
-		return s.OnTeam.Alias
-	} else {
-		return s.OnGroup.Alias
-	}
+	return s.OnTeam.Alias
 }
 
 func (s *EntityOwner) Id() ID {
-	if s.OnGroup.Id == "" {
-		return s.OnTeam.Id
-	} else {
-		return s.OnGroup.Id
-	}
-}
-
-func (s *EntityOwnerGroup) AsGroup() GroupId {
-	return GroupId{
-		Alias: s.Alias,
-		Id:    s.Id,
-	}
+	return s.OnTeam.Id
 }
 
 func (s *EntityOwnerTeam) AsTeam() TeamId {

--- a/owner_test.go
+++ b/owner_test.go
@@ -7,22 +7,6 @@ import (
 	"github.com/rocktavious/autopilot/v2023"
 )
 
-// func TestEntityOwnerGroupReturnsCorrectId(t *testing.T) {
-// 	// Arrange
-// 	owner := ol.EntityOwner{
-// 		OnGroup: ol.EntityOwnerGroup{
-// 			Id:    id1,
-// 			Alias: "Example",
-// 		},
-// 	}
-// 	// Act
-// 	// Assert
-// 	autopilot.Equals(t, id1, owner.Id())
-// 	autopilot.Equals(t, id1, owner.OnGroup.AsGroup().Id)
-// 	autopilot.Equals(t, "Example", owner.Alias())
-// 	autopilot.Equals(t, "Example", owner.OnGroup.AsGroup().Alias)
-// }
-
 func TestEntityOwnerTeamReturnsCorrectId(t *testing.T) {
 	// Arrange
 	owner := ol.EntityOwner{

--- a/owner_test.go
+++ b/owner_test.go
@@ -7,21 +7,21 @@ import (
 	"github.com/rocktavious/autopilot/v2023"
 )
 
-func TestEntityOwnerGroupReturnsCorrectId(t *testing.T) {
-	// Arrange
-	owner := ol.EntityOwner{
-		OnGroup: ol.EntityOwnerGroup{
-			Id:    id1,
-			Alias: "Example",
-		},
-	}
-	// Act
-	// Assert
-	autopilot.Equals(t, id1, owner.Id())
-	autopilot.Equals(t, id1, owner.OnGroup.AsGroup().Id)
-	autopilot.Equals(t, "Example", owner.Alias())
-	autopilot.Equals(t, "Example", owner.OnGroup.AsGroup().Alias)
-}
+// func TestEntityOwnerGroupReturnsCorrectId(t *testing.T) {
+// 	// Arrange
+// 	owner := ol.EntityOwner{
+// 		OnGroup: ol.EntityOwnerGroup{
+// 			Id:    id1,
+// 			Alias: "Example",
+// 		},
+// 	}
+// 	// Act
+// 	// Assert
+// 	autopilot.Equals(t, id1, owner.Id())
+// 	autopilot.Equals(t, id1, owner.OnGroup.AsGroup().Id)
+// 	autopilot.Equals(t, "Example", owner.Alias())
+// 	autopilot.Equals(t, "Example", owner.OnGroup.AsGroup().Alias)
+// }
 
 func TestEntityOwnerTeamReturnsCorrectId(t *testing.T) {
 	// Arrange

--- a/system_test.go
+++ b/system_test.go
@@ -10,7 +10,7 @@ import (
 func TestSystemCreate(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation SystemCreate($input:SystemInput!){systemCreate(input:$input){system{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},errors{message,path}}}"`,
+		`"mutation SystemCreate($input:SystemInput!){systemCreate(input:$input){system{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},errors{message,path}}}"`,
 		`{"input": { "name": "PlatformSystem3", "description": "creating this for testing purposes", "ownerId": "{{ template "id4_string" }}", "note": "hello world" } }`,
 		`{"data": { "systemCreate": { "system": {{ template "system1_response" }}, "errors": [] }}}`,
 	)
@@ -94,7 +94,7 @@ func TestSystemGetTags(t *testing.T) {
 func TestSystemAssignService(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation SystemAssignService($childServices:[IdentifierInput!]!$system:IdentifierInput!){systemChildAssign(system:$system, childServices:$childServices){system{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},errors{message,path}}}"`,
+		`"mutation SystemAssignService($childServices:[IdentifierInput!]!$system:IdentifierInput!){systemChildAssign(system:$system, childServices:$childServices){system{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},errors{message,path}}}"`,
 		`{"system": { {{ template "id3" }} }, "childServices": [ { {{ template "id4" }} } ] }`,
 		`{"data": { "systemChildAssign": { "system": {{ template "system1_response" }} } }}`,
 	)
@@ -114,7 +114,7 @@ func TestSystemAssignService(t *testing.T) {
 func TestSystemGetId(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"query SystemGet($input:IdentifierInput!){account{system(input: $input){id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note}}}"`,
+		`"query SystemGet($input:IdentifierInput!){account{system(input: $input){id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note}}}"`,
 		`{ "input": { {{ template "id1" }} } }`,
 		`{"data": { "account": { "system": {{ template "system1_response" }} }}}`,
 	)
@@ -129,7 +129,7 @@ func TestSystemGetId(t *testing.T) {
 func TestSystemGetAlias(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"query SystemGet($input:IdentifierInput!){account{system(input: $input){id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note}}}"`,
+		`"query SystemGet($input:IdentifierInput!){account{system(input: $input){id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note}}}"`,
 		`{ "input": { "alias": "platformsystem1" } }`,
 		`{"data": { "account": { "system": {{ template "system1_response" }} }}}`,
 	)
@@ -144,12 +144,12 @@ func TestSystemGetAlias(t *testing.T) {
 func TestListSystems(t *testing.T) {
 	// Arrange
 	testRequestOne := NewTestRequest(
-		`"query SystemsList($after:String!$first:Int!){account{systems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}"`,
+		`"query SystemsList($after:String!$first:Int!){account{systems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}"`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "systems": { "nodes": [ {{ template "system1_response" }}, {{ template "system2_response" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := NewTestRequest(
-		`"query SystemsList($after:String!$first:Int!){account{systems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}"`,
+		`"query SystemsList($after:String!$first:Int!){account{systems(after: $after, first: $first){nodes{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},{{ template "pagination_request" }}}}}"`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "systems": { "nodes": [ {{ template "system3_response" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
@@ -171,7 +171,7 @@ func TestListSystems(t *testing.T) {
 func TestSystemUpdate(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
-		`"mutation SystemUpdate($input:SystemInput!$system:IdentifierInput!){systemUpdate(system:$system,input:$input){system{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},note},note},errors{message,path}}}"`,
+		`"mutation SystemUpdate($input:SystemInput!$system:IdentifierInput!){systemUpdate(system:$system,input:$input){system{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,name,description,htmlUrl,owner{... on Team{teamAlias:alias,id}},note},note},errors{message,path}}}"`,
 		`{"system": { {{ template "id1" }} }, "input":{ "name": "PlatformSystem1", "description":"Yolo!", "ownerId":"{{ template "id4_string" }}", "note": "Please delete me" }}`,
 		`{"data": {"systemUpdate": {"system": {{ template "system1_response" }}, "errors": [] }}}`,
 	)

--- a/team.go
+++ b/team.go
@@ -47,8 +47,9 @@ type TeamId struct {
 type Team struct {
 	TeamId
 
-	Aliases          []string
-	Contacts         []Contact
+	Aliases  []string
+	Contacts []Contact
+	// Deprecated: Group field will be removed in a future release
 	Group            GroupId
 	HTMLUrl          string
 	Manager          User
@@ -76,7 +77,6 @@ type TeamCreateInput struct {
 	Name             string           `json:"name"`
 	ManagerEmail     string           `json:"managerEmail,omitempty"`
 	Responsibilities string           `json:"responsibilities,omitempty"`
-	Group            *IdentifierInput `json:"group"`
 	Contacts         *[]ContactInput  `json:"contacts,omitempty"`
 	ParentTeam       *IdentifierInput `json:"parentTeam"`
 }
@@ -86,7 +86,6 @@ type TeamUpdateInput struct {
 	Alias            string           `json:"alias,omitempty"`
 	Name             string           `json:"name,omitempty"`
 	ManagerEmail     string           `json:"managerEmail,omitempty"`
-	Group            *IdentifierInput `json:"group"`
 	Responsibilities string           `json:"responsibilities,omitempty"`
 	ParentTeam       *IdentifierInput `json:"parentTeam"`
 }

--- a/team_test.go
+++ b/team_test.go
@@ -108,7 +108,7 @@ func TestCreateTeam(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
 		`"mutation TeamCreate($input:TeamCreateInput!){teamCreate(input: $input){team{alias,id,aliases,contacts{address,displayName,id,type},group{alias,id},htmlUrl,manager{id,email,htmlUrl,name,role},members{nodes{id,email,htmlUrl,name,role},{{ template "pagination_request" }},totalCount},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount}},errors{message,path}}}"`,
-		`{"input": {"name": "Example", "managerEmail": "john@example.com", "parentTeam": {"alias": "parent_team"}, "responsibilities": "Foo & bar", "group": {"alias": "test_group"}, "contacts": [ {"type": "slack_handle", "address": "@mozzie"}, {"type": "slack", "displayName": "", "address": "#general"}, {"type": "web", "displayName": "Homepage", "address": "https://example.com"} ] }}`,
+		`{"input": {"name": "Example", "managerEmail": "john@example.com", "parentTeam": {"alias": "parent_team"}, "responsibilities": "Foo & bar", "contacts": [ {"type": "slack_handle", "address": "@mozzie"}, {"type": "slack", "displayName": "", "address": "#general"}, {"type": "web", "displayName": "Homepage", "address": "https://example.com"} ] }}`,
 		`{ "data": {
     "teamCreate": {
       "team": {
@@ -131,10 +131,6 @@ func TestCreateTeam(t *testing.T) {
             "type": "web"
           }
         ],
-        "group": {
-          {{ template "id4" }},
-          "alias": "test_group"
-        },
         "htmlUrl": "https://app.opslevel-staging.com/teams/example",
         "manager": {
           "email": "john@example.com",
@@ -183,7 +179,6 @@ func TestCreateTeam(t *testing.T) {
 		ManagerEmail:     "john@example.com",
 		Responsibilities: "Foo & bar",
 		Contacts:         &contacts,
-		Group:            ol.NewIdentifier("test_group"),
 		ParentTeam:       ol.NewIdentifier("parent_team"),
 	})
 	// Assert
@@ -191,7 +186,6 @@ func TestCreateTeam(t *testing.T) {
 	autopilot.Equals(t, "Example", result.Name)
 	autopilot.Equals(t, "john@example.com", result.Manager.Email)
 	autopilot.Equals(t, "Foo & bar", result.Responsibilities)
-	autopilot.Equals(t, "test_group", result.Group.Alias)
 	autopilot.Equals(t, "parent_team", result.ParentTeam.Alias)
 }
 
@@ -716,7 +710,7 @@ func TestUpdateTeam(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
 		`"mutation TeamUpdate($input:TeamUpdateInput!){teamUpdate(input: $input){team{alias,id,aliases,contacts{address,displayName,id,type},group{alias,id},htmlUrl,manager{id,email,htmlUrl,name,role},members{nodes{id,email,htmlUrl,name,role},{{ template "pagination_request" }},totalCount},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount}},errors{message,path}}}"`,
-		`{"input": { {{ template "id1" }}, "managerEmail": "ken@example.com", "responsibilities": "Foo & bar", "parentTeam": {"alias": "parent_team"}, "group": {"alias": "test_group" }}}`,
+		`{"input": { {{ template "id1" }}, "managerEmail": "ken@example.com", "responsibilities": "Foo & bar", "parentTeam": {"alias": "parent_team"} }}`,
 		`{ "data": {
       "teamUpdate": {
         "team": {
@@ -739,10 +733,6 @@ func TestUpdateTeam(t *testing.T) {
               "type": "web"
             }
           ],
-          "group": {
-            {{ template "id3" }},
-            "alias": "test_group"
-          },
           "htmlUrl": "https://app.opslevel.com/teams/example",
           "manager":               {
             "email": "ken@example.com",
@@ -798,7 +788,6 @@ func TestUpdateTeam(t *testing.T) {
 		Id:               id1,
 		ManagerEmail:     "ken@example.com",
 		Responsibilities: "Foo & bar",
-		Group:            ol.NewIdentifier("test_group"),
 		ParentTeam:       ol.NewIdentifier("parent_team"),
 	})
 	// Assert
@@ -806,7 +795,6 @@ func TestUpdateTeam(t *testing.T) {
 	autopilot.Equals(t, "Example", result.Name)
 	autopilot.Equals(t, "ken@example.com", result.Manager.Email)
 	autopilot.Equals(t, "Foo & bar", result.Responsibilities)
-	autopilot.Equals(t, "test_group", result.Group.Alias)
 	autopilot.Equals(t, "parent_team", result.ParentTeam.Alias)
 }
 

--- a/testdata/templates/domains.tpl
+++ b/testdata/templates/domains.tpl
@@ -8,7 +8,6 @@
     "description": "Our first Platform Domain!",
     "htmlUrl": "https://app.opslevel-staging.com/catalog/domains/platformdomain",
     "owner": {
-      "groupAlias": "kyle_team",
       {{ template "id4" }}
     },
     "note": "{{ template "description" }}"
@@ -24,7 +23,6 @@
     "description": "Our second domain!",
     "htmlUrl": "https://app.opslevel-staging.com/catalog/domains/platformdomain2",
     "owner": {
-      "groupAlias": "kyle_team",
       {{ template "id4" }}
     },
     "note": "{{ template "description" }}"

--- a/testdata/templates/infrastructure.tpl
+++ b/testdata/templates/infrastructure.tpl
@@ -5,7 +5,6 @@
     "name": "my-big-query",
     "type": "Database",
     "owner": {
-      "groupAlias": "test_team",
       {{ template "id1" }}
     },
     "ownerLocked": false,

--- a/testdata/templates/scorecards.tpl
+++ b/testdata/templates/scorecards.tpl
@@ -1,5 +1,5 @@
 {{- define "scorecard_create_request" }}
-"mutation ScorecardCreate($input:ScorecardInput!){scorecardCreate(input: $input){scorecard{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
+"mutation ScorecardCreate($input:ScorecardInput!){scorecardCreate(input: $input){scorecard{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
 {{ end }}
 
 {{- define "scorecard_create_request_vars" }}
@@ -19,7 +19,7 @@
 }{{ end }}
 
 {{- define "scorecard_update_request" }}
-"mutation ScorecardUpdate($input:ScorecardInput!$scorecard:IdentifierInput!){scorecardUpdate(scorecard: $scorecard, input: $input){scorecard{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
+"mutation ScorecardUpdate($input:ScorecardInput!$scorecard:IdentifierInput!){scorecardUpdate(scorecard: $scorecard, input: $input){scorecard{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},errors{message,path}}}"
 {{ end }}
 
 {{- define "scorecard_update_request_vars" }}
@@ -43,7 +43,7 @@
 }{{ end }}
 
 {{- define "scorecard_get_request" }}
-"query ScorecardGet($input:IdentifierInput!){account{scorecard(input: $input){aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks}}}"
+"query ScorecardGet($input:IdentifierInput!){account{scorecard(input: $input){aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks}}}"
 {{ end }}
 
 {{- define "scorecard_get_request_vars" }}
@@ -54,7 +54,7 @@
     "data":{"account":{"scorecard":{"aliases":["existing_scorecard"],"id":"Z2lkOi8vMTIzNDU2Nzg5MTAK","description":"hello there!","filter":{"connective":null,"htmlUrl":"https://app.opslevel.com/filters/123456123","id":"Z2lkOi8vMTIzNDU2MTIzCg==","name":"some filter","predicates":[]},"name":"fetched scorecard","owner":{"id":"Z2lkOi8vMTIzNDU2Nzg5Cg=="},"passingChecks":10,"serviceCount":20,"totalChecks":30}}}
 }{{ end }}
 
-{{- define "scorecard_list_query" }}query ScorecardsList($after:String!$first:Int!){account{scorecards(after: $after, first: $first){nodes{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Group{groupAlias:alias,id},... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}{{ end }}
+{{- define "scorecard_list_query" }}query ScorecardsList($after:String!$first:Int!){account{scorecards(after: $after, first: $first){nodes{aliases,id,affectsOverallServiceLevels,description,filter{connective,htmlUrl,id,name,predicates{key,keyData,type,value,caseSensitive}},name,owner{... on Team{teamAlias:alias,id}},passingChecks,serviceCount,totalChecks},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}{{ end }}
 
 {{- define "scorecard_1_response" }}
     "id":"Z2lkOi8vMTExMTExMTEK",

--- a/testdata/templates/systems.tpl
+++ b/testdata/templates/systems.tpl
@@ -8,7 +8,6 @@
     "description": "Yolo!",
     "htmlUrl": "https://app.opslevel-staging.com/catalog/systems/platformsystem1",
     "owner": {
-      "groupAlias": "kyle_team",
       {{ template "id4" }}
     },
     "parent": {{ template "domain1_response" }},
@@ -25,7 +24,6 @@
     "description": "Yolo2!",
     "htmlUrl": "https://app.opslevel-staging.com/catalog/systems/platformsystem2",
     "owner": {
-      "groupAlias": "kyle_team",
       {{ template "id4" }}
     },
     "note": "{{ template "description" }}"

--- a/testdata/templates/teams.tpl
+++ b/testdata/templates/teams.tpl
@@ -29,7 +29,6 @@
 "contacts": [
   {{ template "contact_1" }}
 ],
-"group": null,
 "htmlUrl": "https://app.opslevel.com/teams/bots",
 "manager": {{ template "user_1" }},
 "members": {
@@ -59,7 +58,6 @@
 "contacts": [
   {{ template "contact_2" }}
 ],
-"group": null,
 "htmlUrl": "https://app.opslevel.com/teams/bots",
 "manager": {{ template "user_1" }},
 "members": {
@@ -89,7 +87,6 @@
 "contacts": [
   {{ template "contact_3" }}
 ],
-"group": null,
 "htmlUrl": "https://app.opslevel.com/teams/bots",
 "manager": {{ template "user_1" }},
 "members": {


### PR DESCRIPTION
## Issues

[#124](https://github.com/OpsLevel/team-platform/issues/124)

## Changelog

### Removed
- `GroupInput` and `EntityOwnerGroup` structs
- `CreateGroup()` and `UpdateGroup()` methods from client
- `Group` field from `TeamCreateInput` and `TeamUpdateInput` structs

### Deprecated
- Added a comment above the `Group` field in `Team` as another reminder.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` shows all tests passing
