### PR TITLE
Add new json input type that should be used for service properties

### DIFF
--- a/.changes/unreleased/Feature-20231201-182930.yaml
+++ b/.changes/unreleased/Feature-20231201-182930.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add `NewJSONInput` which creates a properly marshalled input type for graphql
+time: 2023-12-01T18:29:30.253906-06:00

--- a/json.go
+++ b/json.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"encoding/json"
+	"github.com/rs/zerolog/log"
 	"strconv"
 )
 
@@ -49,12 +50,43 @@ func NewJSONInput(data any) JSONString {
 	return JSONString(bytes)
 }
 
-func JsonStringAs[T any](data JSONString) T {
+func JsonStringAs[T any](data JSONString) (T, error) {
 	var result T
 	if err := json.Unmarshal([]byte(data), &result); err != nil {
-		panic(err)
+		log.Warn().Err(err).Msgf("unable to marshal json as %T", result)
+		return result, err
 	}
-	return result
+	return result, nil
+}
+
+func (s JSONString) Bool() bool {
+	value, _ := JsonStringAs[bool](s)
+	return value
+}
+
+func (s JSONString) Int() int {
+	value, _ := JsonStringAs[int](s)
+	return value
+}
+
+func (s JSONString) Float64() float64 {
+	value, _ := JsonStringAs[float64](s)
+	return value
+}
+
+func (s JSONString) String() string {
+	value, _ := JsonStringAs[string](s)
+	return value
+}
+
+func (s JSONString) Array() []any {
+	value, _ := JsonStringAs[[]any](s)
+	return value
+}
+
+func (s JSONString) Map() map[string]any {
+	value, _ := JsonStringAs[map[string]any](s)
+	return value
 }
 
 //

--- a/json.go
+++ b/json.go
@@ -2,8 +2,9 @@ package opslevel
 
 import (
 	"encoding/json"
-	"github.com/rs/zerolog/log"
 	"strconv"
+
+	"github.com/rs/zerolog/log"
 )
 
 // JSON is a specialized map[string]string to support proper graphql serialization

--- a/json.go
+++ b/json.go
@@ -36,6 +36,19 @@ func (s JSON) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.Quote(string(b))), err
 }
 
+// JSONInput is a specialized input type to support serialization to JSON for input to graphql
+type JSONInput string
+
+func (s JSONInput) GetGraphQLType() string { return "JsonString" }
+
+func NewJSONInput(data any) JSONInput {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	return JSONInput(bytes)
+}
+
 //
 //func (s *JSON) UnmarshalJSON(data []byte) error {
 //	escaped, err := strconv.Unquote(string(data))

--- a/json.go
+++ b/json.go
@@ -36,17 +36,25 @@ func (s JSON) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.Quote(string(b))), err
 }
 
-// JSONInput is a specialized input type to support serialization to JSON for input to graphql
-type JSONInput string
+// JSONString is a specialized input type to support serialization to JSON for input to graphql
+type JSONString string
 
-func (s JSONInput) GetGraphQLType() string { return "JsonString" }
+func (s JSONString) GetGraphQLType() string { return "JsonString" }
 
-func NewJSONInput(data any) JSONInput {
+func NewJSONInput(data any) JSONString {
 	bytes, err := json.Marshal(data)
 	if err != nil {
 		panic(err)
 	}
-	return JSONInput(bytes)
+	return JSONString(bytes)
+}
+
+func JsonStringAs[T any](data JSONString) T {
+	var result T
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		panic(err)
+	}
+	return result
 }
 
 //

--- a/json_test.go
+++ b/json_test.go
@@ -24,10 +24,14 @@ func TestNewJSON(t *testing.T) {
 	result1, err1 := json.Marshal(data1)
 	result2, err2 := json.Marshal(data2)
 	result3 := ol.NewJSONInput(`{"foo":"bar"}`)
-	result4 := ol.NewJSONInput(map[string]any{"foo": "bar"})
-	result5 := ol.NewJSONInput(true)
-	result6 := ol.NewJSONInput(1.32)
+
+	result4 := ol.NewJSONInput(true)
+	result4a := ol.NewJSONInput(false)
+	result5 := ol.NewJSONInput(1.32)
+	result5a := ol.NewJSONInput(0)
+	result6 := ol.NewJSONInput("hello world")
 	result7 := ol.NewJSONInput([]any{"foo", "bar"})
+	result8 := ol.NewJSONInput(map[string]any{"foo": "bar"})
 	// Assert
 	autopilot.Ok(t, err1)
 	autopilot.Ok(t, err2)
@@ -36,10 +40,14 @@ func TestNewJSON(t *testing.T) {
 	autopilot.Equals(t, result1, result2)
 	autopilot.Equals(t, string(result1), string(result3))
 	autopilot.Equals(t, string(result2), string(result3))
-	autopilot.Equals(t, `{"foo":"bar"}`, string(result4))
-	autopilot.Equals(t, `true`, string(result5))
-	autopilot.Equals(t, `1.32`, string(result6))
+
+	autopilot.Equals(t, `true`, string(result4))
+	autopilot.Equals(t, `false`, string(result4a))
+	autopilot.Equals(t, `1.32`, string(result5))
+	autopilot.Equals(t, `0`, string(result5a))
+	autopilot.Equals(t, `"hello world"`, string(result6))
 	autopilot.Equals(t, `["foo","bar"]`, string(result7))
+	autopilot.Equals(t, `{"foo":"bar"}`, string(result8))
 }
 
 func TestMarshalJSON(t *testing.T) {
@@ -128,4 +136,31 @@ func TestConstructMutationJSON(t *testing.T) {
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, `mutation MyMutation($id1:JSON!$id2:JSON$id3:JsonString!){account{myMutation(id1: $id1 id2: $id2 id3: $id3){data}}}`, query)
+}
+
+func TestUnmarshalJSONString(t *testing.T) {
+	// Arrange
+	data1 := true
+	data1a := false
+	data2 := 1.32
+	data2a := 0
+	data3 := "hello world"
+	data4 := []any{"foo", "bar"}
+	data5 := map[string]any{"foo": "bar"}
+	// Act
+	result1 := ol.JsonStringAs[bool](ol.NewJSONInput(data1))
+	result1a := ol.JsonStringAs[bool](ol.NewJSONInput(data1a))
+	result2 := ol.JsonStringAs[float64](ol.NewJSONInput(data2))
+	result2a := ol.JsonStringAs[int](ol.NewJSONInput(data2a))
+	result3 := ol.JsonStringAs[string](ol.NewJSONInput(data3))
+	result4 := ol.JsonStringAs[[]any](ol.NewJSONInput(data4))
+	result5 := ol.JsonStringAs[map[string]any](ol.NewJSONInput(data5))
+	// Assert
+	autopilot.Equals(t, data1, result1)
+	autopilot.Equals(t, data1a, result1a)
+	autopilot.Equals(t, data2, result2)
+	autopilot.Equals(t, data2a, result2a)
+	autopilot.Equals(t, data3, result3)
+	autopilot.Equals(t, data4, result4)
+	autopilot.Equals(t, data5, result5)
 }

--- a/json_test.go
+++ b/json_test.go
@@ -23,12 +23,23 @@ func TestNewJSON(t *testing.T) {
 	// Act
 	result1, err1 := json.Marshal(data1)
 	result2, err2 := json.Marshal(data2)
+	result3 := ol.NewJSONInput(`{"foo":"bar"}`)
+	result4 := ol.NewJSONInput(map[string]any{"foo": "bar"})
+	result5 := ol.NewJSONInput(true)
+	result6 := ol.NewJSONInput(1.32)
+	result7 := ol.NewJSONInput([]any{"foo", "bar"})
 	// Assert
 	autopilot.Ok(t, err1)
 	autopilot.Ok(t, err2)
 	autopilot.Equals(t, data1, data2)
 	autopilot.Assert(t, &data1 != &data2, "The JSON objects have the same memory address")
 	autopilot.Equals(t, result1, result2)
+	autopilot.Equals(t, string(result1), string(result3))
+	autopilot.Equals(t, string(result2), string(result3))
+	autopilot.Equals(t, `{"foo":"bar"}`, string(result4))
+	autopilot.Equals(t, `true`, string(result5))
+	autopilot.Equals(t, `1.32`, string(result6))
+	autopilot.Equals(t, `["foo","bar"]`, string(result7))
 }
 
 func TestMarshalJSON(t *testing.T) {
@@ -76,18 +87,21 @@ func TestConstructQueryJSON(t *testing.T) {
 		Account struct {
 			Output struct {
 				Data ol.JSON `json:"data" scalar:"true"`
-			} `graphql:"myQuery(id1: $id1 id2: $id2)"`
+			} `graphql:"myQuery(id1: $id1 id2: $id2 id3: $id3)"`
 		}
 	}
 	v := ol.PayloadVariables{
 		"id1": data,
 		"id2": &data,
+		"id3": ol.NewJSONInput(map[string]any{
+			"foo": "bar",
+		}),
 	}
 	// Act
 	query, err := graphql.ConstructQuery(q, v, ol.WithName("MyQuery"))
 	// Assert
 	autopilot.Ok(t, err)
-	autopilot.Equals(t, `query MyQuery($id1:JSON!$id2:JSON){account{myQuery(id1: $id1 id2: $id2){data}}}`, query)
+	autopilot.Equals(t, `query MyQuery($id1:JSON!$id2:JSON$id3:JsonString!){account{myQuery(id1: $id1 id2: $id2 id3: $id3){data}}}`, query)
 }
 
 func TestConstructMutationJSON(t *testing.T) {
@@ -99,16 +113,19 @@ func TestConstructMutationJSON(t *testing.T) {
 		Account struct {
 			Output struct {
 				Data ol.JSON `json:"data" scalar:"true"`
-			} `graphql:"myMutation(id1: $id1 id2: $id2)"`
+			} `graphql:"myMutation(id1: $id1 id2: $id2 id3: $id3)"`
 		}
 	}
 	v := ol.PayloadVariables{
 		"id1": data,
 		"id2": &data,
+		"id3": ol.NewJSONInput(map[string]any{
+			"foo": "bar",
+		}),
 	}
 	// Act
 	query, err := graphql.ConstructMutation(q, v, ol.WithName("MyMutation"))
 	// Assert
 	autopilot.Ok(t, err)
-	autopilot.Equals(t, `mutation MyMutation($id1:JSON!$id2:JSON){account{myMutation(id1: $id1 id2: $id2){data}}}`, query)
+	autopilot.Equals(t, `mutation MyMutation($id1:JSON!$id2:JSON$id3:JsonString!){account{myMutation(id1: $id1 id2: $id2 id3: $id3){data}}}`, query)
 }

--- a/json_test.go
+++ b/json_test.go
@@ -148,13 +148,14 @@ func TestUnmarshalJSONString(t *testing.T) {
 	data4 := []any{"foo", "bar"}
 	data5 := map[string]any{"foo": "bar"}
 	// Act
-	result1 := ol.JsonStringAs[bool](ol.NewJSONInput(data1))
-	result1a := ol.JsonStringAs[bool](ol.NewJSONInput(data1a))
-	result2 := ol.JsonStringAs[float64](ol.NewJSONInput(data2))
-	result2a := ol.JsonStringAs[int](ol.NewJSONInput(data2a))
-	result3 := ol.JsonStringAs[string](ol.NewJSONInput(data3))
-	result4 := ol.JsonStringAs[[]any](ol.NewJSONInput(data4))
-	result5 := ol.JsonStringAs[map[string]any](ol.NewJSONInput(data5))
+	result1 := ol.NewJSONInput(data1).Bool()
+	result1a := ol.NewJSONInput(data1a).Bool()
+	result2 := ol.NewJSONInput(data2).Float64()
+	result2a := ol.NewJSONInput(data2a).Int()
+	result3 := ol.NewJSONInput(data3).String()
+	result4 := ol.NewJSONInput(data4).Array()
+	result5 := ol.NewJSONInput(data5).Map()
+	_, err := ol.JsonStringAs[float32](ol.NewJSONInput(data1))
 	// Assert
 	autopilot.Equals(t, data1, result1)
 	autopilot.Equals(t, data1a, result1a)
@@ -163,4 +164,5 @@ func TestUnmarshalJSONString(t *testing.T) {
 	autopilot.Equals(t, data3, result3)
 	autopilot.Equals(t, data4, result4)
 	autopilot.Equals(t, data5, result5)
+	autopilot.Assert(t, err != nil, "The JSON string of type bool should be unable to unmarshalled into a float32")
 }


### PR DESCRIPTION
## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

See the test assertions in `TestNewJSON` to show how it takes in different types like, bool, number, array and maps and property marshals them to string data that will get passed to our API.  We could just use a `string` and force the customer to use `json.Marshal` themselves but we don't for 3 reasons 
- ease of use
- we need to name the type `JsonString` in the mutation - see the `TestConstructQueryJSON` and `TestConstructMutationJSON`
- we need to have a way to convert it back to a more concrete type
