### PR TITLE
add listing services by filter

### DIFF
--- a/.changes/unreleased/Feature-20240425-115837.yaml
+++ b/.changes/unreleased/Feature-20240425-115837.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add listing services by filter
+time: 2024-04-25T11:58:37.676105-05:00

--- a/service_test.go
+++ b/service_test.go
@@ -723,6 +723,31 @@ func TestListServices(t *testing.T) {
 	autopilot.Equals(t, ol.ApiDocumentSourceEnumPull, *result[1].PreferredApiDocumentSource)
 }
 
+func TestListServicesWithFilter(t *testing.T) {
+	// Arrange
+	testRequestOne := autopilot.NewTestRequest(
+		`query ServiceListWithFilterIdentifier($after:String!$filter:IdentifierInput!$first:Int!){account{services(filterIdentifier: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`{ {{ template "first_page_variables" }}, "filter": { "alias": "backend_api" }}`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 1 }}}}`,
+	)
+	testRequestTwo := autopilot.NewTestRequest(
+		`query ServiceListWithFilterIdentifier($after:String!$filter:IdentifierInput!$first:Int!){account{services(filterIdentifier: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`{ {{ template "second_page_variables" }}, "filter": { "alias": "backend_api" }}`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_2" }} ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
+	)
+	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
+
+	client := BestTestClient(t, "service/list_with_filter", requests...)
+	// Act
+	response, err := client.ListServicesWithFilter("backend_api", nil)
+	result := response.Nodes
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 2, response.TotalCount)
+	autopilot.Equals(t, "Foo", result[0].Name)
+	autopilot.Equals(t, ol.ApiDocumentSourceEnumPull, *result[1].PreferredApiDocumentSource)
+}
+
 func TestListServicesWithFramework(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(


### PR DESCRIPTION
## Issues

[Support the filterIdentifier argument in the services datasource in terraform](https://github.com/OpsLevel/team-platform/issues/321)
- This is the opslevel-go precondition for the Terraform provider

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - tests pass
