### PR TITLE
Fix JSON marshalling of an ID to be `null` (stop using unnecessary pointer)

### DIFF
--- a/.changes/unreleased/Bugfix-20240121-160519.yaml
+++ b/.changes/unreleased/Bugfix-20240121-160519.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Concrete opslevel.ID structs now correctly JSON marshal to null instead of ""
+time: 2024-01-21T16:05:19.350349-05:00

--- a/scalar.go
+++ b/scalar.go
@@ -17,13 +17,13 @@ func NewID(id ...string) *ID {
 	return &output
 }
 
-func (s ID) GetGraphQLType() string { return "ID" }
+func (id ID) GetGraphQLType() string { return "ID" }
 
-func (s *ID) MarshalJSON() ([]byte, error) {
-	if *s == "" {
+func (id ID) MarshalJSON() ([]byte, error) {
+	if id == "" {
 		return []byte("null"), nil
 	}
-	return []byte(strconv.Quote(string(*s))), nil
+	return []byte(strconv.Quote(string(id))), nil
 }
 
 type Identifier struct {
@@ -31,15 +31,15 @@ type Identifier struct {
 	Aliases []string `graphql:"aliases"`
 }
 
-func (i IdentifierInput) MarshalJSON() ([]byte, error) {
-	if i.Id == nil && i.Alias == nil {
+func (identifierInput IdentifierInput) MarshalJSON() ([]byte, error) {
+	if identifierInput.Id == nil && identifierInput.Alias == nil {
 		return []byte("null"), nil
 	}
 	var out string
-	if i.Id != nil {
-		out = fmt.Sprintf(`{"id":"%s"}`, string(*i.Id))
+	if identifierInput.Id != nil {
+		out = fmt.Sprintf(`{"id":"%s"}`, string(*identifierInput.Id))
 	} else {
-		out = fmt.Sprintf(`{"alias":"%s"}`, string(*i.Alias))
+		out = fmt.Sprintf(`{"alias":"%s"}`, *identifierInput.Alias)
 	}
 	return []byte(out), nil
 }
@@ -60,7 +60,7 @@ func NewIdentifier(value ...string) *IdentifierInput {
 }
 
 func NewIdentifierArray(values []string) []IdentifierInput {
-	output := []IdentifierInput{}
+	output := make([]IdentifierInput, 0)
 	for _, value := range values {
 		output = append(output, *NewIdentifier(value))
 	}

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -40,9 +40,9 @@ func TestMarshalID(t *testing.T) {
 	buf3, err3 := json.Marshal(case3)
 	// Assert
 	autopilot.Ok(t, err1)
-	autopilot.Equals(t, `{"key1":"","key3":null}`, string(buf1))
+	autopilot.Equals(t, `{"key1":null,"key3":null}`, string(buf1))
 	autopilot.Ok(t, err2)
-	autopilot.Equals(t, `{"key1":"","key3":null,"key4":null}`, string(buf2))
+	autopilot.Equals(t, `{"key1":null,"key3":null,"key4":null}`, string(buf2))
 	autopilot.Ok(t, err3)
 	autopilot.Equals(t, `{"key1":"Z2lkOi8vMTIzNDU2Nzg5","key2":"Z2lkOi8vMTIzNDU2Nzg5","key3":"Z2lkOi8vMTIzNDU2Nzg5","key4":"Z2lkOi8vMTIzNDU2Nzg5"}`, string(buf3))
 }


### PR DESCRIPTION
## Issues

Extracted from https://github.com/OpsLevel/opslevel-go/pull/356

## TL;DR

The test expectation is wrong because we shouldn't be using a pointer receiver. 

## Explanation

These changes in the test expectation is justified. The test expectations before were incorrect.

```
type IDTester struct {
	Key1 ol.ID  `json:"key1"`
	Key2 ol.ID  `json:"key2,omitempty"`
	Key3 *ol.ID `json:"key3"`
	Key4 *ol.ID `json:"key4,omitempty"`
}

func TestMarshalID(t *testing.T) {
	// Arrange
	id1 := ol.NewID() <------ we're getting a pointer to a blank ID (string)
	id2 := ol.NewID("Z2lkOi8vMTIzNDU2Nzg5")
	case1 := IDTester{}
	case2 := IDTester{
		Key1: *id1, <------ this is now a concrete empty ID (""). key1 is not omit empty, so it should serialize to null.
		Key2: *id1,
		Key3: id1,
		Key4: id1,
	}
	case3 := IDTester{
		Key1: *id2, <------ empty ID (""). again, key 1 is not omit empty, so it should serialize to null.
		Key2: *id2,
		Key3: id2,
		Key4: id2,
	}
	// Act
	buf1, err1 := json.Marshal(case1)
	buf2, err2 := json.Marshal(case2)
	buf3, err3 := json.Marshal(case3)
	// Assert
	autopilot.Ok(t, err1)
	autopilot.Equals(t, `{"key1":null,"key3":null}`, string(buf1))
	autopilot.Ok(t, err2)
	autopilot.Equals(t, `{"key1":null,"key3":null,"key4":null}`, string(buf2))

```

## Changelog

- [x] Stop using unnecessary pointer
- [x] Fix test accordingly
- [x] Make a `changie` entry
