### PR TITLE
add error check to JSON unmarshal, ci fails if linting fails

### DIFF
--- a/.changes/unreleased/Feature-20231115-103353.yaml
+++ b/.changes/unreleased/Feature-20231115-103353.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add error check to JSON unmarshalling
+time: 2023-11-15T10:33:53.209882-06:00

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,12 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Tests
+      - name: Lint code
         run: |-
           task setup
           task lint
-          task test
+      - name: Test code
+        run: task test
       - name: Upload Coverage
         run: |-
           bash <(curl -s https://codecov.io/bash)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,0 @@
-run:
-  timeout: 2m
-linters:
-  disable:
-    - errcheck

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,7 +14,7 @@ tasks:
     desc: Formatting and linting
     deps: [install-gofumpt]
     cmds:
-      - gofumpt -d .
+      - test -z "$(gofumpt -d -e . | tee /dev/stderr)"
       - go vet ./...
       - golangci-lint run
 
@@ -60,6 +60,7 @@ tasks:
     cmds:
       - task: install-go-tool
         vars: { GO_TOOL: "gofumpt", GO_TOOL_PATH: "mvdan.cc/gofumpt@latest" }
+      - echo "  'gofumpt' is installed."
 
   install-golangci-lint:
     desc: go install "golangci-lint" and set GOBIN if not set
@@ -67,3 +68,4 @@ tasks:
     cmds:
       - task: install-go-tool
         vars: { GO_TOOL: "golangci-lint", GO_TOOL_PATH: "github.com/golangci/golangci-lint/cmd/golangci-lint@latest" }
+      - echo "  'golangci-lint' is installed."

--- a/clientGQL_test.go
+++ b/clientGQL_test.go
@@ -57,7 +57,9 @@ func GraphQLQueryTemplate(request string) autopilot.GraphqlQuery {
 	exp := autopilot.GraphqlQuery{
 		Variables: nil,
 	}
-	json.Unmarshal([]byte(Templated(request)), &exp)
+	if err := json.Unmarshal([]byte(Templated(request)), &exp); err != nil {
+		panic(err)
+	}
 	return exp
 }
 

--- a/json.go
+++ b/json.go
@@ -12,7 +12,9 @@ func (s JSON) GetGraphQLType() string { return "JSON" }
 
 func NewJSON(data string) JSON {
 	result := make(JSON)
-	json.Unmarshal([]byte(data), &result)
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		panic(err)
+	}
 	return result
 }
 


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Removed `.golangci.yml` file - this was disabling some error checking
Check for errors on `json.Unmarshall()`
- `NewTestRequest()` vets test data and verifies it's working with valid JSON. Checking for JSON errors is now a safe move.

`task lint` now returns a non-zero return code so we can enforce this in CI

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - tests pass
