### PR TITLE
Assign Properties on a Service

### DIFF
--- a/.changes/unreleased/Feature-20231219-150011.yaml
+++ b/.changes/unreleased/Feature-20231219-150011.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for assigning Properties to Services
+time: 2023-12-19T15:00:11.68729-05:00

--- a/.changes/unreleased/Feature-20231221-152309.yaml
+++ b/.changes/unreleased/Feature-20231221-152309.yaml
@@ -1,3 +1,3 @@
 kind: Feature
 body: Add support for assigning Properties to Services
-time: 2023-12-19T15:00:11.68729-05:00
+time: 2023-12-21T15:23:09.021892-05:00

--- a/owner.go
+++ b/owner.go
@@ -23,3 +23,15 @@ func (s *EntityOwnerTeam) AsTeam() TeamId {
 		Id:    s.Id,
 	}
 }
+
+type EntityOwnerService struct {
+	OnService ServiceId `graphql:"... on Service"`
+}
+
+func (s *EntityOwnerService) Aliases() []string {
+	return s.OnService.Aliases
+}
+
+func (s *EntityOwnerService) Id() ID {
+	return s.OnService.Id
+}

--- a/property.go
+++ b/property.go
@@ -45,13 +45,8 @@ type Property struct {
 	Value            JSONString           `graphql:"value"`
 }
 
-type ServicePropertiesEdge struct {
-	Cursor string    `graphql:"cursor"`
-	Node   *Property `graphql:"node"`
-}
-
 type ServicePropertiesConnection struct {
-	Edges      []ServicePropertiesEdge
+	Nodes      []Property
 	PageInfo   PageInfo
 	TotalCount int `graphql:"-"`
 }
@@ -206,7 +201,7 @@ func (service *Service) GetProperties(client *Client, variables *PayloadVariable
 	if service.Properties == nil {
 		service.Properties = &ServicePropertiesConnection{}
 	}
-	service.Properties.Edges = append(service.Properties.Edges, q.Account.Service.Properties.Edges...)
+	service.Properties.Nodes = append(service.Properties.Nodes, q.Account.Service.Properties.Nodes...)
 	service.Properties.PageInfo = q.Account.Service.Properties.PageInfo
 	for service.Properties.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Properties.PageInfo.End

--- a/property.go
+++ b/property.go
@@ -151,7 +151,7 @@ func (client *Client) GetProperty(owner string, definition string) (*Property, e
 	}
 	err := client.Query(&q, v, WithName("PropertyGet"))
 	if q.Account.Property.Definition.Id == "" {
-		err = fmt.Errorf("Property with ID or alias matching '%s' on Service with ID or alias matching '%s' not found", owner, definition)
+		err = fmt.Errorf("Property with ID or alias matching '%s' on Service with ID or alias matching '%s' not found", definition, owner)
 	}
 	return &q.Account.Property, HandleErrors(err, nil)
 }

--- a/property.go
+++ b/property.go
@@ -145,9 +145,6 @@ func (client *Client) GetProperty(owner string, definition string) (*Property, e
 		"definition": *NewIdentifier(definition),
 	}
 	err := client.Query(&q, v, WithName("PropertyGet"))
-	if q.Account.Property.Definition.Id == "" {
-		err = fmt.Errorf("Property with ID or alias matching '%s' on Service with ID or alias matching '%s' not found", definition, owner)
-	}
 	return &q.Account.Property, HandleErrors(err, nil)
 }
 

--- a/property.go
+++ b/property.go
@@ -32,10 +32,10 @@ type PropertyDefinitionId struct {
 }
 
 type PropertyInput struct {
-	Owner         IdentifierInput `json:"owner"`
-	Definition    IdentifierInput `json:"definition"`
-	Value         JSONString      `json:"value"`
-	RunValidation *bool           `json:"runValidation,omitempty"`
+	Owner         IdentifierInput `json:"owner" yaml:"owner" default:"{\"id\":\"XXX_SERVICE_ID_XXX\"}"`
+	Definition    IdentifierInput `json:"definition" yaml:"definition" default:"{\"alias\":\"prop_def_alias\"}"`
+	Value         JSONString      `json:"value" yaml:"value" default:"[\"any\",\"valid\",\"JSON\",1.23,{\"nested\":true}]"`
+	RunValidation *bool           `json:"runValidation,omitempty" yaml:"runValidation,omitempty" default:"true"`
 }
 
 type Property struct {

--- a/property.go
+++ b/property.go
@@ -205,10 +205,11 @@ func (service *Service) GetProperties(client *Client, variables *PayloadVariable
 	service.Properties.PageInfo = q.Account.Service.Properties.PageInfo
 	for service.Properties.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Properties.PageInfo.End
-		_, err := service.GetProperties(client, variables)
+		resp, err := service.GetProperties(client, variables)
 		if err != nil {
 			return nil, err
 		}
+		service.Properties.TotalCount += resp.TotalCount
 	}
 	return service.Properties, nil
 }

--- a/property.go
+++ b/property.go
@@ -40,7 +40,7 @@ type PropertyInput struct {
 
 type Property struct {
 	Definition       PropertyDefinitionId `graphql:"definition"`
-	Owner            ServiceId            `graphql:"owner"`
+	Owner            EntityOwnerService   `graphql:"owner"`
 	ValidationErrors []OpsLevelErrors     `graphql:"validationErrors"`
 	Value            JSONString           `graphql:"value"`
 }

--- a/property.go
+++ b/property.go
@@ -26,6 +26,11 @@ type PropertyDefinitionConnection struct {
 	TotalCount int `graphql:"-"`
 }
 
+type PropertyDefinitionId struct {
+	Id      ID       `json:"id"`
+	Aliases []string `json:"aliases,omitempty"`
+}
+
 type PropertyInput struct {
 	Owner         IdentifierInput `json:"owner"`
 	Definition    IdentifierInput `json:"definition"`
@@ -33,13 +38,11 @@ type PropertyInput struct {
 	RunValidation *bool           `json:"runValidation,omitempty"`
 }
 
-// Treating Definition (PropertyDefinition) as an IdentifierInput
-// Treating Owner (... on Service) as an IdentifierInput
 type Property struct {
-	Definition       IdentifierInput  `graphql:"definition"`
-	Owner            IdentifierInput  `graphql:"owner"`
-	ValidationErrors []OpsLevelErrors `graphql:"validationErrors"`
-	Value            JSONString       `graphql:"value"`
+	Definition       PropertyDefinitionId `graphql:"definition"`
+	Owner            ServiceId            `graphql:"owner"`
+	ValidationErrors []OpsLevelErrors     `graphql:"validationErrors"`
+	Value            JSONString           `graphql:"value"`
 }
 
 type ServicePropertiesEdge struct {
@@ -147,7 +150,7 @@ func (client *Client) GetProperty(owner string, definition string) (*Property, e
 		"definition": *NewIdentifier(definition),
 	}
 	err := client.Query(&q, v, WithName("PropertyGet"))
-	if q.Account.Property.Definition.Id == nil {
+	if q.Account.Property.Definition.Id == "" {
 		err = fmt.Errorf("Property with ID or alias matching '%s' on Service with ID or alias matching '%s' not found", owner, definition)
 	}
 	return &q.Account.Property, HandleErrors(err, nil)

--- a/property.go
+++ b/property.go
@@ -42,7 +42,7 @@ type Property struct {
 	Definition       PropertyDefinitionId `graphql:"definition"`
 	Owner            EntityOwnerService   `graphql:"owner"`
 	ValidationErrors []OpsLevelErrors     `graphql:"validationErrors"`
-	Value            JSONString           `graphql:"value"`
+	Value            *JSONString          `graphql:"value"`
 }
 
 type ServicePropertiesConnection struct {

--- a/property_test.go
+++ b/property_test.go
@@ -168,3 +168,48 @@ func TestListPropertyDefinitions(t *testing.T) {
 	autopilot.Equals(t, expectedPropDefsPageOne[1].Schema, result[1].Schema)
 	autopilot.Equals(t, expectedPropDefPageTwo.Schema, result[2].Schema)
 }
+
+func TestAssignProperty(t *testing.T) {
+	// Arrange
+	schema := ol.NewJSON(schemaString)
+	expectedPropertyDefinition := autopilot.Register[ol.PropertyDefinition]("expected_property_definition", ol.PropertyDefinition{
+		Aliases: []string{"my_prop"},
+		Id:      "XXX",
+		Name:    "my-prop",
+		Schema:  schema,
+	})
+	propertyDefinitionInput := autopilot.Register[ol.PropertyDefinitionInput]("property_definition_input", ol.PropertyDefinitionInput{
+		Name:   "my-prop",
+		Schema: ol.JSONString(schemaString),
+	})
+	testRequest := autopilot.NewTestRequest(
+		`mutation PropertyDefinitionCreate($input:PropertyDefinitionInput!){propertyDefinitionCreate(input: $input){definition{aliases,id,name,schema},errors{message,path}}}`,
+		`{"input": {{ template "property_definition_input" }} }`,
+		fmt.Sprintf(`{"data":{"propertyDefinitionCreate":{"definition": {"aliases":["my_prop"],"id":"XXX","name":"my-prop","schema": %s}, "errors":[] }}}`, schema.ToJSON()),
+	)
+	client := BestTestClient(t, "properties/definition_create", testRequest)
+
+	// Act
+	actualPropertyDefinition, err := client.CreatePropertyDefinition(propertyDefinitionInput)
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, expectedPropertyDefinition, *actualPropertyDefinition)
+	autopilot.Equals(t, ol.JSON(propertyDefinitionInput.Schema.AsMap()), actualPropertyDefinition.Schema)
+}
+
+func TestUnassignProperty(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation PropertyDefinitionDelete($input:IdentifierInput!){propertyDefinitionDelete(resource: $input){errors{message,path}}}`,
+		`{"input":{"alias":"my_prop"}}`,
+		`{"data":{"propertyDefinitionDelete":{"errors":[]}}}`,
+	)
+	client := BestTestClient(t, "properties/definition_delete", testRequest)
+
+	// Act
+	err := client.DeletePropertyDefinition("my_prop")
+
+	// Assert
+	autopilot.Ok(t, err)
+}

--- a/property_test.go
+++ b/property_test.go
@@ -213,3 +213,19 @@ func TestAssignProperty(t *testing.T) {
 	autopilot.Equals(t, 0, len(property.ValidationErrors))
 	autopilot.Equals(t, "true", string(property.Value))
 }
+
+func TestUnassignProperty(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation PropertyUnassign($definition:IdentifierInput!$owner:IdentifierInput!){propertyUnassign(owner: $owner, definition: $definition){errors{message,path}}}`,
+		`{"owner":{"alias":"monolith"},"definition":{"alias":"is_beta_feature"}}`,
+		`{"data":{"propertyUnassign":{"errors":[]}}}`,
+	)
+	client := BestTestClient(t, "properties/property_unassign", testRequest)
+
+	// Act
+	err := client.PropertyUnassign("monolith", "is_beta_feature")
+
+	// Assert
+	autopilot.Ok(t, err)
+}

--- a/property_test.go
+++ b/property_test.go
@@ -259,7 +259,6 @@ func TestGetServiceProperties(t *testing.T) {
 			Value:            ol.JSONString("\"Hello World!\""),
 		},
 	})
-	// log.Debug().Msg(`{"data":{"account":{"service":{"properties":{"edges":[{{ template "service_property_edge_1" }}],{{ template "pagination_initial_pageInfo_response" }}}}}}`))
 	testRequestOne := autopilot.NewTestRequest(
 		`query ServicePropertiesList($after:String!$first:Int!$service:ID!){account{service(id: $service){properties(after: $after, first: $first){edges{cursor,node{definition{id,alias},owner{id,alias},validationErrors{message,path},value}},{{ template "pagination_request" }}}}}}`,
 		`{ {{ template "first_page_variables" }}, "service": "{{ template "id1_string" }}" }`,
@@ -268,7 +267,7 @@ func TestGetServiceProperties(t *testing.T) {
 	testRequestTwo := autopilot.NewTestRequest(
 		`query ServicePropertiesList($after:String!$first:Int!$service:ID!){account{service(id: $service){properties(after: $after, first: $first){edges{cursor,node{definition{id,alias},owner{id,alias},validationErrors{message,path},value}},{{ template "pagination_request" }}}}}}`,
 		`{ {{ template "second_page_variables" }}, "service": "{{ template "id1_string" }}" }`,
-		`{"data":{"account":{"service":{"properties":{"edges":[{{ template "service_property_edge_3" }}],{{ template "pagination_initial_pageInfo_response" }}}}}}}`,
+		`{"data":{"account":{"service":{"properties":{"edges":[{{ template "service_property_edge_3" }}],{{ template "pagination_second_pageInfo_response" }}}}}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
 	client := BestTestClient(t, "service/get_properties", requests...)
@@ -280,8 +279,7 @@ func TestGetServiceProperties(t *testing.T) {
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, 3, len(result))
-	autopilot.Equals(t, expectedPropsPageOne[0].Definition.Alias, result[0].Node.Definition.Alias)
-	autopilot.Equals(t, expectedPropsPageOne[1].Definition.Alias, result[1].Node.Definition.Alias)
-	autopilot.Equals(t, expectedPropsPageTwo[0].Definition.Alias, result[2].Node.Definition.Alias)
-	// TODO: expectations here.
+	autopilot.Equals(t, expectedPropsPageOne[0].Value, result[0].Node.Value)
+	autopilot.Equals(t, expectedPropsPageOne[1].Value, result[1].Node.Value)
+	autopilot.Equals(t, expectedPropsPageTwo[0].Value, result[2].Node.Value)
 }

--- a/property_test.go
+++ b/property_test.go
@@ -186,7 +186,7 @@ func TestGetProperty(t *testing.T) {
 	autopilot.Equals(t, string(id1), string(property.Owner.Id()))
 	autopilot.Equals(t, string(id2), string(property.Definition.Id))
 	autopilot.Equals(t, 0, len(property.ValidationErrors))
-	autopilot.Equals(t, "true", string(property.Value))
+	autopilot.Equals(t, "true", string(*property.Value))
 }
 
 func TestAssignProperty(t *testing.T) {
@@ -211,7 +211,7 @@ func TestAssignProperty(t *testing.T) {
 	autopilot.Equals(t, string(id1), string(property.Owner.Id()))
 	autopilot.Equals(t, string(id2), string(property.Definition.Id))
 	autopilot.Equals(t, 0, len(property.ValidationErrors))
-	autopilot.Equals(t, "true", string(property.Value))
+	autopilot.Equals(t, "true", string(*property.Value))
 }
 
 func TestUnassignProperty(t *testing.T) {
@@ -241,6 +241,9 @@ func TestGetServiceProperties(t *testing.T) {
 	owner := ol.EntityOwnerService{
 		OnService: serviceId,
 	}
+	value1 := ol.JSONString("true")
+	value2 := ol.JSONString("false")
+	value3 := ol.JSONString("\"Hello World!\"")
 	expectedPropsPageOne := autopilot.Register[[]ol.Property]("service_properties", []ol.Property{
 		{
 			Definition: ol.PropertyDefinitionId{
@@ -248,7 +251,7 @@ func TestGetServiceProperties(t *testing.T) {
 			},
 			Owner:            owner,
 			ValidationErrors: []ol.OpsLevelErrors{},
-			Value:            ol.JSONString("true"),
+			Value:            &value1,
 		},
 		{
 			Definition: ol.PropertyDefinitionId{
@@ -256,7 +259,7 @@ func TestGetServiceProperties(t *testing.T) {
 			},
 			Owner:            owner,
 			ValidationErrors: []ol.OpsLevelErrors{},
-			Value:            ol.JSONString("false"),
+			Value:            &value2,
 		},
 	})
 	expectedPropsPageTwo := autopilot.Register[[]ol.Property]("service_properties_3", []ol.Property{
@@ -266,7 +269,7 @@ func TestGetServiceProperties(t *testing.T) {
 			},
 			Owner:            owner,
 			ValidationErrors: []ol.OpsLevelErrors{},
-			Value:            ol.JSONString("\"Hello World!\""),
+			Value:            &value3,
 		},
 	})
 	testRequestOne := autopilot.NewTestRequest(

--- a/property_test.go
+++ b/property_test.go
@@ -267,29 +267,29 @@ func TestGetServiceProperties(t *testing.T) {
 		},
 	})
 	testRequestOne := autopilot.NewTestRequest(
-		`query ServicePropertiesList($after:String!$first:Int!$service:ID!){account{service(id: $service){properties(after: $after, first: $first){edges{cursor,node{definition{id,aliases},owner{id,aliases},validationErrors{message,path},value}},{{ template "pagination_request" }}}}}}`,
+		`query ServicePropertiesList($after:String!$first:Int!$service:ID!){account{service(id: $service){properties(after: $after, first: $first){nodes{definition{id,aliases},owner{id,aliases},validationErrors{message,path},value},{{ template "pagination_request" }}}}}}`,
 		`{ {{ template "first_page_variables" }}, "service": "{{ template "id1_string" }}" }`,
-		`{"data":{"account":{"service":{"properties":{"edges":[{{ template "service_property_edge_1" }}],{{ template "pagination_initial_pageInfo_response" }}}}}}}`,
+		`{"data":{"account":{"service":{"properties":{"nodes":[{{ template "service_properties_page_1" }}],{{ template "pagination_initial_pageInfo_response" }}}}}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query ServicePropertiesList($after:String!$first:Int!$service:ID!){account{service(id: $service){properties(after: $after, first: $first){edges{cursor,node{definition{id,aliases},owner{id,aliases},validationErrors{message,path},value}},{{ template "pagination_request" }}}}}}`,
+		`query ServicePropertiesList($after:String!$first:Int!$service:ID!){account{service(id: $service){properties(after: $after, first: $first){nodes{definition{id,aliases},owner{id,aliases},validationErrors{message,path},value},{{ template "pagination_request" }}}}}}`,
 		`{ {{ template "second_page_variables" }}, "service": "{{ template "id1_string" }}" }`,
-		`{"data":{"account":{"service":{"properties":{"edges":[{{ template "service_property_edge_3" }}],{{ template "pagination_second_pageInfo_response" }}}}}}}`,
+		`{"data":{"account":{"service":{"properties":{"nodes":[{{ template "service_properties_page_2" }}],{{ template "pagination_second_pageInfo_response" }}}}}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
 	client := BestTestClient(t, "service/get_properties", requests...)
 
 	// Act
 	properties, err := service.GetProperties(client, nil)
-	result := properties.Edges
+	result := properties.Nodes
 
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, 3, len(result))
-	autopilot.Equals(t, expectedPropsPageOne[0], *result[0].Node)
-	autopilot.Equals(t, expectedPropsPageOne[1], *result[1].Node)
-	autopilot.Equals(t, expectedPropsPageTwo[0], *result[2].Node)
-	autopilot.Equals(t, expectedPropsPageOne[0].Value, result[0].Node.Value)
-	autopilot.Equals(t, expectedPropsPageOne[1].Value, result[1].Node.Value)
-	autopilot.Equals(t, expectedPropsPageTwo[0].Value, result[2].Node.Value)
+	autopilot.Equals(t, expectedPropsPageOne[0], result[0])
+	autopilot.Equals(t, expectedPropsPageOne[1], result[1])
+	autopilot.Equals(t, expectedPropsPageTwo[0], result[2])
+	autopilot.Equals(t, expectedPropsPageOne[0].Value, result[0].Value)
+	autopilot.Equals(t, expectedPropsPageOne[1].Value, result[1].Value)
+	autopilot.Equals(t, expectedPropsPageTwo[0].Value, result[2].Value)
 }

--- a/property_test.go
+++ b/property_test.go
@@ -223,7 +223,7 @@ func TestGetPropertyHasNullValue(t *testing.T) {
 	testRequest := autopilot.NewTestRequest(
 		`query PropertyGet($definition:IdentifierInput!$owner:IdentifierInput!){account{property(owner: $owner, definition: $definition){definition{id,aliases},owner{... on Service{id,aliases}},validationErrors{message,path},value}}}`,
 		`{"owner":{"alias":"monolith"},"definition":{"alias":"is_beta_feature"}}`,
-		`{"data":{"account":{"property":{"definition":{"id":"{{ template "id2_string" }}"},"owner":{"id":"{{ template "id1_string" }}"},"validationErrors":[],"value":"null"}}}}`,
+		`{"data":{"account":{"property":{"definition":{"id":"{{ template "id2_string" }}"},"owner":{"id":"{{ template "id1_string" }}"},"validationErrors":[],"value":null}}}}`,
 	)
 	client := BestTestClient(t, "properties/property_get_has_null_value", testRequest)
 
@@ -235,7 +235,7 @@ func TestGetPropertyHasNullValue(t *testing.T) {
 	autopilot.Equals(t, string(id1), string(property.Owner.Id()))
 	autopilot.Equals(t, string(id2), string(property.Definition.Id))
 	autopilot.Equals(t, 0, len(property.ValidationErrors))
-	autopilot.Equals(t, "null", string(*property.Value))
+	autopilot.Equals(t, true, property.Value == nil)
 }
 
 func TestAssignProperty(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -35,6 +35,8 @@ type Service struct {
 
 	Dependencies *ServiceDependenciesConnection `graphql:"-"`
 	Dependents   *ServiceDependentsConnection   `graphql:"-"`
+
+	Properties *ServicePropertiesConnection `graphql:"-"`
 }
 
 type ServiceConnection struct {

--- a/testdata/templates/properties.tpl
+++ b/testdata/templates/properties.tpl
@@ -1,0 +1,1 @@
+{{- define "property_assign_input" }}{"owner":{"alias":"monolith"},"definition":{"alias":"is_beta_feature"},"value":"true"}{{ end }}

--- a/testdata/templates/properties.tpl
+++ b/testdata/templates/properties.tpl
@@ -1,46 +1,37 @@
 {{- define "property_assign_input" }}{"owner":{"id":"{{ template "id1_string" }}"},"definition":{"id":"{{ template "id2_string" }}"},"value":"true"}{{ end }}
 
-{{- define "service_property_edge_1" }}
+{{- define "service_properties_page_1" }}
 {
-    "cursor": "",
-    "node": {
-        "definition": {
-            "id": "{{ template "id2_string" }}"
-        },
-        "owner": {
-            "id": "{{ template "id1_string" }}"
-        },
-        "validationErrors": [],
-        "value": "true"
-    }
+    "definition": {
+        "id": "{{ template "id2_string" }}"
+    },
+    "owner": {
+        "id": "{{ template "id1_string" }}"
+    },
+    "validationErrors": [],
+    "value": "true"
 },
 {
-    "cursor": "",
-    "node": {
-        "definition": {
-            "id": "{{ template "id3_string" }}"
-        },
-        "owner": {
-            "id": "{{ template "id1_string" }}"
-        },
-        "validationErrors": [],
-        "value": "false"
-    }
+    "definition": {
+        "id": "{{ template "id3_string" }}"
+    },
+    "owner": {
+        "id": "{{ template "id1_string" }}"
+    },
+    "validationErrors": [],
+    "value": "false"
 }
 {{ end }}
 
-{{- define "service_property_edge_3" }}
+{{- define "service_properties_page_2" }}
 {
-    "cursor": "",
-    "node": {
-        "definition": {
-            "id": "{{ template "id4_string" }}"
-        },
-        "owner": {
-            "id": "{{ template "id1_string" }}"
-        },
-        "validationErrors": [],
-        "value": "\"Hello World!\""
-    }
+    "definition": {
+        "id": "{{ template "id4_string" }}"
+    },
+    "owner": {
+        "id": "{{ template "id1_string" }}"
+    },
+    "validationErrors": [],
+    "value": "\"Hello World!\""
 }
 {{ end }}

--- a/testdata/templates/properties.tpl
+++ b/testdata/templates/properties.tpl
@@ -1,1 +1,46 @@
 {{- define "property_assign_input" }}{"owner":{"alias":"monolith"},"definition":{"alias":"is_beta_feature"},"value":"true"}{{ end }}
+
+{{- define "service_property_edge_1" }}
+{
+    "cursor": "",
+    "node": {
+        "definition": {
+            "alias": "propdef1"
+        },
+        "owner": {
+            "id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+        },
+        "validationErrors": [],
+        "value": "true"
+    }
+},
+{
+    "cursor": "",
+    "node": {
+        "definition": {
+            "alias": "propdef2"
+        },
+        "owner": {
+            "id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+        },
+        "validationErrors": [],
+        "value": "false"
+    }
+}
+{{ end }}
+
+{{- define "service_property_edge_3" }}
+{
+    "cursor": "",
+    "node": {
+        "definition": {
+            "alias": "propdef3"
+        },
+        "owner": {
+            "id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+        },
+        "validationErrors": [],
+        "value": "\"Hello World!\""
+    }
+}
+{{ end }}

--- a/testdata/templates/properties.tpl
+++ b/testdata/templates/properties.tpl
@@ -1,14 +1,14 @@
-{{- define "property_assign_input" }}{"owner":{"alias":"monolith"},"definition":{"alias":"is_beta_feature"},"value":"true"}{{ end }}
+{{- define "property_assign_input" }}{"owner":{"id":"{{ template "id1_string" }}"},"definition":{"id":"{{ template "id2_string" }}"},"value":"true"}{{ end }}
 
 {{- define "service_property_edge_1" }}
 {
     "cursor": "",
     "node": {
         "definition": {
-            "alias": "propdef1"
+            "id": "{{ template "id2_string" }}"
         },
         "owner": {
-            "id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+            "id": "{{ template "id1_string" }}"
         },
         "validationErrors": [],
         "value": "true"
@@ -18,10 +18,10 @@
     "cursor": "",
     "node": {
         "definition": {
-            "alias": "propdef2"
+            "id": "{{ template "id3_string" }}"
         },
         "owner": {
-            "id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+            "id": "{{ template "id1_string" }}"
         },
         "validationErrors": [],
         "value": "false"
@@ -34,10 +34,10 @@
     "cursor": "",
     "node": {
         "definition": {
-            "alias": "propdef3"
+            "id": "{{ template "id4_string" }}"
         },
         "owner": {
-            "id": "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx"
+            "id": "{{ template "id1_string" }}"
         },
         "validationErrors": [],
         "value": "\"Hello World!\""


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/123

## Changelog

- [x] Allow getting a property with `owner` and `definition`
- [x] Assign a property
- [x] Unassign a property
- [x] On a service, be able to do the `Service.properties` query like in graphql.
- [x] NEW - Handle case where `Property.Value` can be null (possible according to schema)
- [x] Make a `changie` entry

## Tophatting

Unit tests should pass/tested in graphiql.
