### PR TITLE
add task ci, effort to standardize taskfile usage in CI across repos

### DIFF
--- a/.changes/unreleased/Feature-20231222-133813.yaml
+++ b/.changes/unreleased/Feature-20231222-133813.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add task ci, standardizing task usage in our CI
+time: 2023-12-22T13:38:13.396697-06:00

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,16 +18,14 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
       - name: Install Task
         uses: arduino/setup-task@v1
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Lint code
-        run: |-
-          task setup
-          task lint
+      - name: Run quality checks and tests
+        run: task ci
       - name: Test code
         run: task test
       - name: Upload Coverage

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,13 @@
 version: '3'
 
 tasks:
+  ci:
+    desc: Workflow to run in CI
+    deps: [setup]
+    cmds:
+      - task: lint
+      - task: test
+
   generate:
     desc: Generate code based on public GraphQL Interface
     aliases: [gen]
@@ -12,15 +19,13 @@ tasks:
 
   lint:
     desc: Formatting and linting
-    deps: [install-gofumpt]
     cmds:
       - test -z "$(gofumpt -d -e . | tee /dev/stderr)"
       - go vet ./...
       - golangci-lint run
 
-  lintfix:
+  fix:
     desc: Fix formatting and linting
-    deps: [install-gofumpt]
     cmds:
       - gofumpt -w .
       - go mod tidy
@@ -29,8 +34,10 @@ tasks:
   setup:
     desc: Setup linter, formatter, etc. for local testing and CI
     cmds:
-      - task: install-gofumpt
-      - task: install-golangci-lint
+      - task: install-go-tool
+        vars: { GO_TOOL: "gofumpt", GO_TOOL_PATH: "mvdan.cc/gofumpt@latest" }
+      - task: install-go-tool
+        vars: { GO_TOOL: "golangci-lint", GO_TOOL_PATH: "github.com/golangci/golangci-lint/cmd/golangci-lint@latest" }
 
   test:
     desc: Run tests
@@ -51,21 +58,6 @@ tasks:
       - test -z "{{.IS_TOOL_INSTALLED}}" || echo "Installing {{.GO_TOOL}}..."
       - test -z "{{.IS_TOOL_INSTALLED}}" || go install {{.GO_TOOL_PATH}}
       - test -n $(go env GOBIN) || go env -w GOBIN=$(go env GOPATH)/bin
+      - echo "  '{{.GO_TOOL}}' is installed."
     requires:
       vars: [GO_TOOL, GO_TOOL_PATH]
-
-  install-gofumpt:
-    desc: go install "gofumpt" and set GOBIN if not set
-    silent: true
-    cmds:
-      - task: install-go-tool
-        vars: { GO_TOOL: "gofumpt", GO_TOOL_PATH: "mvdan.cc/gofumpt@latest" }
-      - echo "  'gofumpt' is installed."
-
-  install-golangci-lint:
-    desc: go install "golangci-lint" and set GOBIN if not set
-    silent: true
-    cmds:
-      - task: install-go-tool
-        vars: { GO_TOOL: "golangci-lint", GO_TOOL_PATH: "github.com/golangci/golangci-lint/cmd/golangci-lint@latest" }
-      - echo "  'golangci-lint' is installed."


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

Ideally our CI should be predictable, boring, and standardized across our Go repos.

## Changelog

Add `task ci`.
- This verifies our linters, formatters are installed and installs them if not
- Runs linters, formatters, and go vet
- Runs the repo's tests
- `task ci` makes a _great_ git pre-push hook.

Optionally save this to `.git/hooks/pre-push` to locally verify our ci test workflow.
```bash
#!/bin/sh
task ci
```


- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task ci`
