### PR TITLE
Db/ci test clean up

### DIFF
--- a/.github/workflows/enum-gen.yaml
+++ b/.github/workflows/enum-gen.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
       - name: Install Task
         uses: arduino/setup-task@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
       - name: Cache Go modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
 
 jobs:
   test:
@@ -26,8 +29,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run quality checks and tests
         run: task ci
-      - name: Test code
-        run: task test
       - name: Upload Coverage
-        run: |-
-          bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./src/coverage.txt
+          fail_ci_if_error: false
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Run quality checks and tests
         run: task ci
       - name: Upload Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Upload Coverage
         uses: codecov/codecov-action@v3
         with:
-          files: ./src/coverage.txt
+          files: ./coverage.txt
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Remove redundant `task test` from "Tests" github workflow. The tests are already being run by `task ci`

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
