### PR TITLE
Db/add defaults to input structs

### DIFF
--- a/.changes/unreleased/Feature-20231215-070846.yaml
+++ b/.changes/unreleased/Feature-20231215-070846.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add yaml and default struct tags to Input structs
+time: 2023-12-15T07:08:46.1384-08:00

--- a/actions.go
+++ b/actions.go
@@ -87,12 +87,12 @@ type CustomActionsTriggerDefinitionsConnection struct {
 }
 
 type CustomActionsWebhookActionCreateInput struct {
-	Name           string                      `json:"name"`
-	Description    *string                     `json:"description,omitempty"`
-	LiquidTemplate string                      `json:"liquidTemplate"`
-	WebhookURL     string                      `json:"webhookUrl"`
-	HTTPMethod     CustomActionsHttpMethodEnum `json:"httpMethod"`
-	Headers        JSON                        `json:"headers"`
+	Name           string                      `json:"name" yaml:"name" default:"Page The On Call"`
+	Description    *string                     `json:"description,omitempty" yaml:"description,omitempty" default:"Pages The On Call"`
+	LiquidTemplate string                      `json:"liquidTemplate" yaml:"liquidTemplate" default:"{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}"`
+	WebhookURL     string                      `json:"webhookUrl" yaml:"webhookUrl" default:"https://api.pagerduty.com/incidents"`
+	HTTPMethod     CustomActionsHttpMethodEnum `json:"httpMethod" yaml:"httpMethod" default:"POST"`
+	Headers        JSON                        `json:"headers" yaml:"headers" default:"{\"accept\": \"application/vnd.pagerduty+json;version=2\",\"authorization\":\"Token token=XXXXXXXXXXXXX\",\"from\":\"someone@example.com\"}"`
 }
 
 type CustomActionsWebhookActionUpdateInput struct {
@@ -106,21 +106,21 @@ type CustomActionsWebhookActionUpdateInput struct {
 }
 
 type CustomActionsTriggerDefinitionCreateInput struct {
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
-	Owner       ID      `json:"ownerId"`
+	Name        string  `json:"name" yaml:"name" default:"Page The On Call"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty" default:"Pages the On Call"`
+	Owner       ID      `json:"ownerId" yaml:"ownerId" default:"XXX_owner_id_XXX"`
 	// In the API actionID is `ID!` but that's because of the CustomActionsWebhookActionCreateInput
 	// But we are not implementing that because it is used for the UI, so we need to enforce an actionId is given
-	Action ID  `json:"actionId"`
-	Filter *ID `json:"filterId,omitempty"`
+	Action ID  `json:"actionId" yaml:"actionId"`
+	Filter *ID `json:"filterId,omitempty" yaml:"filterId,omitempty"`
 	// This is being explicitly left out to reduce the complexity of the implementation
 	// action *CustomActionsWebhookActionCreateInput
-	ManualInputsDefinition string                                          `json:"manualInputsDefinition"`
-	Published              *bool                                           `json:"published,omitempty"`
-	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `json:"accessControl"`
-	ResponseTemplate       string                                          `json:"responseTemplate"`
-	EntityType             CustomActionsEntityTypeEnum                     `json:"entityType"`
-	ExtendedTeamAccess     *[]IdentifierInput                              `json:"extendedTeamAccess,omitempty"`
+	ManualInputsDefinition string                                          `json:"manualInputsDefinition" yaml:"manualInputsDefinition"`
+	Published              *bool                                           `json:"published,omitempty" yaml:"published,omitempty"`
+	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `json:"accessControl" yaml:"accessControl"`
+	ResponseTemplate       string                                          `json:"responseTemplate" yaml:"responseTemplate"`
+	EntityType             CustomActionsEntityTypeEnum                     `json:"entityType" yaml:"entityType"`
+	ExtendedTeamAccess     *[]IdentifierInput                              `json:"extendedTeamAccess,omitempty" yaml:"extendedTeamAccess,omitempty"`
 }
 
 type CustomActionsTriggerDefinitionUpdateInput struct {
@@ -132,12 +132,12 @@ type CustomActionsTriggerDefinitionUpdateInput struct {
 	Filter      *ID     `json:"filterId,omitempty"`
 	// This is being explicitly left out to reduce the complexity of the implementation
 	// action *CustomActionsWebhookActionCreateInput
-	ManualInputsDefinition *string                                         `json:"manualInputsDefinition,omitempty"`
-	Published              *bool                                           `json:"published,omitempty"`
-	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `json:"accessControl,omitempty"`
-	ResponseTemplate       *string                                         `json:"responseTemplate,omitempty"`
-	EntityType             CustomActionsEntityTypeEnum                     `json:"entityType,omitempty"`
-	ExtendedTeamAccess     *[]IdentifierInput                              `json:"extendedTeamAccess,omitempty"`
+	ManualInputsDefinition *string                                         `json:"manualInputsDefinition,omitempty" yaml:"manualInputsDefinition,omitempty"`
+	Published              *bool                                           `json:"published,omitempty" yaml:"published,omitempty"`
+	AccessControl          CustomActionsTriggerDefinitionAccessControlEnum `json:"accessControl,omitempty" yaml:"accessControl,omitempty" default:"service_owners"`
+	ResponseTemplate       *string                                         `json:"responseTemplate,omitempty" yaml:"responseTemplate,omitempty"`
+	EntityType             CustomActionsEntityTypeEnum                     `json:"entityType,omitempty" yaml:"entityType,omitempty"`
+	ExtendedTeamAccess     *[]IdentifierInput                              `json:"extendedTeamAccess,omitempty" yaml:"extendedTeamAccess,omitempty" default:"[\"alias\":\"team_alias_1\",\"id\":\"XXX_team_id_XXX\"]"`
 }
 
 func (client *Client) CreateWebhookAction(input CustomActionsWebhookActionCreateInput) (*CustomActionsExternalAction, error) {

--- a/actions_test.go
+++ b/actions_test.go
@@ -20,6 +20,7 @@ func TestCreateWebhookAction(t *testing.T) {
 	client := BestTestClient(t, "custom_actions/create_action", testRequest)
 
 	// Act
+	// TODO: does CustomActionsWebhookActionCreateInput.LiquidTemplate work as ol.JSONString?
 	action, err := client.CreateWebhookAction(ol.CustomActionsWebhookActionCreateInput{
 		Name:           "Deploy Rollback",
 		LiquidTemplate: "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}",

--- a/actions_test.go
+++ b/actions_test.go
@@ -20,7 +20,6 @@ func TestCreateWebhookAction(t *testing.T) {
 	client := BestTestClient(t, "custom_actions/create_action", testRequest)
 
 	// Act
-	// TODO: does CustomActionsWebhookActionCreateInput.LiquidTemplate work as ol.JSONString?
 	action, err := client.CreateWebhookAction(ol.CustomActionsWebhookActionCreateInput{
 		Name:           "Deploy Rollback",
 		LiquidTemplate: "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}",

--- a/alert_source.go
+++ b/alert_source.go
@@ -1,8 +1,8 @@
 package opslevel
 
 type AlertSourceExternalIdentifier struct {
-	Type       AlertSourceTypeEnum `json:"type"`
-	ExternalId string              `json:"externalId"`
+	Type       AlertSourceTypeEnum `json:"type" yaml:"type"`
+	ExternalId string              `json:"externalId" yaml:"externalId"`
 }
 
 type AlertSource struct {
@@ -23,9 +23,9 @@ type AlertSourceService struct {
 }
 
 type AlertSourceServiceCreateInput struct {
-	Service    IdentifierInput                `json:"service"`
-	Id         ID                             `json:"alertSourceId,omitempty"`
-	ExternalID *AlertSourceExternalIdentifier `json:"alertSourceExternalIdentifier,omitempty"`
+	Service    IdentifierInput                `json:"service" yaml:"service" default:"{\"alias\":\"sound-the-alarm\"}"`
+	Id         ID                             `json:"alertSourceId,omitempty" yaml:"alertSourceId,omitempty"`
+	ExternalID *AlertSourceExternalIdentifier `json:"alertSourceExternalIdentifier,omitempty" yaml:"alertSourceExternalIdentifier,omitempty"`
 }
 
 type AlertSourceDeleteInput struct {

--- a/category.go
+++ b/category.go
@@ -18,7 +18,7 @@ type CategoryConnection struct {
 }
 
 type CategoryCreateInput struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" default:"Example Category"`
 }
 
 type CategoryUpdateInput struct {

--- a/check.go
+++ b/check.go
@@ -111,14 +111,14 @@ type CheckCreateInputProvider interface {
 }
 
 type CheckCreateInput struct {
-	Name     string        `json:"name"`
-	Enabled  bool          `json:"enabled"`
-	EnableOn *iso8601.Time `json:"enableOn,omitempty"`
-	Category ID            `json:"categoryId"`
-	Level    ID            `json:"levelId"`
-	Owner    *ID           `json:"ownerId,omitempty"`
-	Filter   *ID           `json:"filterId,omitempty"`
-	Notes    string        `json:"notes"`
+	Name     string        `json:"name" yaml:"name" default:"Example Check to create"`
+	Enabled  bool          `json:"enabled" yaml:"enabled" default:"true"`
+	EnableOn *iso8601.Time `json:"enableOn,omitempty" yaml:"enableOn,omitempty"`
+	Category ID            `json:"categoryId" yaml:"categoryId" default:"XXX_category_id_XXX"`
+	Level    ID            `json:"levelId" yaml:"levelId" default:"XXX_rubric_level_id_XXX"`
+	Owner    *ID           `json:"ownerId,omitempty" yaml:"ownerId,omitempty" default:"XXX_owner_id_XXX"`
+	Filter   *ID           `json:"filterId,omitempty" yaml:"filterId,omitempty" default:"XXX_filter_id_XXX"`
+	Notes    string        `json:"notes" yaml:"notes" default:"Notes on Example Check"`
 }
 
 func (c *CheckCreateInput) GetCheckCreateInput() *CheckCreateInput {

--- a/check_custom_event.go
+++ b/check_custom_event.go
@@ -11,11 +11,11 @@ type CustomEventCheckFragment struct {
 type CheckCustomEventCreateInput struct {
 	CheckCreateInput
 
-	Integration      ID     `json:"integrationId"`
-	ServiceSelector  string `json:"serviceSelector"`
-	SuccessCondition string `json:"successCondition"`
-	Message          string `json:"resultMessage,omitempty"`
-	PassPending      *bool  `json:"passPending,omitempty"`
+	Integration      ID     `json:"integrationId" yaml:"integrationId" default:"XXX_integration_id_XXX"`
+	ServiceSelector  string `json:"serviceSelector" yaml:"serviceSelector" default:".metadata.name"`
+	SuccessCondition string `json:"successCondition" yaml:"successCondition" default:".metadata.name"`
+	Message          string `json:"resultMessage,omitempty" yaml:"resultMessage,omitempty" default:"#Hello World"`
+	PassPending      *bool  `json:"passPending,omitempty" yaml:"passPending,omitempty" default:"false"`
 }
 
 type CheckCustomEventUpdateInput struct {

--- a/check_has_documentation.go
+++ b/check_has_documentation.go
@@ -8,8 +8,8 @@ type HasDocumentationCheckFragment struct {
 type CheckHasDocumentationCreateInput struct {
 	CheckCreateInput
 
-	DocumentType    HasDocumentationTypeEnum    `json:"documentType"`
-	DocumentSubtype HasDocumentationSubtypeEnum `json:"documentSubtype"`
+	DocumentType    HasDocumentationTypeEnum    `json:"documentType" yaml:"documentType" default:"api"`
+	DocumentSubtype HasDocumentationSubtypeEnum `json:"documentSubtype" yaml:"documentSubtype" default:"openapi"`
 }
 
 type CheckHasDocumentationUpdateInput struct {

--- a/check_has_recent_deploy.go
+++ b/check_has_recent_deploy.go
@@ -7,7 +7,7 @@ type HasRecentDeployCheckFragment struct {
 type CheckHasRecentDeployCreateInput struct {
 	CheckCreateInput
 
-	Days int `json:"days"`
+	Days int `json:"days" yaml:"days" default:"12"`
 }
 
 type CheckHasRecentDeployUpdateInput struct {

--- a/check_manual.go
+++ b/check_manual.go
@@ -14,9 +14,9 @@ type ManualCheckFrequency struct {
 }
 
 type ManualCheckFrequencyInput struct {
-	StartingDate       iso8601.Time       `json:"startingDate"`
-	FrequencyTimeScale FrequencyTimeScale `json:"frequencyTimeScale"`
-	FrequencyValue     int                `json:"frequencyValue"`
+	StartingDate       iso8601.Time       `json:"startingDate" yaml:"startingDate" default:"2023-11-05T20:22:44.427Z"`
+	FrequencyTimeScale FrequencyTimeScale `json:"frequencyTimeScale" yaml:"frequencyTimeScale" default:"day"`
+	FrequencyValue     int                `json:"frequencyValue" yaml:"frequencyValue" default:"1"`
 }
 
 func NewManualCheckFrequencyInput(startingDate string, timeScale FrequencyTimeScale, value int) *ManualCheckFrequencyInput {
@@ -30,8 +30,8 @@ func NewManualCheckFrequencyInput(startingDate string, timeScale FrequencyTimeSc
 type CheckManualCreateInput struct {
 	CheckCreateInput
 
-	UpdateFrequency       *ManualCheckFrequencyInput `json:"updateFrequency,omitempty"`
-	UpdateRequiresComment bool                       `json:"updateRequiresComment"`
+	UpdateFrequency       *ManualCheckFrequencyInput `json:"updateFrequency,omitempty" yaml:"updateFrequency,omitempty"`
+	UpdateRequiresComment bool                       `json:"updateRequiresComment" yaml:"updateRequiresComment" default:"false"`
 }
 
 type CheckManualUpdateInput struct {

--- a/check_repo_file.go
+++ b/check_repo_file.go
@@ -10,10 +10,10 @@ type RepositoryFileCheckFragment struct {
 type CheckRepositoryFileCreateInput struct {
 	CheckCreateInput
 
-	DirectorySearch       bool            `json:"directorySearch"`
-	Filepaths             []string        `json:"filePaths"`
-	FileContentsPredicate *PredicateInput `json:"fileContentsPredicate,omitempty"`
-	UseAbsoluteRoot       bool            `json:"useAbsoluteRoot"`
+	DirectorySearch       bool            `json:"directorySearch" yaml:"directorySearch" default:"false"`
+	Filepaths             []string        `json:"filePaths" yaml:"filePaths" default:"[\"**/hello.go\", \"src/**\"]"`
+	FileContentsPredicate *PredicateInput `json:"fileContentsPredicate,omitempty" yaml:"fileContentsPredicate,omitempty"`
+	UseAbsoluteRoot       bool            `json:"useAbsoluteRoot" yaml:"useAbsoluteRoot" default:"false"`
 }
 
 type CheckRepositoryFileUpdateInput struct {

--- a/check_repo_grep.go
+++ b/check_repo_grep.go
@@ -9,9 +9,9 @@ type RepositoryGrepCheckFragment struct {
 type CheckRepositoryGrepCreateInput struct {
 	CheckCreateInput
 
-	DirectorySearch       bool            `json:"directorySearch"`
-	Filepaths             []string        `json:"filePaths"`
-	FileContentsPredicate *PredicateInput `json:"fileContentsPredicate,omitempty"`
+	DirectorySearch       bool            `json:"directorySearch" yaml:"directorySearch" default:"false"`
+	Filepaths             []string        `json:"filePaths" yaml:"filePaths" default:"[\"**/hello.go\", \"src/**\"]"`
+	FileContentsPredicate *PredicateInput `json:"fileContentsPredicate,omitempty" yaml:"fileContentsPredicate,omitempty"`
 }
 
 type CheckRepositoryGrepUpdateInput struct {

--- a/check_repo_search.go
+++ b/check_repo_search.go
@@ -8,8 +8,8 @@ type RepositorySearchCheckFragment struct {
 type CheckRepositorySearchCreateInput struct {
 	CheckCreateInput
 
-	FileExtensions        []string       `json:"fileExtensions,omitempty"`
-	FileContentsPredicate PredicateInput `json:"fileContentsPredicate"`
+	FileExtensions        []string       `json:"fileExtensions,omitempty" yaml:"fileExtensions,omitempty" default:"[\"py\",\"js\",\"ts\"]"`
+	FileContentsPredicate PredicateInput `json:"fileContentsPredicate" yaml:"fileContentsPredicate"`
 }
 
 type CheckRepositorySearchUpdateInput struct {

--- a/check_service_property.go
+++ b/check_service_property.go
@@ -8,8 +8,8 @@ type ServicePropertyCheckFragment struct {
 type CheckServicePropertyCreateInput struct {
 	CheckCreateInput
 
-	Property  ServicePropertyTypeEnum `json:"serviceProperty"`
-	Predicate *PredicateInput         `json:"propertyValuePredicate,omitempty"`
+	Property  ServicePropertyTypeEnum `json:"serviceProperty" yaml:"serviceProperty" default:"framework"`
+	Predicate *PredicateInput         `json:"propertyValuePredicate,omitempty" yaml:"propertyValuePredicate,omitempty"`
 }
 
 type CheckServicePropertyUpdateInput struct {

--- a/check_tag_defined.go
+++ b/check_tag_defined.go
@@ -8,8 +8,8 @@ type TagDefinedCheckFragment struct {
 type CheckTagDefinedCreateInput struct {
 	CheckCreateInput
 
-	TagKey       string          `json:"tagKey"`
-	TagPredicate *PredicateInput `json:"tagPredicate,omitempty"`
+	TagKey       string          `json:"tagKey" yaml:"tagKey" default:"app"`
+	TagPredicate *PredicateInput `json:"tagPredicate,omitempty" yaml:"tagPredicate,omitempty" default:"{\"TagKey\":\"equals\", \"Value\":\"postgres\"}"`
 }
 
 type CheckTagDefinedUpdateInput struct {

--- a/check_tool_usage.go
+++ b/check_tool_usage.go
@@ -10,10 +10,10 @@ type ToolUsageCheckFragment struct {
 type CheckToolUsageCreateInput struct {
 	CheckCreateInput
 
-	ToolCategory         ToolCategory    `json:"toolCategory"`
-	ToolNamePredicate    *PredicateInput `json:"toolNamePredicate,omitempty"`
-	ToolUrlPredicate     *PredicateInput `json:"toolUrlPredicate,omitempty"`
-	EnvironmentPredicate *PredicateInput `json:"environmentPredicate,omitempty"`
+	ToolCategory         ToolCategory    `json:"toolCategory" yaml:"toolCategory" default:"backlog"`
+	ToolNamePredicate    *PredicateInput `json:"toolNamePredicate,omitempty" yaml:"toolNamePredicate,omitempty"`
+	ToolUrlPredicate     *PredicateInput `json:"toolUrlPredicate,omitempty" yaml:"toolUrlPredicate,omitempty"`
+	EnvironmentPredicate *PredicateInput `json:"environmentPredicate,omitempty" yaml:"environmentPredicate,omitempty"`
 }
 
 type CheckToolUsageUpdateInput struct {

--- a/dependencies.go
+++ b/dependencies.go
@@ -34,13 +34,13 @@ type ServiceDependentsConnection struct {
 }
 
 type ServiceDependencyKey struct {
-	Service   IdentifierInput `json:"sourceIdentifier"`
-	DependsOn IdentifierInput `json:"destinationIdentifier"`
+	Service   IdentifierInput `json:"sourceIdentifier" yaml:"sourceIdentifier" default:"{\"alias\":\"service-alias\"}"`
+	DependsOn IdentifierInput `json:"destinationIdentifier" yaml:"destinationIdentifier" default:"{\"id\":\"XXX_deponds_on_id_XXX\"}"`
 }
 
 type ServiceDependencyCreateInput struct {
-	Key   ServiceDependencyKey `json:"dependencyKey"`
-	Notes string               `json:"notes,omitempty"`
+	Key   ServiceDependencyKey `json:"dependencyKey" yaml:"dependencyKey"`
+	Notes string               `json:"notes,omitempty" yaml:"notes,omitempty" default:"An example description"`
 }
 
 //#region Create

--- a/filters.go
+++ b/filters.go
@@ -12,8 +12,8 @@ type Predicate struct {
 }
 
 type PredicateInput struct {
-	Type  PredicateTypeEnum `json:"type"`
-	Value string            `json:"value,omitempty"`
+	Type  PredicateTypeEnum `json:"type" yaml:"type" default:"equals"`
+	Value string            `json:"value,omitempty" yaml:"value,omitempty" default:"Requests"`
 }
 
 type PredicateUpdateInput struct {
@@ -34,11 +34,11 @@ type Filter struct {
 }
 
 type FilterPredicate struct {
-	Key           PredicateKeyEnum  `json:"key"`
-	KeyData       string            `json:"keyData,omitempty"`
-	Type          PredicateTypeEnum `json:"type"`
-	Value         string            `json:"value,omitempty"`
-	CaseSensitive *bool             `json:"caseSensitive,omitempty"`
+	Key           PredicateKeyEnum  `json:"key" yaml:"key" default:"repository_ids"`
+	KeyData       string            `json:"keyData,omitempty" yaml:"keyData,omitempty" default:"null"`
+	Type          PredicateTypeEnum `json:"type" yaml:"type" default:"equals"`
+	Value         string            `json:"value,omitempty" yaml:"value,omitempty" default:"1"`
+	CaseSensitive *bool             `json:"caseSensitive,omitempty" yaml:"caseSensitive,omitempty" default:"false"`
 }
 
 type FilterConnection struct {
@@ -48,9 +48,9 @@ type FilterConnection struct {
 }
 
 type FilterCreateInput struct {
-	Name       string            `json:"name"`
-	Predicates []FilterPredicate `json:"predicates"`
-	Connective ConnectiveEnum    `json:"connective,omitempty"`
+	Name       string            `json:"name" yaml:"name" default:"Kubernetes"`
+	Predicates []FilterPredicate `json:"predicates" yaml:"predicates"`
+	Connective ConnectiveEnum    `json:"connective,omitempty" yaml:"connective,omitempty" default:"and"`
 }
 
 type FilterUpdateInput struct {

--- a/infra.go
+++ b/infra.go
@@ -70,8 +70,7 @@ type InfraInput struct {
 	Schema   string              `json:"schema" yaml:"schema" default:"Database"`
 	Owner    *ID                 `json:"owner" yaml:"owner" default:"XXX_owner_id_XXX"`
 	Provider *InfraProviderInput `json:"provider" yaml:"provider"`
-	// TODO: should InfraInput.Data be JSON type?
-	Data map[string]any `json:"data" yaml:"data" default:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"`
+	Data     map[string]any      `json:"data" yaml:"data" default:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"`
 }
 
 func (i *InfrastructureResource) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {

--- a/infra.go
+++ b/infra.go
@@ -42,35 +42,36 @@ type InfrastructureResourceConnection struct {
 }
 
 type InfrastructureResourceSchemaInput struct {
-	Type string `json:"type" yaml:"type"`
+	Type string `json:"type" yaml:"type" default:"Database"`
 }
 
 type InfrastructureResourceProviderInput struct {
-	AccountName  string `json:"accountName" yaml:"accountName"`
-	ExternalURL  string `json:"externalUrl" yaml:"externalUrl"`
-	ProviderName string `json:"providerName" yaml:"providerName"`
+	AccountName  string `json:"accountName" yaml:"accountName" default:"Dev - 123456789"`
+	ExternalURL  string `json:"externalUrl" yaml:"externalUrl" default:"https://google.com"`
+	ProviderName string `json:"providerName" yaml:"providerName" default:"Google"`
 }
 
 type InfrastructureResourceInput struct {
-	Schema       *InfrastructureResourceSchemaInput   `json:"schema,omitempty"`
-	ProviderType *string                              `json:"providerResourceType,omitempty" yaml:"providerResourceType"`
-	ProviderData *InfrastructureResourceProviderInput `json:"providerData,omitempty" yaml:"providerData"`
-	Owner        *ID                                  `json:"ownerId,omitempty" yaml:"owner"`
-	Data         JSON                                 `json:"data,omitempty" yaml:"data" scalar:"true"`
+	Schema       *InfrastructureResourceSchemaInput   `json:"schema,omitempty" yaml:"schema,omitempty"`
+	ProviderType *string                              `json:"providerResourceType,omitempty" yaml:"providerResourceType,omitempty" default:"BigQuery"`
+	ProviderData *InfrastructureResourceProviderInput `json:"providerData,omitempty" yaml:"providerData,omitempty"`
+	Owner        *ID                                  `json:"ownerId,omitempty" yaml:"owner,omitempty"`
+	Data         JSON                                 `json:"data,omitempty" yaml:"data,omitempty" scalar:"true" default:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false,\"storage_size\":{\"value\":1024,\"unit\": \"GB\"}}"`
 }
 
 type InfraProviderInput struct {
-	Account string `json:"account" yaml:"account"`
-	Name    string `json:"name" yaml:"name"`
-	Type    string `json:"type" yaml:"type"`
-	URL     string `json:"url" yaml:"url"`
+	Account string `json:"account" yaml:"account" default:"Dev - 123456789"`
+	Name    string `json:"name" yaml:"name" default:"Google"`
+	Type    string `json:"type" yaml:"type" default:"BigQuery"`
+	URL     string `json:"url" yaml:"url" default:"https://google.com"`
 }
 
 type InfraInput struct {
-	Schema   string              `json:"schema" yaml:"schema"`
-	Owner    *ID                 `json:"owner" yaml:"owner"`
+	Schema   string              `json:"schema" yaml:"schema" default:"Database"`
+	Owner    *ID                 `json:"owner" yaml:"owner" default:"XXX_owner_id_XXX"`
 	Provider *InfraProviderInput `json:"provider" yaml:"provider"`
-	Data     map[string]any      `json:"data" yaml:"data"`
+	// TODO: should InfraInput.Data be JSON type?
+	Data map[string]any `json:"data" yaml:"data" default:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"`
 }
 
 func (i *InfrastructureResource) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {

--- a/job.go
+++ b/job.go
@@ -106,22 +106,22 @@ func (j *RunnerJob) Number() string {
 }
 
 type RunnerAppendJobLogInput struct {
-	RunnerId    ID           `json:"runnerId"`
-	RunnerJobId ID           `json:"runnerJobId"`
-	SentAt      iso8601.Time `json:"sentAt"`
-	Logs        []string     `json:"logChunk"`
+	RunnerId    ID           `json:"runnerId" yaml:"runnerId" default:"46290"`
+	RunnerJobId ID           `json:"runnerJobId" yaml:"runnerJobId" default:"4133720"`
+	SentAt      iso8601.Time `json:"sentAt" yaml:"sentAt" default:"2023-11-05T01:00:00.000Z"`
+	Logs        []string     `json:"logChunk" yaml:"logChunk" default:"[\"LogRoger\",\"LogDodger\"]"`
 }
 
 type RunnerJobOutcomeVariable struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string `json:"key" yaml:"key" default:"job_task"`
+	Value string `json:"value" yaml:"value" default:"job_status"`
 }
 
 type RunnerReportJobOutcomeInput struct {
-	RunnerId         ID                         `json:"runnerId"`
-	RunnerJobId      ID                         `json:"runnerJobId"`
-	Outcome          RunnerJobOutcomeEnum       `json:"outcome"`
-	OutcomeVariables []RunnerJobOutcomeVariable `json:"outcomeVariables,omitempty"`
+	RunnerId         ID                         `json:"runnerId" yaml:"runnerId" default:"42690"`
+	RunnerJobId      ID                         `json:"runnerJobId" yaml:"runnerJobId" default:"4213370"`
+	Outcome          RunnerJobOutcomeEnum       `json:"outcome" yaml:"outcome" default:"pod_timeout"`
+	OutcomeVariables []RunnerJobOutcomeVariable `json:"outcomeVariables,omitempty" yaml:"outcomeVariables,omitempty"`
 }
 
 type RunnerScale struct {

--- a/level.go
+++ b/level.go
@@ -21,9 +21,9 @@ type LevelConnection struct {
 }
 
 type LevelCreateInput struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Index       *int   `json:"index,omitempty"`
+	Name        string `json:"name" yaml:"name" default:"Gold"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty" default:"Go for it"`
+	Index       *int   `json:"index,omitempty" yaml:"index,omitempty" default:"3"`
 }
 
 type LevelUpdateInput struct {

--- a/property.go
+++ b/property.go
@@ -3,8 +3,8 @@ package opslevel
 import "fmt"
 
 type PropertyDefinitionInput struct {
-	Name   string     `json:"name" default:"John Doe"`
-	Schema JSONString `json:"schema,string" default:"{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"Packages\",\"description\":\"A list of packages.\",\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"lock_file\":{\"type\":\"string\"},\"manager\":{\"type\":\"string\"}},\"required\":[\"name\",\"version\"]},\"minItems\":0,\"uniqueItems\":true}"`
+	Name   string     `json:"name" yaml:"name" default:"Example Package Schema"`
+	Schema JSONString `json:"schema,string" yaml:"schema" default:"{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"title\":\"Packages\",\"description\":\"A list of packages.\",\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"lock_file\":{\"type\":\"string\"},\"manager\":{\"type\":\"string\"}},\"required\":[\"name\",\"version\"]},\"minItems\":0,\"uniqueItems\":true}"`
 }
 
 type PropertyDefinition struct {

--- a/repository.go
+++ b/repository.go
@@ -95,10 +95,10 @@ type ServiceRepositoryConnection struct {
 }
 
 type ServiceRepositoryCreateInput struct {
-	Service       IdentifierInput `json:"service"`
-	Repository    IdentifierInput `json:"repository"`
-	BaseDirectory string          `json:"baseDirectory"`
-	DisplayName   string          `json:"displayName,omitempty"`
+	Service       IdentifierInput `json:"service" yaml:"service" default:"{\"alias\":\"service-alias\"}"`
+	Repository    IdentifierInput `json:"repository" yaml:"repository" default:"{\"alias\":\"repository-alias\"}"`
+	BaseDirectory string          `json:"baseDirectory" yaml:"baseDirectory" default:"/"`
+	DisplayName   string          `json:"displayName,omitempty" yaml:"displayName,omitempty" default:"OpsLevel/opslevel-go"`
 }
 
 type ServiceRepositoryUpdateInput struct {

--- a/scalar.go
+++ b/scalar.go
@@ -31,8 +31,8 @@ type Identifier struct {
 }
 
 type IdentifierInput struct {
-	Id    *ID     `graphql:"id" json:"id,omitempty"`
-	Alias *string `graphql:"alias" json:"alias,omitempty"`
+	Id    *ID     `graphql:"id" json:"id,omitempty" yaml:"id,omitempty"`
+	Alias *string `graphql:"alias" json:"alias,omitempty" yaml:"alias,omitempty"`
 }
 
 func NewIdentifier(value string) *IdentifierInput {

--- a/scorecards.go
+++ b/scorecards.go
@@ -29,11 +29,11 @@ type ScorecardConnection struct {
 }
 
 type ScorecardInput struct {
-	AffectsOverallServiceLevels *bool   `graphql:"affectsOverallServiceLevels" json:"affectsOverallServiceLevels,omitempty"`
-	Name                        string  `graphql:"name" json:"name"`
-	Description                 *string `graphql:"description" json:"description,omitempty"`
-	OwnerId                     ID      `graphql:"ownerId" json:"ownerId"`
-	FilterId                    *ID     `graphql:"filterId" json:"filterId,omitempty"`
+	AffectsOverallServiceLevels *bool   `graphql:"affectsOverallServiceLevels" json:"affectsOverallServiceLevels,omitempty" yaml:"affectsOverallServiceLevels,omitempty" default:"false"`
+	Name                        string  `graphql:"name" json:"name" yaml:"name" default:"new scorecard"`
+	Description                 *string `graphql:"description" json:"description,omitempty" yaml:"description,omitempty" default:"a newly created scorecard"`
+	OwnerId                     ID      `graphql:"ownerId" json:"ownerId" yaml:"ownerId" default:"XXX_team_id_XXX"`
+	FilterId                    *ID     `graphql:"filterId" json:"filterId,omitempty" yaml:"filterId,omitempty" default:"XXX_filter_id_XXX"`
 }
 
 func (client *Client) CreateScorecard(input ScorecardInput) (*Scorecard, error) {

--- a/secrets.go
+++ b/secrets.go
@@ -8,8 +8,8 @@ type Secret struct {
 }
 
 type SecretInput struct {
-	Owner IdentifierInput `json:"owner" yaml:"owner"`
-	Value string          `json:"value" yaml:"value"`
+	Owner IdentifierInput `json:"owner" yaml:"owner" default:"{\"alias\":\"devs\"}"`
+	Value string          `json:"value" yaml:"value" default:"my-really-secure-secret-shhhh"`
 }
 
 type SecretsVaultsSecretConnection struct {

--- a/service.go
+++ b/service.go
@@ -50,15 +50,15 @@ type ServiceDocumentsConnection struct {
 }
 
 type ServiceCreateInput struct {
-	Name        string           `json:"name"`
-	Product     string           `json:"product,omitempty"`
-	Description string           `json:"description,omitempty"`
-	Language    string           `json:"language,omitempty"`
-	Framework   string           `json:"framework,omitempty"`
-	Tier        string           `json:"tierAlias,omitempty"`
-	Owner       *IdentifierInput `json:"ownerInput,omitempty"`
-	Lifecycle   string           `json:"lifecycleAlias,omitempty"`
-	Parent      *IdentifierInput `json:"parent,omitempty"`
+	Name        string           `json:"name" yaml:"name" default:"Hello World"`
+	Product     string           `json:"product,omitempty" yaml:"product,omitempty" default:"OSS"`
+	Description string           `json:"description,omitempty" yaml:"description,omitempty" default:"Hello World Service"`
+	Language    string           `json:"language,omitempty" yaml:"language,omitempty" default:"Go"`
+	Framework   string           `json:"framework,omitempty" yaml:"framework,omitempty" default:"fasthttp"`
+	Tier        string           `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" default:"tier_4"`
+	Owner       *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty" default:"{\"alias\":\"Platform\"}"`
+	Lifecycle   string           `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" default:"beta"`
+	Parent      *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty" default:"{\"alias\":\"Engineering\"}"`
 }
 
 type ServiceUpdateInput struct {

--- a/tags.go
+++ b/tags.go
@@ -36,23 +36,23 @@ type TagConnection struct {
 }
 
 type TagInput struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string `json:"key" yaml:"key" default:"environment"`
+	Value string `json:"value" yaml:"value" default:"production"`
 }
 
 type TagAssignInput struct {
-	Id    ID               `json:"id,omitempty"`
-	Alias string           `json:"alias,omitempty"`
-	Type  TaggableResource `json:"type,omitempty"`
-	Tags  []TagInput       `json:"tags"`
+	Id    ID               `json:"id,omitempty" yaml:"id,omitempty"`
+	Alias string           `json:"alias,omitempty" yaml:"alias,omitempty" default:"my-team-alias"`
+	Type  TaggableResource `json:"type,omitempty" yaml:"type,omitempty" default:"Team"`
+	Tags  []TagInput       `json:"tags" yaml:"tags"`
 }
 
 type TagCreateInput struct {
-	Id    ID               `json:"id,omitempty"`
-	Alias string           `json:"alias,omitempty"`
-	Type  TaggableResource `json:"type,omitempty"`
-	Key   string           `json:"key"`
-	Value string           `json:"value"`
+	Id    ID               `json:"id,omitempty" yaml:"id,omitempty"`
+	Alias string           `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Type  TaggableResource `json:"type,omitempty" yaml:"type,omitempty" default:"Repository"`
+	Key   string           `json:"key" yaml:"key" default:"environment"`
+	Value string           `json:"value" yaml:"value" default:"production"`
 }
 
 type TagUpdateInput struct {

--- a/team.go
+++ b/team.go
@@ -14,17 +14,17 @@ type Contact struct {
 }
 
 type ContactInput struct {
-	Type        ContactType `json:"type"`
-	DisplayName *string     `json:"displayName,omitempty"`
-	Address     string      `json:"address"`
+	Type        ContactType `json:"type" yaml:"type" default:"email"`
+	DisplayName *string     `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Address     string      `json:"address" yaml:"address" default:"team@example.com"`
 }
 
 type ContactCreateInput struct {
-	Type        ContactType `json:"type"`
-	DisplayName string      `json:"displayName,omitempty"`
-	Address     string      `json:"address"`
-	TeamId      *ID         `json:"teamId,omitempty"`
-	TeamAlias   string      `json:"teamAlias,omitempty"`
+	Type        ContactType `json:"type" yaml:"type" default:"email"`
+	DisplayName string      `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Address     string      `json:"address" yaml:"address" default:"team@example.com"`
+	TeamId      *ID         `json:"teamId,omitempty" yaml:"teamId,omitempty"`
+	TeamAlias   string      `json:"teamAlias,omitempty" yaml:"teamAlias,omitempty"`
 }
 
 type ContactUpdateInput struct {
@@ -75,11 +75,11 @@ type TeamConnection struct {
 }
 
 type TeamCreateInput struct {
-	Name             string           `json:"name"`
-	ManagerEmail     string           `json:"managerEmail,omitempty"`
-	Responsibilities string           `json:"responsibilities,omitempty"`
-	Contacts         *[]ContactInput  `json:"contacts,omitempty"`
-	ParentTeam       *IdentifierInput `json:"parentTeam"`
+	Name             string           `json:"name" default:"Platform"`
+	ManagerEmail     string           `json:"managerEmail,omitempty" yaml:"managerEmail,omitempty" default:"manager@example.com"`
+	Responsibilities string           `json:"responsibilities,omitempty" yaml:"responsibilities,omitempty" default:"Makes Tools"`
+	Contacts         *[]ContactInput  `json:"contacts,omitempty" yaml:"contacts,omitempty" default:"[{\"Type\":\"slack\",\"DisplayName\":\"Team Eng\",\"Address\":\"#team-engineering\"}]"`
+	ParentTeam       *IdentifierInput `json:"parentTeam" yaml:"parentTeam" default:"{\"alias\":\"Engineering\"}"`
 }
 
 type TeamUpdateInput struct {
@@ -110,16 +110,16 @@ type TeamMembershipConnection struct {
 
 type TeamMembershipUserInput struct {
 	User UserIdentifierInput `json:"user"`
-	Role string              `json:"role"`
+	Role string              `json:"role" default:"admin"`
 }
 
 type TeamMembershipCreateInput struct {
-	TeamId  ID                        `json:"teamId"`
+	TeamId  ID                        `json:"teamId" yaml:"teamId" default:"XXX_team_id_XXX"`
 	Members []TeamMembershipUserInput `json:"members"`
 }
 
 type TeamMembershipDeleteInput struct {
-	TeamId  ID                        `json:"teamId"`
+	TeamId  ID                        `json:"teamId" yaml:"teamId" default:"XXX_team_id_XXX"`
 	Members []TeamMembershipUserInput `json:"members"`
 }
 

--- a/team.go
+++ b/team.go
@@ -75,7 +75,7 @@ type TeamConnection struct {
 }
 
 type TeamCreateInput struct {
-	Name             string           `json:"name" default:"Platform"`
+	Name             string           `json:"name" yaml:"name" default:"Platform"`
 	ManagerEmail     string           `json:"managerEmail,omitempty" yaml:"managerEmail,omitempty" default:"manager@example.com"`
 	Responsibilities string           `json:"responsibilities,omitempty" yaml:"responsibilities,omitempty" default:"Makes Tools"`
 	Contacts         *[]ContactInput  `json:"contacts,omitempty" yaml:"contacts,omitempty" default:"[{\"Type\":\"slack\",\"DisplayName\":\"Team Eng\",\"Address\":\"#team-engineering\"}]"`
@@ -109,8 +109,8 @@ type TeamMembershipConnection struct {
 }
 
 type TeamMembershipUserInput struct {
-	User UserIdentifierInput `json:"user"`
-	Role string              `json:"role" default:"admin"`
+	User UserIdentifierInput `json:"user" yaml:"user"`
+	Role string              `json:"role" yaml:"role" default:"admin"`
 }
 
 type TeamMembershipCreateInput struct {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `yaml:""` and `default:""` struct tags to `type *Input struct`s.
One use for these is to automate documentation updates in the cli. The cli can call `opslevel example <resource>` and to print out usable examples to customers. This can also be piped into the doc examples for each `opslevel create <resource>` command.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
