### PR TITLE
Bugfix for service fields not being unsettable

### DIFF
--- a/.changes/unreleased/Bugfix-20231201-172947.yaml
+++ b/.changes/unreleased/Bugfix-20231201-172947.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix a bug where during UpdateService you were unable to "unset" fields like
+  description, framework, lifecycle, etc
+time: 2023-12-01T17:29:47.430731-06:00

--- a/service.go
+++ b/service.go
@@ -63,14 +63,14 @@ type ServiceCreateInput struct {
 type ServiceUpdateInput struct {
 	Id          ID               `json:"id,omitempty"`
 	Alias       string           `json:"alias,omitempty"`
-	Name        string           `json:"name,omitempty"`
-	Product     string           `json:"product,omitempty"`
-	Description string           `json:"description,omitempty"`
-	Language    string           `json:"language,omitempty"`
-	Framework   string           `json:"framework,omitempty"`
-	Tier        string           `json:"tierAlias,omitempty"`
+	Name        *string          `json:"name,omitempty"`
+	Product     *string          `json:"product,omitempty"`
+	Description *string          `json:"description,omitempty"`
+	Language    *string          `json:"language,omitempty"`
+	Framework   *string          `json:"framework,omitempty"`
+	Tier        *string          `json:"tierAlias,omitempty"`
 	Owner       *IdentifierInput `json:"ownerInput,omitempty"`
-	Lifecycle   string           `json:"lifecycleAlias,omitempty"`
+	Lifecycle   *string          `json:"lifecycleAlias,omitempty"`
 }
 
 type ServiceDeleteInput struct {

--- a/service_test.go
+++ b/service_test.go
@@ -264,6 +264,48 @@ func TestUpdateService(t *testing.T) {
 	autopilot.Equals(t, "Foo", result.Name)
 }
 
+func TestUpdateServiceUnsetDescription(t *testing.T) {
+	// Arrange
+	testRequest := NewTestRequest(
+		`"mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}"`,
+		`{"input":{"id": "123456789", "description": ""}}`,
+		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
+	)
+
+	client := BestTestClient(t, "service/update_unset_description", testRequest)
+
+	// Act
+	result, err := client.UpdateService(ol.ServiceUpdateInput{
+		Id:          "123456789",
+		Description: ol.NewString(""),
+	})
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Foo", result.Name)
+}
+
+func TestUpdateServiceUnsetFramework(t *testing.T) {
+	// Arrange
+	testRequest := NewTestRequest(
+		`"mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}"`,
+		`{"input":{"id": "123456789", "framework": ""}}`,
+		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
+	)
+
+	client := BestTestClient(t, "service/update_unset_framework", testRequest)
+
+	// Act
+	result, err := client.UpdateService(ol.ServiceUpdateInput{
+		Id:        "123456789",
+		Framework: ol.NewString(""),
+	})
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Foo", result.Name)
+}
+
 func TestGetServiceIdWithAlias(t *testing.T) {
 	// Arrange
 	testRequest := NewTestRequest(


### PR DESCRIPTION
The needed changes to fix a bug where service fields were not "unset"-able during service update

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

The tests show if you pass in a new string pointer the field shows up in the input as being set to an empty string.
