### PR TITLE
Allow access to ManagedAliases on InfraResource

### DIFF
--- a/.changes/unreleased/Feature-20231107-160831.yaml
+++ b/.changes/unreleased/Feature-20231107-160831.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Can access managed aliases on infra resources
+time: 2023-11-07T16:08:31.601168-05:00

--- a/infra.go
+++ b/infra.go
@@ -23,16 +23,17 @@ type InfrastructureResourceProviderData struct {
 }
 
 type InfrastructureResource struct {
-	Id           string                             `json:"id"`
-	Aliases      []string                           `json:"aliases"`
-	Name         string                             `json:"name"`
-	Schema       string                             `json:"type" graphql:"type @include(if: $all)"`
-	ProviderType string                             `json:"providerResourceType" graphql:"providerResourceType @include(if: $all)"`
-	ProviderData InfrastructureResourceProviderData `json:"providerData" graphql:"providerData @include(if: $all)"`
-	Owner        EntityOwner                        `json:"owner" graphql:"owner @include(if: $all)"`
-	OwnerLocked  bool                               `json:"ownerLocked" graphql:"ownerLocked @include(if: $all)"`
-	ParsedData   JSON                               `json:"data" scalar:"true" graphql:"data @include(if: $all)"`
-	Data         JSON                               `json:"rawData" scalar:"true" graphql:"rawData @include(if: $all)"`
+	Id             string                             `json:"id"`
+	Aliases        []string                           `json:"aliases"`
+	ManagedAliases []string                           `json:"managedAliases"`
+	Name           string                             `json:"name"`
+	Schema         string                             `json:"type" graphql:"type @include(if: $all)"`
+	ProviderType   string                             `json:"providerResourceType" graphql:"providerResourceType @include(if: $all)"`
+	ProviderData   InfrastructureResourceProviderData `json:"providerData" graphql:"providerData @include(if: $all)"`
+	Owner          EntityOwner                        `json:"owner" graphql:"owner @include(if: $all)"`
+	OwnerLocked    bool                               `json:"ownerLocked" graphql:"ownerLocked @include(if: $all)"`
+	ParsedData     JSON                               `json:"data" scalar:"true" graphql:"data @include(if: $all)"`
+	Data           JSON                               `json:"rawData" scalar:"true" graphql:"rawData @include(if: $all)"`
 }
 
 type InfrastructureResourceConnection struct {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/112 -- prereq to supporting aliases on infra resources in terraform. 

Field was added to the graphql API.

## Changelog

- [x] Add the field
- [x] Make a `changie` entry
