### PR TITLE
update IdentifierInput struct fields to be pointers and usage of struct

### DIFF
--- a/.changes/unreleased/Bugfix-20231113-103954.yaml
+++ b/.changes/unreleased/Bugfix-20231113-103954.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: 'BREAKING: change IdentifierInput struct fields to pointers'
+time: 2023-11-13T10:39:54.061401-06:00

--- a/actions.go
+++ b/actions.go
@@ -165,7 +165,7 @@ func (client *Client) GetCustomAction(input IdentifierInput) (*CustomActionsExte
 	}
 	err := client.Query(&q, v, WithName("ExternalActionGet"))
 	if q.Account.Action.Id == "" {
-		err = fmt.Errorf("CustomActionsExternalAction with ID '%s' or Alias '%s' not found", input.Id, input.Alias)
+		err = fmt.Errorf("CustomActionsExternalAction with ID '%s' or Alias '%s' not found", string(*input.Id), *input.Alias)
 	}
 	return &q.Account.Action, HandleErrors(err, nil)
 }
@@ -252,7 +252,7 @@ func (client *Client) GetTriggerDefinition(input IdentifierInput) (*CustomAction
 	}
 	err := client.Query(&q, v, WithName("TriggerDefinitionGet"))
 	if q.Account.Definition.Id == "" {
-		err = fmt.Errorf("CustomActionsTriggerDefinition with ID '%s' or Alias '%s' not found", input.Id, input.Alias)
+		err = fmt.Errorf("CustomActionsTriggerDefinition with ID '%s' or Alias '%s' not found", string(*input.Id), *input.Alias)
 	}
 	return &q.Account.Definition, HandleErrors(err, nil)
 }

--- a/actions_test.go
+++ b/actions_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/rocktavious/autopilot/v2023"
 )
 
+var newID *ol.ID = ol.NewID("123456789")
+
 func TestCreateWebhookAction(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(
@@ -70,7 +72,7 @@ func TestUpdateWebhookAction(t *testing.T) {
 
 	// Act
 	action, err := client.UpdateWebhookAction(ol.CustomActionsWebhookActionUpdateInput{
-		Id:         "123456789",
+		Id:         *newID,
 		HTTPMethod: ol.CustomActionsHttpMethodEnumPut,
 	})
 
@@ -94,7 +96,7 @@ func TestUpdateWebhookAction2(t *testing.T) {
 
 	// Act
 	action, err := client.UpdateWebhookAction(ol.CustomActionsWebhookActionUpdateInput{
-		Id:          "123456789",
+		Id:          *newID,
 		Description: ol.NewString(""),
 		Headers:     &headers,
 	})
@@ -116,7 +118,7 @@ func TestDeleteWebhookAction(t *testing.T) {
 
 	// Act
 	err := client.DeleteWebhookAction(ol.IdentifierInput{
-		Id: "123456789",
+		Id: newID,
 	})
 
 	// Assert
@@ -136,8 +138,8 @@ func TestCreateTriggerDefinition(t *testing.T) {
 	trigger, err := client.CreateTriggerDefinition(ol.CustomActionsTriggerDefinitionCreateInput{
 		Name:        "Deploy Rollback",
 		Description: ol.NewString("Disables the Deploy Freeze"),
-		Action:      "123456789",
-		Owner:       "123456789",
+		Action:      *newID,
+		Owner:       *newID,
 		Filter:      ol.NewID("987654321"),
 	})
 	// Assert
@@ -158,8 +160,8 @@ func TestCreateTriggerDefinitionWithGlobalEntityType(t *testing.T) {
 	trigger, err := client.CreateTriggerDefinition(ol.CustomActionsTriggerDefinitionCreateInput{
 		Name:        "Deploy Rollback",
 		Description: ol.NewString("Disables the Deploy Freeze"),
-		Action:      "123456789",
-		Owner:       "123456789",
+		Action:      *newID,
+		Owner:       *newID,
 		Filter:      ol.NewID("987654321"),
 		EntityType:  "GLOBAL",
 		ExtendedTeamAccess: &[]ol.IdentifierInput{
@@ -185,8 +187,8 @@ func TestCreateTriggerDefinitionWithNullExtendedTeams(t *testing.T) {
 	trigger, err := client.CreateTriggerDefinition(ol.CustomActionsTriggerDefinitionCreateInput{
 		Name:               "Deploy Rollback",
 		Description:        ol.NewString("Disables the Deploy Freeze"),
-		Action:             "123456789",
-		Owner:              "123456789",
+		Action:             *newID,
+		Owner:              *newID,
 		Filter:             ol.NewID("987654321"),
 		ExtendedTeamAccess: &[]ol.IdentifierInput{},
 	})
@@ -205,12 +207,12 @@ func TestGetTriggerDefinition(t *testing.T) {
 	client := BestTestClient(t, "custom_actions/get_trigger", testRequest)
 
 	// Act
-	trigger, err := client.GetTriggerDefinition(ol.IdentifierInput{Id: "123456789"})
+	trigger, err := client.GetTriggerDefinition(ol.IdentifierInput{Id: newID})
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, "Release", trigger.Name)
 	autopilot.Equals(t, "Uses Ruby", trigger.Filter.Name)
-	autopilot.Equals(t, "123456789", string(trigger.Owner.Id))
+	autopilot.Equals(t, *newID, trigger.Owner.Id)
 }
 
 func TestListTriggerDefinitions(t *testing.T) {
@@ -236,7 +238,7 @@ func TestListTriggerDefinitions(t *testing.T) {
 	autopilot.Equals(t, 3, triggers.TotalCount)
 	autopilot.Equals(t, "Release", result[1].Name)
 	autopilot.Equals(t, "Uses Ruby", result[1].Filter.Name)
-	autopilot.Equals(t, "123456789", string(result[1].Owner.Id))
+	autopilot.Equals(t, *newID, result[1].Owner.Id)
 	autopilot.Equals(t, "Rollback", result[2].Name)
 	autopilot.Equals(t, "Uses Go", result[2].Filter.Name)
 	autopilot.Equals(t, "123456781", string(result[2].Owner.Id))
@@ -253,7 +255,7 @@ func TestUpdateTriggerDefinition(t *testing.T) {
 
 	// Act
 	trigger, err := client.UpdateTriggerDefinition(ol.CustomActionsTriggerDefinitionUpdateInput{
-		Id:     "123456789",
+		Id:     *newID,
 		Filter: ol.NewID(),
 	})
 	// Assert
@@ -272,7 +274,7 @@ func TestUpdateTriggerDefinition2(t *testing.T) {
 
 	// Act
 	trigger, err := client.UpdateTriggerDefinition(ol.CustomActionsTriggerDefinitionUpdateInput{
-		Id:                 "123456789",
+		Id:                 *newID,
 		Name:               ol.NewString("test"),
 		Description:        ol.NewString(""),
 		ExtendedTeamAccess: &[]ol.IdentifierInput{},
@@ -293,11 +295,11 @@ func TestUpdateTriggerDefinition3(t *testing.T) {
 
 	// Act
 	trigger, err := client.UpdateTriggerDefinition(ol.CustomActionsTriggerDefinitionUpdateInput{
-		Id:          "123456789",
+		Id:          *newID,
 		Name:        ol.NewString("test"),
 		Description: ol.NewString(""),
 		ExtendedTeamAccess: &[]ol.IdentifierInput{
-			*ol.NewIdentifier("123456789"),
+			*ol.NewIdentifier(string(*newID)),
 			*ol.NewIdentifier(string(id1)),
 		},
 	})
@@ -328,15 +330,9 @@ func TestDeleteTriggerDefinition(t *testing.T) {
 	clientErr := BestTestClient(t, "custom_actions/delete_trigger_err", testRequestError)
 	clientErr2 := ABetterTestClient(t, "custom_actions/delete_trigger_err2", request, "")
 	// Act
-	err := client.DeleteTriggerDefinition(ol.IdentifierInput{
-		Id: "123456789",
-	})
-	err2 := clientErr.DeleteTriggerDefinition(ol.IdentifierInput{
-		Id: "123456789",
-	})
-	err3 := clientErr2.DeleteTriggerDefinition(ol.IdentifierInput{
-		Id: "123456789",
-	})
+	err := client.DeleteTriggerDefinition(ol.IdentifierInput{Id: newID})
+	err2 := clientErr.DeleteTriggerDefinition(ol.IdentifierInput{Id: newID})
+	err3 := clientErr2.DeleteTriggerDefinition(ol.IdentifierInput{Id: newID})
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, `OpsLevel API Errors:

--- a/repository.go
+++ b/repository.go
@@ -230,8 +230,8 @@ func (r *Repository) GetTags(client *Client, variables *PayloadVariables) (*TagC
 
 func (client *Client) ConnectServiceRepository(service *ServiceId, repository *Repository) (*ServiceRepository, error) {
 	input := ServiceRepositoryCreateInput{
-		Service:       IdentifierInput{Id: service.Id},
-		Repository:    IdentifierInput{Id: repository.Id},
+		Service:       IdentifierInput{Id: &service.Id},
+		Repository:    IdentifierInput{Id: &repository.Id},
 		BaseDirectory: "/",
 		DisplayName:   fmt.Sprintf("%s/%s", repository.Organization, repository.Name),
 	}

--- a/scalar.go
+++ b/scalar.go
@@ -31,18 +31,18 @@ type Identifier struct {
 }
 
 type IdentifierInput struct {
-	Id    ID     `graphql:"id" json:"id,omitempty"`
-	Alias string `graphql:"alias" json:"alias,omitempty"`
+	Id    *ID     `graphql:"id" json:"id,omitempty"`
+	Alias *string `graphql:"alias" json:"alias,omitempty"`
 }
 
 func NewIdentifier(value string) *IdentifierInput {
 	if IsID(value) {
 		return &IdentifierInput{
-			Id: ID(value),
+			Id: NewID(value),
 		}
 	}
 	return &IdentifierInput{
-		Alias: value,
+		Alias: NewString(value),
 	}
 }
 

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -89,10 +89,10 @@ func TestConstructMutationID(t *testing.T) {
 }
 
 type IdentifierTester struct {
-	Key1 ol.IdentifierInput  `json:"key1"`
-	Key2 ol.IdentifierInput  `json:"key2,omitempty"`
-	Key3 *ol.IdentifierInput `json:"key3"`
-	Key4 *ol.IdentifierInput `json:"key4,omitempty"`
+	IdInputConcrete          ol.IdentifierInput  `json:"idInputConcrete"`
+	IdInputConcreteOmitEmpty ol.IdentifierInput  `json:"idInputConcreteNullable,omitempty"`
+	IdInputPointer           *ol.IdentifierInput `json:"idInputPointer"`
+	IdInputPointerOmitEmpty  *ol.IdentifierInput `json:"idInputPointerNullable,omitempty"`
 }
 
 func TestMarshalIdentifier(t *testing.T) {
@@ -102,22 +102,22 @@ func TestMarshalIdentifier(t *testing.T) {
 	id3 := ol.NewIdentifier("Z2lkOi8vMTIzNDU2Nzg5")
 	case1 := IdentifierTester{}
 	case2 := IdentifierTester{
-		Key1: *id1,
-		Key2: *id1,
-		Key3: id1,
-		Key4: id1,
+		IdInputConcrete:          *id1,
+		IdInputConcreteOmitEmpty: *id1,
+		IdInputPointer:           id1,
+		IdInputPointerOmitEmpty:  id1,
 	}
 	case3 := IdentifierTester{
-		Key1: *id2,
-		Key2: *id2,
-		Key3: id2,
-		Key4: id2,
+		IdInputConcrete:          *id2,
+		IdInputConcreteOmitEmpty: *id2,
+		IdInputPointer:           id2,
+		IdInputPointerOmitEmpty:  id2,
 	}
 	case4 := IdentifierTester{
-		Key1: *id3,
-		Key2: *id3,
-		Key3: id3,
-		Key4: id3,
+		IdInputConcrete:          *id3,
+		IdInputConcreteOmitEmpty: *id3,
+		IdInputPointer:           id3,
+		IdInputPointerOmitEmpty:  id3,
 	}
 	// Act
 	buf1, err1 := json.Marshal(case1)
@@ -126,13 +126,13 @@ func TestMarshalIdentifier(t *testing.T) {
 	buf4, err4 := json.Marshal(case4)
 	// Assert
 	autopilot.Ok(t, err1)
-	autopilot.Equals(t, `{"key1":{},"key2":{},"key3":null}`, string(buf1))
+	autopilot.Equals(t, `{"idInputConcrete":{},"idInputConcreteNullable":{},"idInputPointer":null}`, string(buf1))
 	autopilot.Ok(t, err2)
-	autopilot.Equals(t, `{"key1":{},"key2":{},"key3":{},"key4":{}}`, string(buf2))
+	autopilot.Equals(t, `{"idInputConcrete":{"alias":""},"idInputConcreteNullable":{"alias":""},"idInputPointer":{"alias":""},"idInputPointerNullable":{"alias":""}}`, string(buf2))
 	autopilot.Ok(t, err3)
-	autopilot.Equals(t, `{"key1":{"alias":"my-service"},"key2":{"alias":"my-service"},"key3":{"alias":"my-service"},"key4":{"alias":"my-service"}}`, string(buf3))
+	autopilot.Equals(t, `{"idInputConcrete":{"alias":"my-service"},"idInputConcreteNullable":{"alias":"my-service"},"idInputPointer":{"alias":"my-service"},"idInputPointerNullable":{"alias":"my-service"}}`, string(buf3))
 	autopilot.Ok(t, err4)
-	autopilot.Equals(t, `{"key1":{"id":"Z2lkOi8vMTIzNDU2Nzg5"},"key2":{"id":"Z2lkOi8vMTIzNDU2Nzg5"},"key3":{"id":"Z2lkOi8vMTIzNDU2Nzg5"},"key4":{"id":"Z2lkOi8vMTIzNDU2Nzg5"}}`, string(buf4))
+	autopilot.Equals(t, `{"idInputConcrete":{"id":"Z2lkOi8vMTIzNDU2Nzg5"},"idInputConcreteNullable":{"id":"Z2lkOi8vMTIzNDU2Nzg5"},"idInputPointer":{"id":"Z2lkOi8vMTIzNDU2Nzg5"},"idInputPointerNullable":{"id":"Z2lkOi8vMTIzNDU2Nzg5"}}`, string(buf4))
 }
 
 func TestConstructQueryIdentifier(t *testing.T) {
@@ -184,6 +184,6 @@ func TestNewIdentifierArray(t *testing.T) {
 	s := []string{"my-service", "Z2lkOi8vMTIzNDU2Nzg5"}
 	result := ol.NewIdentifierArray(s)
 	// Assert
-	autopilot.Equals(t, "my-service", result[0].Alias)
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), result[1].Id)
+	autopilot.Equals(t, "my-service", string(*result[0].Alias))
+	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }

--- a/scorecards.go
+++ b/scorecards.go
@@ -62,7 +62,7 @@ func (client *Client) GetScorecard(identifier string) (*Scorecard, error) {
 	}
 	err := client.Query(&q, v, WithName("ScorecardGet"))
 	if q.Account.Scorecard.Id == "" {
-		err = fmt.Errorf("Scorecard with ID '%s' or Alias '%s' not found", input.Id, input.Alias)
+		err = fmt.Errorf("Scorecard with ID '%s' or Alias '%s' not found", string(*input.Id), *input.Alias)
 	}
 	return &q.Account.Scorecard, HandleErrors(err, nil)
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -19,7 +19,7 @@ func TestCreateSecret(t *testing.T) {
 	fmt.Println(client)
 	// Act
 	secretInput := opslevel.SecretInput{
-		Owner: opslevel.IdentifierInput{Id: id2},
+		Owner: opslevel.IdentifierInput{Id: &id2},
 		Value: "my-secret",
 	}
 	result, err := client.CreateSecret("alias1", secretInput)
@@ -79,7 +79,7 @@ func TestUpdateSecret(t *testing.T) {
 	client := BestTestClient(t, "secrets/update", testRequest)
 	// Act
 	secretInput := opslevel.SecretInput{
-		Owner: opslevel.IdentifierInput{Id: id2},
+		Owner: opslevel.IdentifierInput{Id: &id2},
 		Value: "secret_value_2",
 	}
 	result, err := client.UpdateSecret(string(id2), secretInput)


### PR DESCRIPTION
## Issues

[#145](https://github.com/OpsLevel/team-platform/issues/145)

## Changelog

*BREAKING CHANGE:*
Update `IdentifierInput` struct fields to be pointers. 
`IdentifierInput`s are core to this code and it's safe to assume this necessary change will cause downstream issues.

### In most cases this is a simple fix.
- dereference the field to get the underlying string
- cast a dereferenced `opslevel.ID` as a string, e.g., `input.Id,` --> `string(*input.Id)`

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - all tests pass
