### PR TITLE
use common Github workflow from our actions repo

### DIFF
--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -1,15 +1,11 @@
 name: Dependabot Labels
 
 on:
-  # Runs when PR is labeled by Dependabot or via the Github UI
   pull_request:
     types:
       - labeled
 
 jobs:
-  pr-labeled:
+  dependabot-pr-label:
     if: github.event.label.name == 'dependencies'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger workflow
-        run: echo "Triggering workflow_run to generate Changie logs"
+    uses: OpsLevel/actions/.github/workflows/dependabot_pr_labels.yml@main


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Use [reusable workflow from our actions repo](https://github.com/OpsLevel/actions/blob/main/.github/workflows/dependabot_pr_labels.yml) to trigger adding a changelog to Dependabot PRs with changie.

Note: the job in this workflow runs only if dependabot opens a PR. If we want to also keep a manual way of triggering the chanige job lmk and I can add some extra "triggered by" stuff [there](https://github.com/OpsLevel/opslevel-go/blob/main/.github/workflows/changie-gen.yml)

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
