### PR TITLE
Fix `repository.GetService` when directory is /

### DIFF
--- a/.changes/unreleased/Bugfix-20240221-191059.yaml
+++ b/.changes/unreleased/Bugfix-20240221-191059.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where GetService did not work when passing `/` as the directory
+time: 2024-02-21T19:10:59.880955-05:00

--- a/repository.go
+++ b/repository.go
@@ -100,7 +100,8 @@ func (r *Repository) ResourceType() TaggableResource {
 func (r *Repository) GetService(service ID, directory string) *ServiceRepository {
 	for _, edge := range r.Services.Edges {
 		for _, connection := range edge.ServiceRepositories {
-			if connection.Service.Id == service && connection.BaseDirectory == directory {
+			// the directory "/" is the same as ""
+			if connection.Service.Id == service && (connection.BaseDirectory == directory || (directory == "/" && connection.BaseDirectory == "")) {
 				return &connection
 			}
 		}


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/kubectl-opslevel/pull/262

## Changelog

- [x] Update if statement
- [x] Make a `changie` entry

## Explanation

```
  "Services": {
    "Edges": [
      {
        "AtRoot": true,
        "Node": {
          "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk2",
          "aliases": [
            "jsonrpc_api",
            "jsonrpc_apis",
            "jsonrpc_apiz"
          ]
        },
        "Paths": [
          {
            "Href": "https://github.com/jasonopslevel/a_repo",
            "Path": ""
          }
        ],
        "ServiceRepositories": [
          {
            "BaseDirectory": "", <-------------------------------------- since this is empty and not /, the GetService() call will fail.
            "DisplayName": "jason-opslevel/a_repo",
            "Id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZVJlcG9zaXRvcnkvNDI3Nw",
            "Repository": {
              "Id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjc5NDU",
              "DefaultAlias": "github.com:jason-opslevel/a_repo"
            },
            "Service": {
              "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk2",
              "aliases": [
                "jsonrpc_api",
                "jsonrpc_apis",
                "jsonrpc_apiz"
              ]
            }

```
