### PR TITLE
Better nullability for IdentifierInput

### DIFF
--- a/.changes/unreleased/Bugfix-20231228-152233.yaml
+++ b/.changes/unreleased/Bugfix-20231228-152233.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where Team inputs did not omit optional ParentTeam field
+time: 2023-12-28T15:22:33.376459-05:00

--- a/.changes/unreleased/Bugfix-20231229-114751.yaml
+++ b/.changes/unreleased/Bugfix-20231229-114751.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug where optional IdentifierInput fields could never be unset - this can
+  now be done by passing NewIdentifier() with no args
+time: 2023-12-29T11:47:51.66582-05:00

--- a/.changes/unreleased/Bugfix-20231229-125723.yaml
+++ b/.changes/unreleased/Bugfix-20231229-125723.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Add missing yaml tags for *IdentifierInput and *ID
+time: 2023-12-29T12:57:23.052325-05:00

--- a/.changes/unreleased/Feature-20231228-102445.yaml
+++ b/.changes/unreleased/Feature-20231228-102445.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Enable unsetting of optional IdentifierInput fields by passing EmptyIdentifier()
+time: 2023-12-28T10:24:45.343329-05:00

--- a/.changes/unreleased/Feature-20231228-102445.yaml
+++ b/.changes/unreleased/Feature-20231228-102445.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Enable unsetting of optional IdentifierInput fields by passing EmptyIdentifier()
+body: Create null IdentifierInput by passing no arguments to NewIdentifier()
 time: 2023-12-28T10:24:45.343329-05:00

--- a/.changes/unreleased/Refactor-20231228-102145.yaml
+++ b/.changes/unreleased/Refactor-20231228-102145.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: '[BREAKING CHANGE] Use string as argument for all client request functions instead
+  of requiring an IdentifierInput'
+time: 2023-12-28T10:21:45.868667-05:00

--- a/.changes/unreleased/Refactor-20231228-102350.yaml
+++ b/.changes/unreleased/Refactor-20231228-102350.yaml
@@ -1,4 +1,0 @@
-kind: Refactor
-body: '[BREAKING CHANGE] Restrict access to IdentifierInput fields, only allow use
-  of identifiers through NewIdentifier()'
-time: 2023-12-28T10:23:50.129816-05:00

--- a/.changes/unreleased/Refactor-20231228-102350.yaml
+++ b/.changes/unreleased/Refactor-20231228-102350.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: '[BREAKING CHANGE] Restrict access to IdentifierInput fields, only allow use
+  of identifiers through NewIdentifier()'
+time: 2023-12-28T10:23:50.129816-05:00

--- a/actions.go
+++ b/actions.go
@@ -127,9 +127,9 @@ type CustomActionsTriggerDefinitionUpdateInput struct {
 	Id          ID      `json:"id"`
 	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`
-	Owner       *ID     `json:"ownerId,omitempty"`
-	Action      *ID     `json:"actionId,omitempty"`
-	Filter      *ID     `json:"filterId,omitempty"`
+	Owner       *ID     `json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
+	Action      *ID     `json:"actionId,omitempty" yaml:"actionId,omitempty"`
+	Filter      *ID     `json:"filterId,omitempty" yaml:"filterId,omitempty"`
 	// This is being explicitly left out to reduce the complexity of the implementation
 	// action *CustomActionsWebhookActionCreateInput
 	ManualInputsDefinition *string                                         `json:"manualInputsDefinition,omitempty" yaml:"manualInputsDefinition,omitempty"`

--- a/actions.go
+++ b/actions.go
@@ -154,18 +154,18 @@ func (client *Client) CreateWebhookAction(input CustomActionsWebhookActionCreate
 	return &m.Payload.WebhookAction, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) GetCustomAction(input IdentifierInput) (*CustomActionsExternalAction, error) {
+func (client *Client) GetCustomAction(input string) (*CustomActionsExternalAction, error) {
 	var q struct {
 		Account struct {
 			Action CustomActionsExternalAction `graphql:"customActionsExternalAction(input: $input)"`
 		}
 	}
 	v := PayloadVariables{
-		"input": input,
+		"input": *NewIdentifier(input),
 	}
 	err := client.Query(&q, v, WithName("ExternalActionGet"))
 	if q.Account.Action.Id == "" {
-		err = fmt.Errorf("CustomActionsExternalAction with ID '%s' or Alias '%s' not found", string(*input.Id), *input.Alias)
+		err = fmt.Errorf("CustomActionsExternalAction with ID or Alias matching '%s' not found", input)
 	}
 	return &q.Account.Action, HandleErrors(err, nil)
 }
@@ -208,14 +208,14 @@ func (client *Client) UpdateWebhookAction(input CustomActionsWebhookActionUpdate
 	return &m.Payload.WebhookAction, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) DeleteWebhookAction(input IdentifierInput) error {
+func (client *Client) DeleteWebhookAction(input string) error {
 	var m struct {
 		Payload struct {
 			Errors []OpsLevelErrors `graphql:"errors"`
 		} `graphql:"customActionsWebhookActionDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
-		"input": input,
+		"input": *NewIdentifier(input),
 	}
 	err := client.Mutate(&m, v, WithName("WebhookActionDelete"))
 	return HandleErrors(err, m.Payload.Errors)
@@ -241,18 +241,18 @@ func (client *Client) CreateTriggerDefinition(input CustomActionsTriggerDefiniti
 	return &m.Payload.TriggerDefinition, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) GetTriggerDefinition(input IdentifierInput) (*CustomActionsTriggerDefinition, error) {
+func (client *Client) GetTriggerDefinition(input string) (*CustomActionsTriggerDefinition, error) {
 	var q struct {
 		Account struct {
 			Definition CustomActionsTriggerDefinition `graphql:"customActionsTriggerDefinition(input: $input)"`
 		}
 	}
 	v := PayloadVariables{
-		"input": input,
+		"input": *NewIdentifier(input),
 	}
 	err := client.Query(&q, v, WithName("TriggerDefinitionGet"))
 	if q.Account.Definition.Id == "" {
-		err = fmt.Errorf("CustomActionsTriggerDefinition with ID '%s' or Alias '%s' not found", string(*input.Id), *input.Alias)
+		err = fmt.Errorf("CustomActionsTriggerDefinition with ID or Alias matching '%s' not found", input)
 	}
 	return &q.Account.Definition, HandleErrors(err, nil)
 }
@@ -296,14 +296,14 @@ func (client *Client) UpdateTriggerDefinition(input CustomActionsTriggerDefiniti
 	return &m.Payload.TriggerDefinition, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) DeleteTriggerDefinition(input IdentifierInput) error {
+func (client *Client) DeleteTriggerDefinition(input string) error {
 	var m struct {
 		Payload struct {
 			Errors []OpsLevelErrors `graphql:"errors"`
 		} `graphql:"customActionsTriggerDefinitionDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
-		"input": input,
+		"input": *NewIdentifier(input),
 	}
 	err := client.Mutate(&m, v, WithName("TriggerDefinitionDelete"))
 	return HandleErrors(err, m.Payload.Errors)

--- a/actions_test.go
+++ b/actions_test.go
@@ -110,16 +110,14 @@ func TestDeleteWebhookAction(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`mutation WebhookActionDelete($input:IdentifierInput!){customActionsWebhookActionDelete(resource: $input){errors{message,path}}}`,
-		`{"input":{"id": "123456789"}}`,
+		`{"input":{"alias": "123456789"}}`,
 		`{"data": {"customActionsWebhookActionDelete": { "errors": [] }}}`,
 	)
 
 	client := BestTestClient(t, "custom_actions/delete_action", testRequest)
 
 	// Act
-	err := client.DeleteWebhookAction(ol.IdentifierInput{
-		Id: newID,
-	})
+	err := client.DeleteWebhookAction("123456789")
 
 	// Assert
 	autopilot.Ok(t, err)
@@ -201,13 +199,13 @@ func TestGetTriggerDefinition(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`query TriggerDefinitionGet($input:IdentifierInput!){account{customActionsTriggerDefinition(input: $input){{ template "custom_actions_trigger_request" }}}}`,
-		`{"input":{"id":"123456789"}}`,
+		`{"input":{"alias":"123456789"}}`,
 		`{"data": {"account": { "customActionsTriggerDefinition": {{ template "custom_action_trigger2" }} }}}`,
 	)
 	client := BestTestClient(t, "custom_actions/get_trigger", testRequest)
 
 	// Act
-	trigger, err := client.GetTriggerDefinition(ol.IdentifierInput{Id: newID})
+	trigger, err := client.GetTriggerDefinition("123456789")
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, "Release", trigger.Name)
@@ -312,12 +310,12 @@ func TestDeleteTriggerDefinition(t *testing.T) {
 	// Arrange
 	request := `{"query":
 		"mutation TriggerDefinitionDelete($input:IdentifierInput!){customActionsTriggerDefinitionDelete(resource: $input){errors{message,path}}}",
-		{"input":{"id":"123456789"}}
+		{"input":{"alias":"123456789"}}
 	}`
 
 	testRequest := autopilot.NewTestRequest(
 		`mutation TriggerDefinitionDelete($input:IdentifierInput!){customActionsTriggerDefinitionDelete(resource: $input){errors{message,path}}}`,
-		`{"input":{"id":"123456789"}}`,
+		`{"input":{"alias":"123456789"}}`,
 		`{"data": {"customActionsTriggerDefinitionDelete": { "errors": [] }}}`,
 	)
 	testRequestError := autopilot.NewTestRequest(
@@ -330,9 +328,9 @@ func TestDeleteTriggerDefinition(t *testing.T) {
 	clientErr := BestTestClient(t, "custom_actions/delete_trigger_err", testRequestError)
 	clientErr2 := ABetterTestClient(t, "custom_actions/delete_trigger_err2", request, "")
 	// Act
-	err := client.DeleteTriggerDefinition(ol.IdentifierInput{Id: newID})
-	err2 := clientErr.DeleteTriggerDefinition(ol.IdentifierInput{Id: newID})
-	err3 := clientErr2.DeleteTriggerDefinition(ol.IdentifierInput{Id: newID})
+	err := client.DeleteTriggerDefinition("123456789")
+	err2 := clientErr.DeleteTriggerDefinition("123456789")
+	err3 := clientErr2.DeleteTriggerDefinition("123456789")
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, `OpsLevel API Errors:

--- a/check.go
+++ b/check.go
@@ -136,8 +136,8 @@ type CheckUpdateInput struct {
 	EnableOn *iso8601.Time `json:"enableOn,omitempty"`
 	Category ID            `json:"categoryId,omitempty"`
 	Level    ID            `json:"levelId,omitempty"`
-	Owner    *ID           `json:"ownerId,omitempty"`
-	Filter   *ID           `json:"filterId,omitempty"`
+	Owner    *ID           `json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
+	Filter   *ID           `json:"filterId,omitempty" yaml:"filterId,omitempty"`
 	Notes    *string       `json:"notes,omitempty"`
 }
 

--- a/check_custom_event.go
+++ b/check_custom_event.go
@@ -25,7 +25,7 @@ type CheckCustomEventUpdateInput struct {
 	SuccessCondition string  `json:"successCondition,omitempty"`
 	Message          *string `json:"resultMessage,omitempty"`
 	PassPending      *bool   `json:"passPending,omitempty"`
-	Integration      *ID     `json:"integrationId,omitempty"`
+	Integration      *ID     `json:"integrationId,omitempty" yaml:"integrationId,omitempty"`
 }
 
 func (client *Client) CreateCheckCustomEvent(input CheckCustomEventCreateInput) (*Check, error) {

--- a/domain.go
+++ b/domain.go
@@ -25,7 +25,7 @@ type DomainConnection struct {
 type DomainInput struct {
 	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`
-	Owner       *ID     `json:"ownerId,omitempty"`
+	Owner       *ID     `json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
 	Note        *string `json:"note,omitempty"`
 }
 

--- a/infra.go
+++ b/infra.go
@@ -55,7 +55,7 @@ type InfrastructureResourceInput struct {
 	Schema       *InfrastructureResourceSchemaInput   `json:"schema,omitempty" yaml:"schema,omitempty"`
 	ProviderType *string                              `json:"providerResourceType,omitempty" yaml:"providerResourceType,omitempty" default:"BigQuery"`
 	ProviderData *InfrastructureResourceProviderInput `json:"providerData,omitempty" yaml:"providerData,omitempty"`
-	Owner        *ID                                  `json:"ownerId,omitempty" yaml:"owner,omitempty"`
+	Owner        *ID                                  `json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
 	Data         JSON                                 `json:"data,omitempty" yaml:"data,omitempty" scalar:"true" default:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false,\"storage_size\":{\"value\":1024,\"unit\": \"GB\"}}"`
 }
 
@@ -68,7 +68,7 @@ type InfraProviderInput struct {
 
 type InfraInput struct {
 	Schema   string              `json:"schema" yaml:"schema" default:"Database"`
-	Owner    *ID                 `json:"owner" yaml:"owner" default:"XXX_owner_id_XXX"`
+	Owner    *ID                 `json:"owner,omitempty" yaml:"owner,omitempty" default:"XXX_owner_id_XXX"`
 	Provider *InfraProviderInput `json:"provider" yaml:"provider"`
 	Data     map[string]any      `json:"data" yaml:"data" default:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"`
 }

--- a/repository.go
+++ b/repository.go
@@ -230,8 +230,8 @@ func (r *Repository) GetTags(client *Client, variables *PayloadVariables) (*TagC
 
 func (client *Client) ConnectServiceRepository(service *ServiceId, repository *Repository) (*ServiceRepository, error) {
 	input := ServiceRepositoryCreateInput{
-		Service:       IdentifierInput{Id: &service.Id},
-		Repository:    IdentifierInput{Id: &repository.Id},
+		Service:       *NewIdentifier(string(service.Id)),
+		Repository:    *NewIdentifier(string(repository.Id)),
 		BaseDirectory: "/",
 		DisplayName:   fmt.Sprintf("%s/%s", repository.Organization, repository.Name),
 	}

--- a/repository.go
+++ b/repository.go
@@ -44,7 +44,7 @@ type Repository struct {
 
 type RepositoryUpdateInput struct {
 	Id    ID  `json:"id"`
-	Owner *ID `json:"ownerId,omitempty"`
+	Owner *ID `json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
 }
 
 type RepositoryPath struct {

--- a/scalar.go
+++ b/scalar.go
@@ -31,8 +31,16 @@ type Identifier struct {
 }
 
 type IdentifierInput struct {
-	Id    *ID     `graphql:"id" json:"id,omitempty" yaml:"id,omitempty"`
-	Alias *string `graphql:"alias" json:"alias,omitempty" yaml:"alias,omitempty"`
+	id    *ID     `graphql:"id" json:"id,omitempty" yaml:"id,omitempty"`
+	alias *string `graphql:"alias" json:"alias,omitempty" yaml:"alias,omitempty"`
+}
+
+func (i *IdentifierInput) ID() *ID {
+	return i.id
+}
+
+func (i *IdentifierInput) Alias() *string {
+	return i.alias
 }
 
 func NewIdentifier(value ...string) *IdentifierInput {
@@ -40,11 +48,11 @@ func NewIdentifier(value ...string) *IdentifierInput {
 	if len(value) == 1 {
 		if IsID(value[0]) {
 			return &IdentifierInput{
-				Id: NewID(value[0]),
+				id: NewID(value[0]),
 			}
 		}
 		return &IdentifierInput{
-			Alias: NewString(value[0]),
+			alias: NewString(value[0]),
 		}
 	}
 	return output

--- a/scalar.go
+++ b/scalar.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strconv"
 	"strings"
 )
@@ -35,7 +36,20 @@ type IdentifierInput struct {
 	alias *string `graphql:"alias" json:"alias,omitempty" yaml:"alias,omitempty"`
 }
 
-func (i *IdentifierInput) ID() *ID {
+func (i IdentifierInput) MarshalJSON() ([]byte, error) {
+	if i.id == nil && i.alias == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(struct {
+		Id    *ID     `json:"id,omitempty"`
+		Alias *string `json:"alias,omitempty"`
+	}{
+		Id:    i.id,
+		Alias: i.alias,
+	})
+}
+
+func (i *IdentifierInput) Id() *ID {
 	return i.id
 }
 

--- a/scalar.go
+++ b/scalar.go
@@ -37,11 +37,9 @@ type IdentifierInput struct {
 }
 
 func (i IdentifierInput) MarshalJSON() ([]byte, error) {
-	// this case can only occur by using an EmptyIdentifier()
 	if i.Id == nil && i.Alias == nil {
 		return []byte("null"), nil
 	}
-
 	var out string
 	if i.Id != nil {
 		out = fmt.Sprintf(`{"id":"%s"}`, string(*i.Id))
@@ -51,18 +49,17 @@ func (i IdentifierInput) MarshalJSON() ([]byte, error) {
 	return []byte(out), nil
 }
 
-func NewIdentifier(value string) *IdentifierInput {
-	if IsID(value) {
+func NewIdentifier(value ...string) *IdentifierInput {
+	if len(value) == 1 {
+		if IsID(value[0]) {
+			return &IdentifierInput{
+				Id: NewID(value[0]),
+			}
+		}
 		return &IdentifierInput{
-			Id: NewID(value),
+			Alias: NewString(value[0]),
 		}
 	}
-	return &IdentifierInput{
-		Alias: NewString(value),
-	}
-}
-
-func EmptyIdentifier() *IdentifierInput {
 	var output IdentifierInput
 	return &output
 }

--- a/scalar.go
+++ b/scalar.go
@@ -32,11 +32,12 @@ type Identifier struct {
 }
 
 type IdentifierInput struct {
-	id    *ID     `graphql:"id" json:"id,omitempty" yaml:"id,omitempty"`
-	alias *string `graphql:"alias" json:"alias,omitempty" yaml:"alias,omitempty"`
+	id    *ID     `json:"id,omitempty" yaml:"id,omitempty"`
+	alias *string `json:"alias,omitempty" yaml:"alias,omitempty"`
 }
 
 func (i IdentifierInput) MarshalJSON() ([]byte, error) {
+	// this case can only occur by using an EmptyIdentifier()
 	if i.id == nil && i.alias == nil {
 		return []byte("null"), nil
 	}
@@ -57,19 +58,20 @@ func (i *IdentifierInput) Alias() *string {
 	return i.alias
 }
 
-func NewIdentifier(value ...string) *IdentifierInput {
-	var output *IdentifierInput
-	if len(value) == 1 {
-		if IsID(value[0]) {
-			return &IdentifierInput{
-				id: NewID(value[0]),
-			}
-		}
+func NewIdentifier(value string) *IdentifierInput {
+	if IsID(value) {
 		return &IdentifierInput{
-			alias: NewString(value[0]),
+			id: NewID(value),
 		}
 	}
-	return output
+	return &IdentifierInput{
+		alias: NewString(value),
+	}
+}
+
+func EmptyIdentifier() *IdentifierInput {
+	var output IdentifierInput
+	return &output
 }
 
 func NewIdentifierArray(values []string) []IdentifierInput {

--- a/scalar.go
+++ b/scalar.go
@@ -32,8 +32,8 @@ type Identifier struct {
 }
 
 type IdentifierInput struct {
-	id    *ID     `json:"id,omitempty" yaml:"id,omitempty"`
-	alias *string `json:"alias,omitempty" yaml:"alias,omitempty"`
+	id    *ID
+	alias *string
 }
 
 func (i IdentifierInput) MarshalJSON() ([]byte, error) {

--- a/scalar.go
+++ b/scalar.go
@@ -2,7 +2,7 @@ package opslevel
 
 import (
 	"encoding/base64"
-	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -32,40 +32,33 @@ type Identifier struct {
 }
 
 type IdentifierInput struct {
-	id    *ID
-	alias *string
+	Id    *ID     `json:"id,omitempty" yaml:"id,omitempty"`
+	Alias *string `json:"alias,omitempty" yaml:"alias,omitempty"`
 }
 
 func (i IdentifierInput) MarshalJSON() ([]byte, error) {
 	// this case can only occur by using an EmptyIdentifier()
-	if i.id == nil && i.alias == nil {
+	if i.Id == nil && i.Alias == nil {
 		return []byte("null"), nil
 	}
-	return json.Marshal(struct {
-		Id    *ID     `json:"id,omitempty"`
-		Alias *string `json:"alias,omitempty"`
-	}{
-		Id:    i.id,
-		Alias: i.alias,
-	})
-}
 
-func (i *IdentifierInput) Id() *ID {
-	return i.id
-}
-
-func (i *IdentifierInput) Alias() *string {
-	return i.alias
+	var out string
+	if i.Id != nil {
+		out = fmt.Sprintf(`{"id":"%s"}`, string(*i.Id))
+	} else {
+		out = fmt.Sprintf(`{"alias":"%s"}`, string(*i.Alias))
+	}
+	return []byte(out), nil
 }
 
 func NewIdentifier(value string) *IdentifierInput {
 	if IsID(value) {
 		return &IdentifierInput{
-			id: NewID(value),
+			Id: NewID(value),
 		}
 	}
 	return &IdentifierInput{
-		alias: NewString(value),
+		Alias: NewString(value),
 	}
 }
 

--- a/scalar.go
+++ b/scalar.go
@@ -35,15 +35,19 @@ type IdentifierInput struct {
 	Alias *string `graphql:"alias" json:"alias,omitempty" yaml:"alias,omitempty"`
 }
 
-func NewIdentifier(value string) *IdentifierInput {
-	if IsID(value) {
+func NewIdentifier(value ...string) *IdentifierInput {
+	var output *IdentifierInput
+	if len(value) == 1 {
+		if IsID(value[0]) {
+			return &IdentifierInput{
+				Id: NewID(value[0]),
+			}
+		}
 		return &IdentifierInput{
-			Id: NewID(value),
+			Alias: NewString(value[0]),
 		}
 	}
-	return &IdentifierInput{
-		Alias: NewString(value),
-	}
+	return output
 }
 
 func NewIdentifierArray(values []string) []IdentifierInput {

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -217,6 +217,6 @@ func TestNewIdentifierArray(t *testing.T) {
 	s := []string{"my-service", "Z2lkOi8vMTIzNDU2Nzg5"}
 	result := ol.NewIdentifierArray(s)
 	// Assert
-	autopilot.Equals(t, "my-service", *result[0].Alias())
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id())
+	autopilot.Equals(t, "my-service", *result[0].Alias)
+	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -96,8 +96,8 @@ func TestMarshalIdentifiers(t *testing.T) {
 	}
 	testCases := []TestCase{
 		{
-			Name:         "the special empty identifier",
-			Identifier:   ol.EmptyIdentifier(),
+			Name:         "empty identifier",
+			Identifier:   ol.NewIdentifier(),
 			OutputBuffer: `null`,
 		},
 		{
@@ -140,8 +140,8 @@ func TestMarshalIdentifiersOmitBehavior(t *testing.T) {
 		},
 		{
 			Name:         "pass empty identifier, owner should null",
-			Owner:        ol.EmptyIdentifier(),
-			Maintainer:   ol.EmptyIdentifier(),
+			Owner:        ol.NewIdentifier(),
+			Maintainer:   ol.NewIdentifier(),
 			OutputBuffer: `{"owner":null,"maintainer":null}`,
 		},
 		{

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -184,6 +184,6 @@ func TestNewIdentifierArray(t *testing.T) {
 	s := []string{"my-service", "Z2lkOi8vMTIzNDU2Nzg5"}
 	result := ol.NewIdentifierArray(s)
 	// Assert
-	autopilot.Equals(t, "my-service", string(*result[0].Alias))
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
+	autopilot.Equals(t, "my-service", *result[0].Alias())
+	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].ID())
 }

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -184,6 +184,6 @@ func TestNewIdentifierArray(t *testing.T) {
 	s := []string{"my-service", "Z2lkOi8vMTIzNDU2Nzg5"}
 	result := ol.NewIdentifierArray(s)
 	// Assert
-	autopilot.Equals(t, "my-service", *result[0].Alias)
+	autopilot.Equals(t, "my-service", string(*result[0].Alias))
 	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -185,5 +185,5 @@ func TestNewIdentifierArray(t *testing.T) {
 	result := ol.NewIdentifierArray(s)
 	// Assert
 	autopilot.Equals(t, "my-service", *result[0].Alias())
-	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].ID())
+	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id())
 }

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -184,6 +184,6 @@ func TestNewIdentifierArray(t *testing.T) {
 	s := []string{"my-service", "Z2lkOi8vMTIzNDU2Nzg5"}
 	result := ol.NewIdentifierArray(s)
 	// Assert
-	autopilot.Equals(t, "my-service", string(*result[0].Alias))
+	autopilot.Equals(t, "my-service", *result[0].Alias)
 	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }

--- a/scorecards.go
+++ b/scorecards.go
@@ -50,19 +50,18 @@ func (client *Client) CreateScorecard(input ScorecardInput) (*Scorecard, error) 
 	return &m.Payload.Scorecard, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) GetScorecard(identifier string) (*Scorecard, error) {
+func (client *Client) GetScorecard(input string) (*Scorecard, error) {
 	var q struct {
 		Account struct {
 			Scorecard Scorecard `graphql:"scorecard(input: $input)"`
 		}
 	}
-	input := *NewIdentifier(identifier)
 	v := PayloadVariables{
-		"input": input,
+		"input": *NewIdentifier(input),
 	}
 	err := client.Query(&q, v, WithName("ScorecardGet"))
 	if q.Account.Scorecard.Id == "" {
-		err = fmt.Errorf("Scorecard with ID '%s' or Alias '%s' not found", string(*input.Id), *input.Alias)
+		err = fmt.Errorf("Scorecard with ID or Alias matching '%s' not found", input)
 	}
 	return &q.Account.Scorecard, HandleErrors(err, nil)
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -19,7 +19,7 @@ func TestCreateSecret(t *testing.T) {
 	fmt.Println(client)
 	// Act
 	secretInput := opslevel.SecretInput{
-		Owner: opslevel.IdentifierInput{Id: &id2},
+		Owner: *opslevel.NewIdentifier(string(id2)),
 		Value: "my-secret",
 	}
 	result, err := client.CreateSecret("alias1", secretInput)
@@ -79,7 +79,7 @@ func TestUpdateSecret(t *testing.T) {
 	client := BestTestClient(t, "secrets/update", testRequest)
 	// Act
 	secretInput := opslevel.SecretInput{
-		Owner: opslevel.IdentifierInput{Id: &id2},
+		Owner: *opslevel.NewIdentifier(string(id2)),
 		Value: "secret_value_2",
 	}
 	result, err := client.UpdateSecret(string(id2), secretInput)

--- a/service.go
+++ b/service.go
@@ -72,9 +72,9 @@ type ServiceUpdateInput struct {
 	Language    string           `json:"language,omitempty"`
 	Framework   string           `json:"framework,omitempty"`
 	Tier        string           `json:"tierAlias,omitempty"`
-	Owner       *IdentifierInput `json:"ownerInput,omitempty"`
+	Owner       *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`
 	Lifecycle   string           `json:"lifecycleAlias,omitempty"`
-	Parent      *IdentifierInput `json:"parent,omitempty"`
+	Parent      *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`
 }
 
 type ServiceDeleteInput struct {

--- a/system.go
+++ b/system.go
@@ -26,8 +26,8 @@ type SystemConnection struct {
 type SystemInput struct {
 	Name        *string          `json:"name,omitempty"`
 	Description *string          `json:"description,omitempty"`
-	Owner       *ID              `json:"ownerId,omitempty"`
-	Parent      *IdentifierInput `json:"parent,omitempty"`
+	Owner       *ID              `json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
+	Parent      *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`
 	Note        *string          `json:"note,omitempty"`
 }
 

--- a/team.go
+++ b/team.go
@@ -88,7 +88,7 @@ type TeamUpdateInput struct {
 	Name             string           `json:"name,omitempty"`
 	ManagerEmail     string           `json:"managerEmail,omitempty"`
 	Responsibilities string           `json:"responsibilities,omitempty"`
-	ParentTeam       *IdentifierInput `json:"parentTeam,omitempty"`
+	ParentTeam       *IdentifierInput `json:"parentTeam,omitempty" yaml:"parentTeam,omitempty"`
 }
 
 type TeamDeleteInput struct {

--- a/team.go
+++ b/team.go
@@ -79,7 +79,7 @@ type TeamCreateInput struct {
 	ManagerEmail     string           `json:"managerEmail,omitempty" yaml:"managerEmail,omitempty" default:"manager@example.com"`
 	Responsibilities string           `json:"responsibilities,omitempty" yaml:"responsibilities,omitempty" default:"Makes Tools"`
 	Contacts         *[]ContactInput  `json:"contacts,omitempty" yaml:"contacts,omitempty" default:"[{\"Type\":\"slack\",\"DisplayName\":\"Team Eng\",\"Address\":\"#team-engineering\"}]"`
-	ParentTeam       *IdentifierInput `json:"parentTeam" yaml:"parentTeam" default:"{\"alias\":\"Engineering\"}"`
+	ParentTeam       *IdentifierInput `json:"parentTeam,omitempty" yaml:"parentTeam,omitempty" default:"{\"alias\":\"Engineering\"}"`
 }
 
 type TeamUpdateInput struct {
@@ -88,7 +88,7 @@ type TeamUpdateInput struct {
 	Name             string           `json:"name,omitempty"`
 	ManagerEmail     string           `json:"managerEmail,omitempty"`
 	Responsibilities string           `json:"responsibilities,omitempty"`
-	ParentTeam       *IdentifierInput `json:"parentTeam"`
+	ParentTeam       *IdentifierInput `json:"parentTeam,omitempty"`
 }
 
 type TeamDeleteInput struct {

--- a/user.go
+++ b/user.go
@@ -30,8 +30,8 @@ type UserConnection struct {
 }
 
 type UserIdentifierInput struct {
-	Id    *ID     `graphql:"id" json:"id,omitempty"`
-	Email *string `graphql:"email" json:"email,omitempty"`
+	Id    *ID     `graphql:"id" json:"id,omitempty" yaml:"id,omitempty"`
+	Email *string `graphql:"email" json:"email,omitempty" yaml:"email,omitempty"`
 }
 
 type UserInput struct {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/158

Allow opslevel-go to pass `NewIdentifier()` (with no args) as `*IdentifierInput` which results in the API being sent `null`. This enables being able to unset optional fields in resource updates.

## Changelog

- [x] Change functions that are using the `IdentifierInput` as arguments to instead take `string`
- [x] Modify `JSONMarshal()` logic for `IdentifierInput` to match the logic of marshalling an empty `ID`
- [x] New test tables for `IdentifierInput`
- [x] Add missing `yaml` tags, which caused bugs in the CLI. When tophatting the CLI, the lack of yaml `omitempty` caused updates to not work correctly.
- [x] Make `changie` entries
- [x] Other tools (changes only need to be made on fields that are `*IdentifierInput`)
    - [x] CLI - https://github.com/OpsLevel/cli/pull/230
    - [x] Terraform - https://github.com/OpsLevel/terraform-provider-opslevel/pull/178
    - [x] Kubectl no changes needed.

## Tophatting

Unit tests pass.
