### PR TITLE
fix typos in default struct tags

### DIFF
--- a/property.go
+++ b/property.go
@@ -3,15 +3,15 @@ package opslevel
 import "fmt"
 
 type PropertyDefinitionInput struct {
-	Name   string     `json:"name" defaults:"John Doe"`
-	Schema JSONString `json:"schema" defaults:"{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"Packages\",\"description\":\"A list of packages.\",\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"lock_file\":{\"type\":\"string\"},\"manager\":{\"type\":\"string\"},},\"required\":[\"name\",\"version\"],},\"minItems\":0,\"uniqueItems\":true}"`
+	Name   string     `json:"name" default:"John Doe"`
+	Schema JSONString `json:"schema,string" default:"\"{\\\"$schema\\\":\\\"https://json-schema.org/draft/2020-12/schema\\\",\\\"title\\\":\\\"Packages\\\",\\\"description\\\":\\\"A list of packages.\\\",\\\"type\\\":\\\"array\\\",\\\"items\\\":{\\\"type\\\":\\\"object\\\",\\\"properties\\\":{\\\"name\\\":{\\\"type\\\":\\\"string\\\"},\\\"version\\\":{\\\"type\\\":\\\"string\\\"},\\\"lock_file\\\":{\\\"type\\\":\\\"string\\\"},\\\"manager\\\":{\\\"type\\\":\\\"string\\\"},},\\\"required\\\":[\\\"name\\\",\\\"version\\\"],},\\\"minItems\\\":0,\\\"uniqueItems\\\":true}\""`
 }
 
 type PropertyDefinition struct {
-	Aliases []string `graphql:"aliases" json:"aliases" defaults:"-"`
-	Id      ID       `graphql:"id" json:"id" defaults:"-"`
-	Name    string   `graphql:"name" json:"name" defaults:"-"`
-	Schema  JSON     `json:"schema" scalar:"true" defaults:"-"` // Do not add graphql struct tag here
+	Aliases []string `graphql:"aliases" json:"aliases" default:"-"`
+	Id      ID       `graphql:"id" json:"id" default:"-"`
+	Name    string   `graphql:"name" json:"name" default:"-"`
+	Schema  JSON     `json:"schema" scalar:"true" default:"-"` // Do not add graphql struct tag here
 }
 
 type PropertyDefinitionConnection struct {

--- a/property.go
+++ b/property.go
@@ -8,10 +8,10 @@ type PropertyDefinitionInput struct {
 }
 
 type PropertyDefinition struct {
-	Aliases []string `graphql:"aliases" json:"aliases" default:"-"`
-	Id      ID       `graphql:"id" json:"id" default:"-"`
-	Name    string   `graphql:"name" json:"name" default:"-"`
-	Schema  JSON     `json:"schema" scalar:"true" default:"-"` // Do not add graphql struct tag here
+	Aliases []string `graphql:"aliases" json:"aliases"`
+	Id      ID       `graphql:"id" json:"id"`
+	Name    string   `graphql:"name" json:"name"`
+	Schema  JSON     `json:"schema" scalar:"true"`
 }
 
 type PropertyDefinitionConnection struct {

--- a/tools.go
+++ b/tools.go
@@ -20,17 +20,17 @@ type ToolCreateInput struct {
 	Category     ToolCategory `json:"category" validate:"required" default:"logs"`
 	DisplayName  string       `json:"displayName" yaml:"displayName" default:"John Doe"`
 	Url          string       `json:"url" default:"john.doe@example.com"`
-	Environment  string       `json:"environment,omitempty" yaml:"environment,omitempty" default:"-"`
-	ServiceId    ID           `json:"serviceId,omitempty" yaml:"serviceId,omitempty" default:"-"`
-	ServiceAlias string       `json:"serviceAlias,omitempty" yaml:"serviceId,omitempty" default:"-"`
+	Environment  string       `json:"environment,omitempty" yaml:"environment,omitempty"`
+	ServiceId    ID           `json:"serviceId,omitempty" yaml:"serviceId,omitempty"`
+	ServiceAlias string       `json:"serviceAlias,omitempty" yaml:"serviceId,omitempty"`
 }
 
 type ToolUpdateInput struct {
 	Id          ID           `json:"id" default:"Z2lkOi8vMTIzNDU2Nzg5MTAK"`
-	Category    ToolCategory `json:"category,omitempty" default:"-"`
+	Category    ToolCategory `json:"category,omitempty"`
 	DisplayName string       `json:"displayName,omitempty" yaml:"displayName,omitempty" default:"John Doe"`
 	Url         string       `json:"url,omitempty" yaml:"url,omitempty" default:"john.doe@example.com"`
-	Environment string       `json:"environment,omitempty" yaml:"environment,omitempty" default:"-"`
+	Environment string       `json:"environment,omitempty" yaml:"environment,omitempty"`
 }
 
 type ToolDeleteInput struct {

--- a/user.go
+++ b/user.go
@@ -30,14 +30,14 @@ type UserConnection struct {
 }
 
 type UserIdentifierInput struct {
-	Id    *ID     `graphql:"id" json:"id,omitempty" default:"-"`
-	Email *string `graphql:"email" json:"email,omitempty" default:"-"`
+	Id    *ID     `graphql:"id" json:"id,omitempty"`
+	Email *string `graphql:"email" json:"email,omitempty"`
 }
 
 type UserInput struct {
-	Name             string   `json:"name,omitempty" default:"-"`
-	Role             UserRole `json:"role,omitempty" default:"-"`
-	SkipWelcomeEmail bool     `json:"skipWelcomeEmail" yaml:"skipWelcomeEmail" default:"false"`
+	Name             string   `json:"name,omitempty"`
+	Role             UserRole `json:"role,omitempty"`
+	SkipWelcomeEmail bool     `json:"skipWelcomeEmail" yaml:"skipWelcomeEmail"`
 }
 
 func (u *User) ResourceId() ID {

--- a/user.go
+++ b/user.go
@@ -6,7 +6,7 @@ import (
 )
 
 type MemberInput struct {
-	Email string `json:"email" defaults:"john.doe@example.com"`
+	Email string `json:"email" default:"john.doe@example.com"`
 }
 
 type UserId struct {
@@ -30,14 +30,14 @@ type UserConnection struct {
 }
 
 type UserIdentifierInput struct {
-	Id    *ID     `graphql:"id" json:"id,omitempty" defaults:"-"`
-	Email *string `graphql:"email" json:"email,omitempty" defaults:"-"`
+	Id    *ID     `graphql:"id" json:"id,omitempty" default:"-"`
+	Email *string `graphql:"email" json:"email,omitempty" default:"-"`
 }
 
 type UserInput struct {
-	Name             string   `json:"name,omitempty" defaults:"-"`
-	Role             UserRole `json:"role,omitempty" defaults:"-"`
-	SkipWelcomeEmail bool     `json:"skipWelcomeEmail" yaml:"skipWelcomeEmail" defaults:"false"`
+	Name             string   `json:"name,omitempty" default:"-"`
+	Role             UserRole `json:"role,omitempty" default:"-"`
+	SkipWelcomeEmail bool     `json:"skipWelcomeEmail" yaml:"skipWelcomeEmail" default:"false"`
 }
 
 func (u *User) ResourceId() ID {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog
Fix typos. `defaults:""` should be `default:""`
The default for JSONString needs loads of these `\` 👀 

- [X] List your changes here
- [ ] Make a `changie` entry, N/A typo fixes

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
