### PR TITLE
use changie action in changie-gen workflow

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -34,8 +34,10 @@ jobs:
 
     - name: Create changie log
       if: steps.changelog_check.outputs.exists == 'false'
-      shell: bash
-      run: changie new --kind Feature --body "${{ github.event.workflow_run.display_title }}"
+      uses: miniscruff/changie-action@v2
+      with:
+        version: latest
+        args: new --kind Feature --body "${{ github.event.workflow_run.display_title }}"
 
     - name: Commit & Push changes
       if: steps.changelog_check.outputs.exists == 'false'


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Use changie github action. This was failing since `changie` itself was never installed.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A changie CI

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
