### PR TITLE
fix paginated listing of over 100 services

### DIFF
--- a/.changes/unreleased/Bugfix-20240306-124839.yaml
+++ b/.changes/unreleased/Bugfix-20240306-124839.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix list services maturity query, crashed if over 100 services
+time: 2024-03-06T12:48:39.473637-06:00

--- a/maturity_test.go
+++ b/maturity_test.go
@@ -133,7 +133,7 @@ func TestGetServiceMaturityWithAlias(t *testing.T) {
 func TestListServicesMaturity(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query ($after:String!$first:Int!){account{services(after: $after, first: $first){nodes{name,maturityReport{categoryBreakdown{category{id,name},level{alias,description,id,index,name}},overallLevel{alias,description,id,index,name}}},{{ template "pagination_request" }}}}}`,
+		`query ServiceMaturityList($after:String!$first:Int!){account{services(after: $after, first: $first){nodes{name,maturityReport{categoryBreakdown{category{id,name},level{alias,description,id,index,name}},overallLevel{alias,description,id,index,name}}},{{ template "pagination_request" }}}}}`,
 		`{"after":"", "first":100}`,
 		`{
   "data": {
@@ -229,7 +229,8 @@ func TestListServicesMaturity(t *testing.T) {
 	)
 	client := BestTestClient(t, "maturity/services", testRequest)
 	// Act
-	result, err := client.ListServicesMaturity()
+	response, err := client.ListServicesMaturity(nil)
+	result := response.Nodes
 	// Assert
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, 1, len(result))


### PR DESCRIPTION
## Issues

[Fix list service maturity query](https://github.com/OpsLevel/team-platform/issues/263)

`opslevel list services maturity` was failing if over 100 services were listed. This was due to old pagination logic.

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - tests pass
