### PR TITLE
add GenYamlFromStruct to generate yaml strings from structs

### DIFF
--- a/.changes/unreleased/Feature-20231211-113343.yaml
+++ b/.changes/unreleased/Feature-20231211-113343.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add func to generate yaml files from our structs
+time: 2023-12-11T11:33:43.214239-06:00

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/relvacode/iso8601 v1.3.0
 	github.com/rocktavious/autopilot/v2023 v2023.12.7
 	github.com/rs/zerolog v1.31.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -169,10 +169,13 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=

--- a/yaml.go
+++ b/yaml.go
@@ -1,0 +1,14 @@
+package opslevel
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// Generate example yaml files for OpsLevel resources
+func GenYamlFromStruct[T any](opslevelResource T) (string, error) {
+	out, err := yaml.Marshal(opslevelResource)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Generate yaml formatted string for our opslevel structs.
This has multiple uses. One example is we can generate the help docs in our cli.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```go
defaultUser, _ := opslevel.GenYamlFromStruct[opslevel.UserInput](opslevel.UserInput{})
definedUser, err := opslevel.GenYamlFromStruct[opslevel.UserInput](opslevel.UserInput{
	Name:             "test",
	Role:             opslevel.UserRoleAdmin,
	SkipWelcomeEmail: true,
})
fmt.Println(defaultUser)
fmt.Println(definedUser)
```
Gives us
```yaml
# for defaultUser 
name: ""
role: ""
skipwelcomeemail: false

# for definedUser 
name: test
role: admin
skipwelcomeemail: true
```
