### PR TITLE
add workflow completed check to changie gen workflow

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -12,14 +12,17 @@ jobs:
       MAIN_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
       PR_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
     runs-on: ubuntu-latest
+    # NOTE: "github.event.workflow_run.conclusion" check needed within "steps"
     steps:
     - name: Checkout branch that Dependabot labeled
+      if: github.event.workflow_run.conclusion == 'success'
       uses: actions/checkout@v4
       with:
         ref: ${{ env.PR_BRANCH }}
         token: ${{ secrets.ORG_GITHUB_TOKEN }}
 
     - name: Check if changelog file exists already
+      if: github.event.workflow_run.conclusion == 'success'
       shell: bash
       id: changelog_check
       run: |
@@ -33,14 +36,18 @@ jobs:
         fi
 
     - name: Create changie log
-      if: steps.changelog_check.outputs.exists == 'false'
+      if: >-
+        github.event.workflow_run.conclusion == 'success' &&
+        steps.changelog_check.outputs.exists == 'false'
       uses: miniscruff/changie-action@v2
       with:
         version: latest
         args: new --kind Feature --body "${{ github.event.workflow_run.display_title }}"
 
     - name: Commit & Push changes
-      if: steps.changelog_check.outputs.exists == 'false'
+      if: >-
+        github.event.workflow_run.conclusion == 'success' &&
+        steps.changelog_check.outputs.exists == 'false'
       shell: bash
       run: |
         git config user.name "OpsLevel Bots"


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `if: github.event.workflow_run.conclusion == 'success'` to job steps to check to make sure this job doesn't run when the triggering workflow is skipped.
NOTE: this check must be done at each step and not at the "job" level since the `success` state has likely not been realized yet. This was the case in an earlier case.

- [x] List your changes here
- [ ] Make a `changie` entry, N/A CI

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
