### PR TITLE
fix changie gen to work with our custom workflow

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -10,14 +10,38 @@ jobs:
   generate-changelog:
     runs-on: ubuntu-latest
     steps:
-    - name: Create and commit changelog on bot PR
-      if: github.event.workflow_run.conclusion == 'success'
-      id: bot_changelog
-      uses: emmyoop/changie_bot@v1.1.0
+    - name: Checkout branch that Dependabot labeled
+      uses: actions/checkout@v4
       with:
-        GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
-        commit_author_name: "Github Build Bot"
-        commit_author_email: "<bots@opslevel.com>"
-        commit_message: "Add automated changelog yaml from template for bot PR"
-        changie_kind: Dependency
-        label: dependencies
+        ref: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
+        token: ${{ secrets.ORG_GITHUB_TOKEN }}
+
+    - name: Check if changelog file exists already
+      shell: bash
+      id: changelog_check
+      run: |
+        git fetch origin ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        RESULT=$(git diff --name-only ${{ github.event.workflow_run.pull_requests[0].head.ref }} ${{ github.event.workflow_run.pull_requests[0].base.ref }})
+        if echo $RESULT | grep '.changes/unreleased/.*.yaml'; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "Changelog already exists for this PR, skip creating a new one"
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "No changelog exists for this PR, creating a new one"
+        fi
+
+    - name: Create changie log
+      if: steps.changelog_check.outputs.exists == 'false'
+      shell: bash
+      run: changie new --kind Feature --body "${{ github.event.workflow_run.display_title }}"
+
+    - name: Commit & Push changes
+      if: steps.changelog_check.outputs.exists == 'false'
+      shell: bash
+      run: |
+        git config user.name "OpsLevel Bots"
+        git config user.email "bots@opslevel.com"
+        git pull
+        git add .
+        git commit -m "Add automated changelog yaml from template"
+        git push

--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -8,21 +8,23 @@ on:
 
 jobs:
   generate-changelog:
+    env:
+      MAIN_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+      PR_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch that Dependabot labeled
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
+        ref: ${{ env.PR_BRANCH }}
         token: ${{ secrets.ORG_GITHUB_TOKEN }}
 
     - name: Check if changelog file exists already
       shell: bash
       id: changelog_check
       run: |
-        git fetch origin ${{ github.event.workflow_run.pull_requests[0].base.ref }}
-        RESULT=$(git diff --name-only ${{ github.event.workflow_run.pull_requests[0].head.ref }} ${{ github.event.workflow_run.pull_requests[0].base.ref }})
-        if echo $RESULT | grep '.changes/unreleased/.*.yaml'; then
+        git fetch origin ${{ env.MAIN_BRANCH }}
+        if [[ -n $(git diff --name-only main -- .changes/unreleased/*.yaml) ]]; then
           echo "exists=true" >> $GITHUB_OUTPUT
           echo "Changelog already exists for this PR, skip creating a new one"
         else


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

With our new workflow, [the changie job](https://github.com/OpsLevel/opslevel-go/actions/runs/7166803671) runs with correct permissions but is detached from the original dependabot PR. This should fix that.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A Ci only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
