### PR TITLE
fix error logged when JSONString passed to fmt.Sprintf()

### DIFF
--- a/.changes/unreleased/Bugfix-20231213-113813.yaml
+++ b/.changes/unreleased/Bugfix-20231213-113813.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix error logged when JSONString passed to fmt.Sprintf()
+time: 2023-12-13T11:38:13.335444-06:00

--- a/json.go
+++ b/json.go
@@ -60,32 +60,32 @@ func JsonStringAs[T any](data JSONString) (T, error) {
 	return result, nil
 }
 
-func (s JSONString) Bool() bool {
+func (s JSONString) AsBool() bool {
 	value, _ := JsonStringAs[bool](s)
 	return value
 }
 
-func (s JSONString) Int() int {
+func (s JSONString) AsInt() int {
 	value, _ := JsonStringAs[int](s)
 	return value
 }
 
-func (s JSONString) Float64() float64 {
+func (s JSONString) AsFloat64() float64 {
 	value, _ := JsonStringAs[float64](s)
 	return value
 }
 
-func (s JSONString) String() string {
+func (s JSONString) AsString() string {
 	value, _ := JsonStringAs[string](s)
 	return value
 }
 
-func (s JSONString) Array() []any {
+func (s JSONString) AsArray() []any {
 	value, _ := JsonStringAs[[]any](s)
 	return value
 }
 
-func (s JSONString) Map() map[string]any {
+func (s JSONString) AsMap() map[string]any {
 	value, _ := JsonStringAs[map[string]any](s)
 	return value
 }

--- a/json_test.go
+++ b/json_test.go
@@ -148,13 +148,13 @@ func TestUnmarshalJSONString(t *testing.T) {
 	data4 := []any{"foo", "bar"}
 	data5 := map[string]any{"foo": "bar"}
 	// Act
-	result1 := ol.NewJSONInput(data1).Bool()
-	result1a := ol.NewJSONInput(data1a).Bool()
-	result2 := ol.NewJSONInput(data2).Float64()
-	result2a := ol.NewJSONInput(data2a).Int()
-	result3 := ol.NewJSONInput(data3).String()
-	result4 := ol.NewJSONInput(data4).Array()
-	result5 := ol.NewJSONInput(data5).Map()
+	result1 := ol.NewJSONInput(data1).AsBool()
+	result1a := ol.NewJSONInput(data1a).AsBool()
+	result2 := ol.NewJSONInput(data2).AsFloat64()
+	result2a := ol.NewJSONInput(data2a).AsInt()
+	result3 := ol.NewJSONInput(data3).AsString()
+	result4 := ol.NewJSONInput(data4).AsArray()
+	result5 := ol.NewJSONInput(data5).AsMap()
 	_, err := ol.JsonStringAs[float32](ol.NewJSONInput(data1))
 	// Assert
 	autopilot.Equals(t, data1, result1)

--- a/property_test.go
+++ b/property_test.go
@@ -36,7 +36,7 @@ func TestCreatePropertyDefinition(t *testing.T) {
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, expectedPropertyDefinition, *actualPropertyDefinition)
-	autopilot.Equals(t, ol.JSON(propertyDefinitionInput.Schema.Map()), actualPropertyDefinition.Schema)
+	autopilot.Equals(t, ol.JSON(propertyDefinitionInput.Schema.AsMap()), actualPropertyDefinition.Schema)
 }
 
 func TestDeletePropertyDefinition(t *testing.T) {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Subtle bugfix. We were seeing weird behavior when variables of `JSONString` were passed as arguments to `fmt.Sprinf()`
- Example: `fmt.Sprintf("my example with arg %s", myJsonString)`

`JSONString` is defined as `type JSONString string` and, before this fix, had a member function `func (s JSONString) String() string`.
- This makes `JSONString` implement the [Stringer](https://github.com/golang/go/blob/master/src/fmt/print.go#L63) interface in Go language's `src/fmt/print.go`.
- `JSONString` being a `Stringer` when passed in to `fmt.Sprintf()`, found its way to this call of `v.String()` [src/fmt/print.go](https://github.com/golang/go/blob/master/src/fmt/print.go#L673). 
- This `v.String()` call led to [JSONString.String()](https://github.com/OpsLevel/opslevel-go/blob/main/json.go#L78) where we were unintentionally calling `JsonStringAs[string](<value of JSONString>)`. In this call there's a ` json.Unmarshal()` call that was logging a warning and raising an error that was being ignored.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
