### PR TITLE
Remove log line from opslevel-go lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hasura/go-graphql-client v0.10.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opslevel/moredefaults v0.0.0-20240112142637-078c8ff8ba9c
+	github.com/pkg/errors v0.9.1
 	github.com/relvacode/iso8601 v1.4.0
 	github.com/rocktavious/autopilot/v2023 v2023.12.7
 	github.com/rs/zerolog v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/I
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/opslevel/moredefaults v0.0.0-20240112142637-078c8ff8ba9c h1:m4sNHcfkE02xZy1oxF2QVGfhHulamxw9UlzRM7c45QQ=
 github.com/opslevel/moredefaults v0.0.0-20240112142637-078c8ff8ba9c/go.mod h1:g2GSXVP6LO+5+AIsnMRPN+BeV86OXuFRTX7HXCDtYeI=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/json.go
+++ b/json.go
@@ -3,8 +3,9 @@ package opslevel
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 // JSON is a specialized map[string]string to support proper graphql serialization

--- a/json.go
+++ b/json.go
@@ -2,9 +2,9 @@ package opslevel
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
 	"strconv"
-
-	"github.com/rs/zerolog/log"
 )
 
 // JSON is a specialized map[string]string to support proper graphql serialization
@@ -87,8 +87,7 @@ func NewJSONInput(data any) (*JsonString, error) {
 func JsonStringAs[T any](data JsonString) (T, error) {
 	var result T
 	if err := json.Unmarshal([]byte(data), &result); err != nil {
-		log.Warn().Err(err).Msgf("unable to marshal json as %T", result)
-		return result, err
+		return result, errors.Wrap(err, fmt.Sprintf("unable to marshal json as %T", result))
 	}
 	return result, nil
 }


### PR DESCRIPTION
This is the only `log.*` call in opslevel-go outside of tests and cache.go. 

An error wrap is more appropriate here and we should avoid logging from opslevel-go since it can affect other programs. 