### PR TITLE
include infra Schema during infra update

### DIFF
--- a/.changes/unreleased/Bugfix-20240326-153538.yaml
+++ b/.changes/unreleased/Bugfix-20240326-153538.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: include Schema field during infrastructure update
+time: 2024-03-26T15:35:38.799114-05:00

--- a/infra.go
+++ b/infra.go
@@ -201,7 +201,8 @@ func (client *Client) ListInfrastructure(variables *PayloadVariables) (*Infrastr
 
 func (client *Client) UpdateInfrastructure(identifier string, input InfraInput) (*InfrastructureResource, error) {
 	i := InfrastructureResourceInput{
-		Data: input.Data,
+		Data:   input.Data,
+		Schema: &InfrastructureResourceSchemaInput{Type: input.Schema},
 	}
 	if input.Owner != nil {
 		i.OwnerId = input.Owner

--- a/infra_test.go
+++ b/infra_test.go
@@ -146,6 +146,7 @@ func TestUpdateInfra(t *testing.T) {
 	autopilot.Equals(t, nil, err)
 	autopilot.Equals(t, string(id1), result.Id)
 	autopilot.Equals(t, "my-big-query", result.Name)
+	autopilot.Equals(t, "Database", result.Schema)
 }
 
 func TestDeleteInfra(t *testing.T) {

--- a/infra_test.go
+++ b/infra_test.go
@@ -127,7 +127,7 @@ func TestUpdateInfra(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}`,
-		`{"all": true, "identifier": { {{ template "id1" }}}, "input": { "ownerId": "{{ template "id1_string" }}", "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}" }}`,
+		`{"all": true, "identifier": { {{ template "id1" }}}, "input": { "ownerId": "{{ template "id1_string" }}", "schema": {"type": ""}, "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}" }}`,
 		`{"data": { "infrastructureResourceUpdate": { "infrastructureResource": {{ template "infra_1" }}, "warnings": [], "errors": [] }}}`,
 	)
 	client := BestTestClient(t, "infra/update", testRequest)

--- a/infra_test.go
+++ b/infra_test.go
@@ -127,13 +127,14 @@ func TestUpdateInfra(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}`,
-		`{"all": true, "identifier": { {{ template "id1" }}}, "input": { "ownerId": "{{ template "id1_string" }}", "schema": {"type": ""}, "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}" }}`,
+		`{"all": true, "identifier": { {{ template "id1" }}}, "input": { "ownerId": "{{ template "id1_string" }}", "schema": {"type": "Database"}, "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}" }}`,
 		`{"data": { "infrastructureResourceUpdate": { "infrastructureResource": {{ template "infra_1" }}, "warnings": [], "errors": [] }}}`,
 	)
 	client := BestTestClient(t, "infra/update", testRequest)
 	// Act
 	result, err := client.UpdateInfrastructure(string(id1), opslevel.InfraInput{
-		Owner: &id1,
+		Schema: "Database",
+		Owner:  &id1,
 		Data: &opslevel.JSON{
 			"name":     "my-big-query",
 			"engine":   "BigQuery",


### PR DESCRIPTION
## Issues

The terraform provider is unable to update an infrastructure resource's `schema` field. This fixes that.

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - all tests pass
