### PR TITLE
consolidate test data in tpl files, DomainInput creates test data

### DIFF
--- a/actions_test.go
+++ b/actions_test.go
@@ -11,7 +11,7 @@ func TestCreateWebhookAction(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
 		`"mutation WebhookActionCreate($input:CustomActionsWebhookActionCreateInput!){customActionsWebhookActionCreate(input: $input){webhookAction{{ template "custom_actions_request" }},errors{message,path}}}"`,
-		`{"input":{"headers":"{\"Content-Type\":\"application/json\"}","httpMethod":"POST","liquidTemplate":"{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}","name":"Deploy Rollback","webhookUrl":"https://gitlab.com/api/v4/projects/1/trigger/pipeline"}}`,
+		`{"input":{"headers":"{\"Content-Type\":\"application/json\"}","httpMethod":"POST",{{ template "liquid_template_rollback" }},"name":"Deploy Rollback","webhookUrl":"https://gitlab.com/api/v4/projects/1/trigger/pipeline"}}`,
 		`{"data": {"customActionsWebhookActionCreate": { "webhookAction": {{ template "custom_action1" }}, "errors": [] }}}`,
 	)
 

--- a/clientGQL_test.go
+++ b/clientGQL_test.go
@@ -137,16 +137,20 @@ func (t *TestDataTemplater) ParseValue(value string) string {
 	return t.ParseTemplatedString(`{{ template "` + value + `" }}`)
 }
 
-func (t *TestDataTemplater) ParseTemplatedString(contents string) string {
+func (t *TestDataTemplater) ParseTemplatedStringWith(contents string, givenData any) string {
 	target, err := t.rootTemplate.Parse(contents)
 	if err != nil {
 		panic(fmt.Errorf("error parsing template: %s", err))
 	}
 	data := bytes.NewBuffer([]byte{})
-	if err = target.Execute(data, nil); err != nil {
+	if err = target.Execute(data, givenData); err != nil {
 		panic(err)
 	}
 	return strings.TrimSpace(data.String())
+}
+
+func (t *TestDataTemplater) ParseTemplatedString(contents string) string {
+	return t.ParseTemplatedStringWith(contents, nil)
 }
 
 type TestRequest struct {

--- a/testdata/templates/check.tpl
+++ b/testdata/templates/check.tpl
@@ -11,13 +11,7 @@
     "enabled": true,
     "filter": null,
     {{ template "id1" }},
-    "level": {
-      "alias": "bronze",
-      "description": "Services in this level satisfy critical checks. This is the minimum standard to ship to production.",
-      "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzE3",
-      "index": 1,
-      "name": "Bronze"
-    },
+    "level": {{ template "level_1" }},
     "name": "Repository Integrated",
     "notes": null
 {{ end }}
@@ -34,44 +28,19 @@
     "category": null,
     "description": "The service has a metrics tool.",
     "enabled": true,
-    "filter": {
-      "connective": null,
-      "htmlUrl": "https://app.opslevel.com/filters/401",
-      "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tsaXN0LzQwMQ",
-      "name": "Tier 1 Services",
-      "predicates": [
-        {
-          "key": "tier_index",
-          "keyData": null,
-          "type": "equals",
-          "value": "1"
-        }
-      ]
-    },
+    "filter": { {{ template "filter_tier1service_response" }} },
     "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMTMyNw",
-    "level": {
-      "alias": "bronze",
-      "description": "Services in this level satisfy critical checks. This is the minimum standard to ship to production.",
-      "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzE3",
-      "index": 1,
-      "name": "Bronze"
-    },
+    {{ template "level_bronze" }},
     "name": "Metrics Tool",
     "notes": null
 {{ end }}
 {{- define "owner_defined_check" }}
     "category": null,
-	"description": "Verifies that the service has an owner defined.",
+    "description": "Verifies that the service has an owner defined.",
     "enabled": true,
     "filter": null,
     "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8xMzI9",
-    "level": {
-      "alias": "bronze",
-      "description": "Services in this level satisfy critical checks. This is the minimum standard to ship to production.",
-      "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzE3",
-      "index": 1,
-      "name": "Bronze"
-    },
+    {{ template "level_bronze" }},
     "name": "Owner Defined",
     "notes": null
 {{ end }}

--- a/testdata/templates/custom_actions.tpl
+++ b/testdata/templates/custom_actions.tpl
@@ -1,8 +1,24 @@
+{{- define "liquid_template_freeze_string" -}}
+{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"freeze\"}
+{{- end }}
+
+{{- define "liquid_template_rollback_string" -}}
+{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}
+{{- end }}
+
+{{- define "liquid_template_freeze" -}}
+"liquidTemplate": "{{- template "liquid_template_freeze_string" -}}"
+{{ end }}
+
+{{- define "liquid_template_rollback" }}
+"liquidTemplate": "{{- template "liquid_template_rollback_string" -}}"
+{{ end }}
+
 {{- define "custom_action1_response" }}
     "aliases": [],
     "description": null,
     "id": "123456789",
-    "liquidTemplate": "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}",
+    {{ template "liquid_template_rollback" }},
     "name": "Deploy Rollback",
     "headers": {
         "Content-Type": "application/json"
@@ -14,7 +30,7 @@
     "aliases": [],
     "description": "Trigger a deploy freeze",
     "id": "987654322",
-    "liquidTemplate": "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"freeze\"}",
+    {{ template "liquid_template_freeze" }},
     "name": "Deploy Freeze",
     "headers": {
         "Accept": "application/vnd.github+json",
@@ -27,7 +43,7 @@
     "aliases": [],
     "description": "Page the On-Call Engineer",
     "id": "987654323",
-    "liquidTemplate": "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"freeze\"}",
+    {{ template "liquid_template_freeze" }},
     "name": "Page On-Call",
     "headers": {
         "Accept": "application/vnd.github+json",
@@ -108,7 +124,7 @@
     "aliases": [],
     "description": null,
     "id": "123456789",
-    "liquidTemplate": "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}",
+    {{ template "liquid_template_rollback" }},
     "name": "Deploy Rollback",
     "headers": {
         "Content-Type": "application/json"
@@ -120,7 +136,7 @@
     "aliases": [],
     "description": "Trigger a deploy freeze",
     "id": "987654321",
-    "liquidTemplate": "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"freeze\"}",
+    {{ template "liquid_template_freeze" }},
     "name": "Deploy Freeze",
     "headers": {
         "Accept": "application/vnd.github+json",

--- a/testdata/templates/domains.tpl
+++ b/testdata/templates/domains.tpl
@@ -1,3 +1,12 @@
+{{- define "domain_input" -}}
+{
+  "name": "{{ .Name }}",
+  "description": "{{ .Description }}",
+  "note": "{{ .Note  }}",
+  "ownerId": "{{ .Owner }}"
+}
+{{- end}}
+
 {{- define "domain1_response" }}
 {
     {{ template "id1" }},

--- a/testdata/templates/filters.tpl
+++ b/testdata/templates/filters.tpl
@@ -42,6 +42,7 @@
   "name": "Kubernetes",
   "predicates": []
 {{ end }}
+
 {{- define "filter_tier1service_response" }}
   "connective": null,
   "htmlUrl": "https://app.opslevel.com/filters/401",
@@ -56,6 +57,7 @@
     }
   ]
 {{ end }}
+
 {{- define "filter_complex_kubernetes_response" }}
   "connective": null,
   "htmlUrl": "https://app.opslevel.com/filters/452",
@@ -87,6 +89,7 @@
 ],
 "connective": "or"
 {{ end }}
+
 {{- define "create_filter_nested_response" }}
 "connective": "or",
 "htmlUrl": "https://app.opslevel.com/filters/2346",
@@ -124,6 +127,7 @@
 ],
 "connective": "and"
 {{ end }}
+
 {{- define "update_filter_nested_response" }}
 "connective": "and",
 "htmlUrl": "https://app.opslevel.com/filters/2346",

--- a/testdata/templates/levels.tpl
+++ b/testdata/templates/levels.tpl
@@ -27,3 +27,13 @@
     "name": "{{ template "name3" }}"
 }
 {{ end }}
+
+{{- define "level_bronze" }}
+"level": {
+  "alias": "bronze",
+  "description": "Services in this level satisfy critical checks. This is the minimum standard to ship to production.",
+  "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzE3",
+  "index": 1,
+  "name": "Bronze"
+}
+{{ end }}


### PR DESCRIPTION
## Issues

[#109](https://github.com/OpsLevel/team-platform/issues/109)

## Changelog

- Consolidate some hardcoded test data into templates
- Add `ParseTemplatedStringWith()` which takes in input data for templates.
  - This lets us create templated test data based on actual structs. See `DomainInput` struct in `domain_test.go` and reference `domain_input` template at top of `testdata/templates/domains.tpl`
- Long term, a polished version of this approach may prove useful for generating test data.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A test only data

## Tophatting

`task test` - all tests pass
