### PR TITLE
run changie workflow only if go files updated. doc,test only updates …

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     # catch when the PR is opened with the label or when the label is added
     types: [labeled]
+    paths:
+      - '**.go'
+      - '!**_test.go'
 
 permissions:
   contents: write


### PR DESCRIPTION

## Issues

Have changie workflow check for changie logs only when actual `*.go` files are updated. Github workflow, docs, and testdata/test only updates do not need changie logs. Dependabot can't merge Dependabot PRs with changie workflows failing.

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [X] List your changes here
- [ ] Make a `changie` entry, N/A github workflow update

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
