### PR TITLE
make UserIdentifierInput fields pointers

### DIFF
--- a/.changes/unreleased/Bugfix-20231110-135823.yaml
+++ b/.changes/unreleased/Bugfix-20231110-135823.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: make UserIdentifierInput fields pointers, fixing the omitempty struct tag behavior
+time: 2023-11-10T13:58:23.41047-06:00

--- a/team_test.go
+++ b/team_test.go
@@ -797,7 +797,7 @@ func TestTeamAddMemberhip(t *testing.T) {
 	team, _ := clientWithAlias.GetTeamWithAlias("example")
 	newMembership := ol.TeamMembershipUserInput{
 		Role: "user",
-		User: ol.UserIdentifierInput{Id: id1, Email: "kyle@opslevel.com"},
+		User: ol.UserIdentifierInput{Id: &id1, Email: ol.NewString("kyle@opslevel.com")},
 	}
 	result, err := clientWithTeamId.AddMemberships(&team.TeamId, newMembership)
 	// Assert
@@ -829,7 +829,7 @@ func TestTeamRemoveMemberhip(t *testing.T) {
 	team, _ := client1.GetTeamWithAlias("example")
 	membershipToDelete := ol.TeamMembershipUserInput{
 		Role: "user",
-		User: ol.UserIdentifierInput{Id: id1, Email: "kyle@opslevel.com"},
+		User: ol.UserIdentifierInput{Id: &id1, Email: ol.NewString("kyle@opslevel.com")},
 	}
 
 	result, err := client2.RemoveMemberships(&team.TeamId, membershipToDelete)

--- a/user.go
+++ b/user.go
@@ -30,8 +30,8 @@ type UserConnection struct {
 }
 
 type UserIdentifierInput struct {
-	Id    ID     `graphql:"id" json:"id,omitempty"`
-	Email string `graphql:"email" json:"email,omitempty"`
+	Id    *ID     `graphql:"id" json:"id,omitempty"`
+	Email *string `graphql:"email" json:"email,omitempty"`
 }
 
 type UserInput struct {
@@ -53,11 +53,11 @@ func (u *User) ResourceType() TaggableResource {
 func NewUserIdentifier(value string) UserIdentifierInput {
 	if IsID(value) {
 		return UserIdentifierInput{
-			Id: ID(value),
+			Id: NewID(value),
 		}
 	}
 	return UserIdentifierInput{
-		Email: value,
+		Email: NewString(value),
 	}
 }
 


### PR DESCRIPTION
## Issues

[#145](https://github.com/OpsLevel/team-platform/issues/145) - partial fix

## Changelog

Make `UserIdentifierInput` fields pointers to enable expected `omitempty` json tag behavior

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - all tests pass
