### PR TITLE
introduce `NullableValue[T]`, allow unsetting fields on a service with `ServiceUpdateInputV2`

### DIFF
--- a/.changes/unreleased/Deprecated-20240503-131333.yaml
+++ b/.changes/unreleased/Deprecated-20240503-131333.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: Deprecate ServiceUpdate(), ServiceUpdateInput
+time: 2024-05-03T13:13:33.378963-04:00

--- a/.changes/unreleased/Deprecated-20240503-131333.yaml
+++ b/.changes/unreleased/Deprecated-20240503-131333.yaml
@@ -1,3 +1,3 @@
 kind: Deprecated
-body: Deprecate ServiceUpdate(), ServiceUpdateInput
+body: Deprecate ServiceUpdateInput, is being replaced by ServiceUpdateInputV2
 time: 2024-05-03T13:13:33.378963-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Introduce NullableValue generic type (adds support for unsetting fields in update input structs)
+body: Introduce Nullable generic type allows string only (to support for unsetting fields in update input structs)
 time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Introduce OptionalString for better object updates (support unsetting fields)
+body: Introduce NullableString for better object updates (support unsetting fields)
 time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Introduce OptionalString for ServiceUpdateV2(), ServiceUpdateInputV2()
+body: Introduce OptionalString for better object updates
 time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Introduce OptionalString for NewServiceUpdate(), NewServiceUpdateInput()
+time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Introduce NullableString for better object updates (support unsetting fields)
+body: Introduce NullableValue generic type (adds support for unsetting fields in update input structs)
 time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Introduce OptionalString for better object updates
+body: Introduce OptionalString for better object updates (support unsetting fields)
 time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-131311.yaml
+++ b/.changes/unreleased/Feature-20240503-131311.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Introduce OptionalString for NewServiceUpdate(), NewServiceUpdateInput()
+body: Introduce OptionalString for ServiceUpdateV2(), ServiceUpdateInputV2()
 time: 2024-05-03T13:13:11.992999-04:00

--- a/.changes/unreleased/Feature-20240503-163606.yaml
+++ b/.changes/unreleased/Feature-20240503-163606.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Fix bug where Service fields like `framework` and foreign keys like `tierAlias`
+  could not be unset, by adding ServiceUpdateInputV2
+time: 2024-05-03T16:36:06.898927-04:00

--- a/.changes/unreleased/Feature-20240503-163606.yaml
+++ b/.changes/unreleased/Feature-20240503-163606.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Fix bug where Service fields like `description`, `framework`, `language`, `lifecycleAlias`, `tierAlias` could not be unset, by adding ServiceUpdateInputV2
+body: Add ServiceUpdateInputV2 - can be used to unset fields on a service like `description`, `framework`, `lifecycleAlias`, `tierAlias`
 time: 2024-05-03T16:36:06.898927-04:00

--- a/.changes/unreleased/Feature-20240503-163606.yaml
+++ b/.changes/unreleased/Feature-20240503-163606.yaml
@@ -1,4 +1,3 @@
 kind: Feature
-body: Fix bug where Service fields like `framework` and foreign keys like `tierAlias`
-  could not be unset, by adding ServiceUpdateInputV2
+body: Fix bug where Service fields like `description`, `framework`, `language`, `lifecycleAlias`, `tierAlias` could not be unset, by adding ServiceUpdateInputV2
 time: 2024-05-03T16:36:06.898927-04:00

--- a/common.go
+++ b/common.go
@@ -31,6 +31,7 @@ type Timestamps struct {
 	UpdatedAt iso8601.Time `json:"updatedAt"`
 }
 
+// TODO: replace me with optional string
 func NullString() *string {
 	var output *string
 	return output

--- a/common.go
+++ b/common.go
@@ -31,7 +31,6 @@ type Timestamps struct {
 	UpdatedAt iso8601.Time `json:"updatedAt"`
 }
 
-// TODO: replace me with optional string
 func NullString() *string {
 	var output *string
 	return output

--- a/input.go
+++ b/input.go
@@ -864,7 +864,7 @@ type ServiceRepositoryUpdateInput struct {
 	DisplayName   *string `json:"displayName,omitempty" yaml:"displayName,omitempty" example:"example_name"`            // The name displayed in the UI for the service repository. (Optional.)
 }
 
-// ServiceUpdateInput specifies the input fields used in the `serviceUpdate` mutation.
+// DEPRECATED: use NewServiceUpdateInput
 type ServiceUpdateInput struct {
 	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
 	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)

--- a/input.go
+++ b/input.go
@@ -864,7 +864,7 @@ type ServiceRepositoryUpdateInput struct {
 	DisplayName   *string `json:"displayName,omitempty" yaml:"displayName,omitempty" example:"example_name"`            // The name displayed in the UI for the service repository. (Optional.)
 }
 
-// DEPRECATED: use NewServiceUpdateInput
+// DEPRECATED: use ServiceUpdateInputV2
 type ServiceUpdateInput struct {
 	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
 	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)

--- a/new_input.go
+++ b/new_input.go
@@ -1,5 +1,9 @@
 package opslevel
 
+// ServiceUpdater exists for backwards compatability between ServiceUpdateInput and ServiceUpdateInputV2
+type ServiceUpdater interface{}
+
+// ServiceUpdateInputV2 enables setting fields like Framework and foreign keys like TierAlias to `null`
 type ServiceUpdateInputV2 struct {
 	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
 	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)

--- a/new_input.go
+++ b/new_input.go
@@ -2,31 +2,27 @@ package opslevel
 
 // ServiceUpdater exists for backwards compatability between ServiceUpdateInput and ServiceUpdateInputV2
 type ServiceUpdater interface {
-	updatesService() bool // exists only to restrict which types qualify as a ServiceUpdater
+	updatesService() // exists only to restrict which types qualify as a ServiceUpdater
 }
 
-func (inputType ServiceUpdateInput) updatesService() bool {
-	return true
-}
+func (inputType ServiceUpdateInput) updatesService() {}
 
-func (inputType ServiceUpdateInputV2) updatesService() bool {
-	return true
-}
+func (inputType ServiceUpdateInputV2) updatesService() {}
 
-// ServiceUpdateInputV2 enables setting fields like Framework and foreign keys like TierAlias to `null`
+// ServiceUpdateInputV2 enables setting string fields like Description, Framework, LifecycleAlias, TierAlias to `null`
 type ServiceUpdateInputV2 struct {
-	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
-	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
-	Alias                 *NullableString  `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
-	Name                  *NullableString  `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
-	Product               *NullableString  `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
-	Description           *NullableString  `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
-	Language              *NullableString  `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
-	Framework             *NullableString  `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *NullableString  `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
-	OwnerInput            *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
-	LifecycleAlias        *NullableString  `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
-	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
+	Parent                *IdentifierInput       `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
+	Id                    *ID                    `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
+	Alias                 *NullableValue[string] `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
+	Name                  *NullableValue[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
+	Product               *NullableValue[string] `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
+	Description           *NullableValue[string] `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
+	Language              *NullableValue[string] `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
+	Framework             *NullableValue[string] `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
+	TierAlias             *NullableValue[string] `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	OwnerInput            *IdentifierInput       `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
+	LifecycleAlias        *NullableValue[string] `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
+	SkipAliasesValidation *bool                  `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 
 func (inputType ServiceUpdateInputV2) GetGraphQLType() string {

--- a/new_input.go
+++ b/new_input.go
@@ -1,7 +1,17 @@
 package opslevel
 
 // ServiceUpdater exists for backwards compatability between ServiceUpdateInput and ServiceUpdateInputV2
-type ServiceUpdater interface{}
+type ServiceUpdater interface {
+	updatesService() bool // exists only to restrict which types qualify as a ServiceUpdater
+}
+
+func (inputType ServiceUpdateInput) updatesService() bool {
+	return true
+}
+
+func (inputType ServiceUpdateInputV2) updatesService() bool {
+	return true
+}
 
 // ServiceUpdateInputV2 enables setting fields like Framework and foreign keys like TierAlias to `null`
 type ServiceUpdateInputV2 struct {

--- a/new_input.go
+++ b/new_input.go
@@ -14,3 +14,7 @@ type ServiceUpdateInputV2 struct {
 	LifecycleAlias        *OptionalString  `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
 	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
+
+func (inputType ServiceUpdateInputV2) GetGraphQLType() string {
+	return "ServiceUpdateInput"
+}

--- a/new_input.go
+++ b/new_input.go
@@ -1,0 +1,16 @@
+package opslevel
+
+type NewServiceUpdateInput struct {
+	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
+	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
+	Alias                 *OptionalString  `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
+	Name                  *OptionalString  `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
+	Product               *OptionalString  `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
+	Description           *OptionalString  `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
+	Language              *OptionalString  `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
+	Framework             *OptionalString  `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
+	TierAlias             *OptionalString  `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	OwnerInput            *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
+	LifecycleAlias        *OptionalString  `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
+	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
+}

--- a/new_input.go
+++ b/new_input.go
@@ -17,15 +17,15 @@ func (inputType ServiceUpdateInputV2) updatesService() bool {
 type ServiceUpdateInputV2 struct {
 	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
 	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
-	Alias                 *OptionalString  `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
-	Name                  *OptionalString  `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
-	Product               *OptionalString  `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
-	Description           *OptionalString  `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
-	Language              *OptionalString  `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
-	Framework             *OptionalString  `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *OptionalString  `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	Alias                 *NullableString  `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
+	Name                  *NullableString  `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
+	Product               *NullableString  `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
+	Description           *NullableString  `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
+	Language              *NullableString  `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
+	Framework             *NullableString  `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
+	TierAlias             *NullableString  `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
 	OwnerInput            *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
-	LifecycleAlias        *OptionalString  `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
+	LifecycleAlias        *NullableString  `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
 	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 

--- a/new_input.go
+++ b/new_input.go
@@ -1,6 +1,6 @@
 package opslevel
 
-type NewServiceUpdateInput struct {
+type ServiceUpdateInputV2 struct {
 	Parent                *IdentifierInput `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
 	Id                    *ID              `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
 	Alias                 *OptionalString  `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)

--- a/new_input.go
+++ b/new_input.go
@@ -11,18 +11,18 @@ func (inputType ServiceUpdateInputV2) updatesService() {}
 
 // ServiceUpdateInputV2 enables setting string fields like Description, Framework, LifecycleAlias, TierAlias to `null`
 type ServiceUpdateInputV2 struct {
-	Parent                *IdentifierInput       `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
-	Id                    *ID                    `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
-	Alias                 *NullableValue[string] `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
-	Name                  *NullableValue[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
-	Product               *NullableValue[string] `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
-	Description           *NullableValue[string] `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
-	Language              *NullableValue[string] `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
-	Framework             *NullableValue[string] `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *NullableValue[string] `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
-	OwnerInput            *IdentifierInput       `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
-	LifecycleAlias        *NullableValue[string] `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
-	SkipAliasesValidation *bool                  `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
+	Parent                *IdentifierInput  `json:"parent,omitempty" yaml:"parent,omitempty"`                                               // The parent system for the service. (Optional.)
+	Id                    *ID               `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the service to be updated. (Optional.)
+	Alias                 *Nullable[string] `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_alias"`                         // The alias of the service to be updated. (Optional.)
+	Name                  *Nullable[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                            // The display name of the service. (Optional.)
+	Product               *Nullable[string] `json:"product,omitempty" yaml:"product,omitempty" example:"example_product"`                   // A product is an application that your end user interacts with. Multiple services can work together to power a single product. (Optional.)
+	Description           *Nullable[string] `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
+	Language              *Nullable[string] `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
+	Framework             *Nullable[string] `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
+	TierAlias             *Nullable[string] `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	OwnerInput            *IdentifierInput  `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
+	LifecycleAlias        *Nullable[string] `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
+	SkipAliasesValidation *bool             `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 
 func (inputType ServiceUpdateInputV2) GetGraphQLType() string {

--- a/scalar.go
+++ b/scalar.go
@@ -75,25 +75,25 @@ func IsID(value string) bool {
 	return strings.HasPrefix(string(decoded), "gid://")
 }
 
-// OptionalString is implemented using a bool indicating whether the field should be unset, this is required for
+// NullableString is implemented using a bool indicating whether the field should be unset, this is required for
 // backwards compatability so that we can still differentiate between "" and nil
-type OptionalString struct {
+type NullableString struct {
 	Value   string
 	SetNull bool
 }
 
-// NewOptionalString will create an optional string provided an input string, if no input string is provided the result
+// NewNullableString will create an optional string provided an input string, if no input string is provided the result
 // will json marshal into `null`
-func NewOptionalString(input ...string) *OptionalString {
+func NewNullableString(input ...string) *NullableString {
 	if len(input) == 1 {
-		return &OptionalString{Value: input[0]}
+		return &NullableString{Value: input[0]}
 	}
-	return &OptionalString{SetNull: true}
+	return &NullableString{SetNull: true}
 }
 
-func (optionalString *OptionalString) MarshalJSON() ([]byte, error) {
-	if optionalString.SetNull {
+func (nullableString *NullableString) MarshalJSON() ([]byte, error) {
+	if nullableString.SetNull {
 		return []byte("null"), nil
 	}
-	return []byte(strconv.Quote(optionalString.Value)), nil
+	return []byte(strconv.Quote(nullableString.Value)), nil
 }

--- a/scalar.go
+++ b/scalar.go
@@ -74,3 +74,30 @@ func IsID(value string) bool {
 	}
 	return strings.HasPrefix(string(decoded), "gid://")
 }
+
+type OptionalString struct {
+	Value   string
+	SetNull bool
+}
+
+func NewNullString() *OptionalString {
+	return &OptionalString{
+		SetNull: true,
+	}
+}
+
+func NewOptionalString(input string) *OptionalString {
+	if input == "" {
+		return NewNullString()
+	}
+	return &OptionalString{
+		Value: input,
+	}
+}
+
+func (optionalString OptionalString) MarshalJSON() ([]byte, error) {
+	if optionalString.SetNull {
+		return []byte("null"), nil
+	}
+	return []byte(strconv.Quote(optionalString.Value)), nil
+}

--- a/scalar.go
+++ b/scalar.go
@@ -75,19 +75,25 @@ func IsID(value string) bool {
 	return strings.HasPrefix(string(decoded), "gid://")
 }
 
-type OptionalString string
+// OptionalString is implemented using a bool indicating whether the field should be unset, this is required for
+// backwards compatability so that we can still differentiate between "" and nil
+type OptionalString struct {
+	Value   string
+	SetNull bool
+}
 
+// NewOptionalString will create an optional string provided an input string, if no input string is provided the result
+// will json marshal into `null`
 func NewOptionalString(input ...string) *OptionalString {
-	var output OptionalString
 	if len(input) == 1 {
-		output = OptionalString(input[0])
+		return &OptionalString{Value: input[0]}
 	}
-	return &output
+	return &OptionalString{SetNull: true}
 }
 
 func (optionalString *OptionalString) MarshalJSON() ([]byte, error) {
-	if *optionalString == "" {
+	if optionalString.SetNull {
 		return []byte("null"), nil
 	}
-	return []byte(strconv.Quote(string(*optionalString))), nil
+	return []byte(strconv.Quote(optionalString.Value)), nil
 }

--- a/scalar.go
+++ b/scalar.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -75,25 +76,28 @@ func IsID(value string) bool {
 	return strings.HasPrefix(string(decoded), "gid://")
 }
 
-// NullableString is implemented using a bool indicating whether the field should be unset, this is required for
-// backwards compatability so that we can still differentiate between "" and nil
-type NullableString struct {
-	Value   string
+// NullableValue can be used to unset a value using an OpsLevel input struct type, should always be instantiated using a constructor.
+type NullableValue[T any] struct {
+	Value   T
 	SetNull bool
 }
 
-// NewNullableString will create an optional string provided an input string, if no input string is provided the result
-// will json marshal into `null`
-func NewNullableString(input ...string) *NullableString {
-	if len(input) == 1 {
-		return &NullableString{Value: input[0]}
-	}
-	return &NullableString{SetNull: true}
-}
-
-func (nullableString *NullableString) MarshalJSON() ([]byte, error) {
-	if nullableString.SetNull {
+func (nullableValue NullableValue[T]) MarshalJSON() ([]byte, error) {
+	if nullableValue.SetNull {
 		return []byte("null"), nil
 	}
-	return []byte(strconv.Quote(nullableString.Value)), nil
+	return json.Marshal(nullableValue.Value)
+}
+
+func NewNullValue[T any]() *NullableValue[T] {
+	return &NullableValue[T]{
+		SetNull: true,
+	}
+}
+
+func NewNullableValue[T any](value T, setNull bool) *NullableValue[T] {
+	return &NullableValue[T]{
+		Value:   value,
+		SetNull: setNull,
+	}
 }

--- a/scalar.go
+++ b/scalar.go
@@ -95,9 +95,9 @@ func NewNullValue[T any]() *NullableValue[T] {
 	}
 }
 
-func NewNullableValue[T any](value T, setNull bool) *NullableValue[T] {
+func NewNullableValue[T any](value T) *NullableValue[T] {
 	return &NullableValue[T]{
 		Value:   value,
-		SetNull: setNull,
+		SetNull: false,
 	}
 }

--- a/scalar.go
+++ b/scalar.go
@@ -94,13 +94,15 @@ func (nullable Nullable[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nullable.Value)
 }
 
+// NewNull returns a Nullable that will always marshal into `null`, can be used to unset fields
 func NewNull[T NullableConstraint]() *Nullable[T] {
 	return &Nullable[T]{
 		SetNull: true,
 	}
 }
 
-func NewNullableWithValue[T NullableConstraint](value T) *Nullable[T] {
+// NewNullableFrom returns a Nullable that will never marshal into `null`, can be used to change fields or even set them to an empty value (like "")
+func NewNullableFrom[T NullableConstraint](value T) *Nullable[T] {
 	return &Nullable[T]{
 		Value:   value,
 		SetNull: false,

--- a/scalar.go
+++ b/scalar.go
@@ -75,29 +75,19 @@ func IsID(value string) bool {
 	return strings.HasPrefix(string(decoded), "gid://")
 }
 
-type OptionalString struct {
-	Value   string
-	SetNull bool
+type OptionalString string
+
+func NewOptionalString(input ...string) *OptionalString {
+	var output OptionalString
+	if len(input) == 1 {
+		output = OptionalString(input[0])
+	}
+	return &output
 }
 
-func NewNullString() *OptionalString {
-	return &OptionalString{
-		SetNull: true,
-	}
-}
-
-func NewOptionalString(input string) *OptionalString {
-	if input == "" {
-		return NewNullString()
-	}
-	return &OptionalString{
-		Value: input,
-	}
-}
-
-func (optionalString OptionalString) MarshalJSON() ([]byte, error) {
-	if optionalString.SetNull {
+func (optionalString *OptionalString) MarshalJSON() ([]byte, error) {
+	if *optionalString == "" {
 		return []byte("null"), nil
 	}
-	return []byte(strconv.Quote(optionalString.Value)), nil
+	return []byte(strconv.Quote(string(*optionalString))), nil
 }

--- a/scalar.go
+++ b/scalar.go
@@ -76,27 +76,32 @@ func IsID(value string) bool {
 	return strings.HasPrefix(string(decoded), "gid://")
 }
 
-// NullableValue can be used to unset a value using an OpsLevel input struct type, should always be instantiated using a constructor.
-type NullableValue[T any] struct {
+// NullableConstraint defines what types can be nullable - keep separated using the union operator (pipe)
+type NullableConstraint interface {
+	string
+}
+
+// Nullable can be used to unset a value using an OpsLevel input struct type, should always be instantiated using a constructor.
+type Nullable[T NullableConstraint] struct {
 	Value   T
 	SetNull bool
 }
 
-func (nullableValue NullableValue[T]) MarshalJSON() ([]byte, error) {
-	if nullableValue.SetNull {
+func (nullable Nullable[T]) MarshalJSON() ([]byte, error) {
+	if nullable.SetNull {
 		return []byte("null"), nil
 	}
-	return json.Marshal(nullableValue.Value)
+	return json.Marshal(nullable.Value)
 }
 
-func NewNullValue[T any]() *NullableValue[T] {
-	return &NullableValue[T]{
+func NewNull[T NullableConstraint]() *Nullable[T] {
+	return &Nullable[T]{
 		SetNull: true,
 	}
 }
 
-func NewNullableValue[T any](value T) *NullableValue[T] {
-	return &NullableValue[T]{
+func NewNullableWithValue[T NullableConstraint](value T) *Nullable[T] {
+	return &Nullable[T]{
 		Value:   value,
 		SetNull: false,
 	}

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -269,95 +269,94 @@ func TestNewNullableValue(t *testing.T) {
 	type TestCase struct {
 		Name         string
 		Value        any
-		SetNull      bool
 		OutputBuffer string
 	}
 	testCases := []TestCase{
 		// string
 		{
 			Name:         "empty string",
-			Value:        "",
-			SetNull:      false,
+			Value:        ol.NewNullableValue(""),
 			OutputBuffer: `""`,
 		},
 		{
 			Name:         "hello world string",
-			Value:        "hello world",
-			SetNull:      false,
+			Value:        ol.NewNullableValue("hello world"),
 			OutputBuffer: `"hello world"`,
 		},
 		{
-			Name:         "non-empty string (but marked as null, value should be ignored)",
-			Value:        "hello world set me to null",
-			SetNull:      true,
+			Name: "a string but with set null",
+			Value: ol.NullableValue[string]{
+				Value:   "abc123",
+				SetNull: true,
+			},
 			OutputBuffer: `null`,
 		},
 
 		// bool
 		{
 			Name:         "bool false",
-			Value:        false,
-			SetNull:      false,
+			Value:        ol.NewNullableValue(false),
 			OutputBuffer: `false`,
 		},
 		{
 			Name:         "bool true",
-			Value:        true,
-			SetNull:      false,
+			Value:        ol.NewNullableValue(true),
 			OutputBuffer: `true`,
 		},
 		{
-			Name:         "bool true (as null)",
-			Value:        true,
-			SetNull:      true,
+			Name: "a bool but with set null",
+			Value: ol.NullableValue[bool]{
+				Value:   true,
+				SetNull: true,
+			},
 			OutputBuffer: `null`,
 		},
 
 		// int
 		{
 			Name:         "integer 0",
-			Value:        0,
-			SetNull:      false,
+			Value:        ol.NewNullableValue(0),
 			OutputBuffer: `0`,
 		},
 		{
 			Name:         "integer 16",
-			Value:        16,
-			SetNull:      false,
+			Value:        ol.NewNullableValue(16),
 			OutputBuffer: `16`,
 		},
 		{
-			Name:         "integer 32 (as null)",
-			Value:        32,
-			SetNull:      true,
+			Name: "an integer but with set null",
+			Value: ol.NullableValue[int]{
+				Value:   32,
+				SetNull: true,
+			},
 			OutputBuffer: `null`,
 		},
 
 		// iso8601.Time
 		{
 			Name:         "zero value of date",
-			Value:        iso8601.Time{},
-			SetNull:      false,
+			Value:        ol.NewNullableValue(iso8601.Time{}),
 			OutputBuffer: `"0001-01-01T00:00:00Z"`,
 		},
 		{
 			Name:         "valid date",
-			Value:        ol.NewISO8601Date("2024-05-06T14:26:19.204501-04:00"),
-			SetNull:      false,
+			Value:        ol.NewNullableValue(ol.NewISO8601Date("2024-05-06T14:26:19.204501-04:00")),
 			OutputBuffer: `"2024-05-06T14:26:19.204501-04:00"`,
 		},
 		{
-			Name:         "valid date (as null)",
-			Value:        ol.NewISO8601DateNow(),
-			SetNull:      true,
+			Name: "a date but with set null",
+			Value: ol.NullableValue[iso8601.Time]{
+				Value:   ol.NewISO8601DateNow(),
+				SetNull: true,
+			},
 			OutputBuffer: `null`,
 		},
 	}
 
 	for _, testCase := range testCases {
-		testName := fmt.Sprintf("%s with args (%+v, %t)", testCase.Name, testCase.Value, testCase.SetNull)
+		testName := fmt.Sprintf("%s with input: %+v", testCase.Name, testCase.Value)
 		t.Run(testName, func(t *testing.T) {
-			buf, err := json.Marshal(ol.NewNullableValue(testCase.Value, testCase.SetNull))
+			buf, err := json.Marshal(ol.NewNullableValue(testCase.Value))
 			if err != nil {
 				t.Errorf("got unexpected error: '%+v'", err)
 			}

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -242,12 +242,12 @@ func TestNewNullableWithValueString(t *testing.T) {
 	testCases := []TestCase{
 		{
 			Name:         "empty string using constructor",
-			Value:        ol.NewNullableWithValue(""),
+			Value:        ol.NewNullableFrom(""),
 			OutputBuffer: `""`,
 		},
 		{
 			Name:         "hello world string using constructor",
-			Value:        ol.NewNullableWithValue("hello world"),
+			Value:        ol.NewNullableFrom("hello world"),
 			OutputBuffer: `"hello world"`,
 		},
 		{

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -221,3 +221,44 @@ func TestNewIdentifierArray(t *testing.T) {
 	autopilot.Equals(t, "my-service", *result[0].Alias)
 	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }
+
+func TestOptionalString(t *testing.T) {
+	type TestCase struct {
+		Name         string
+		Input        string
+		OutputBuffer string
+	}
+	testCases := []TestCase{
+		{
+			Name:         "empty input",
+			Input:        "",
+			OutputBuffer: `null`,
+		},
+		{
+			Name:         "spaces",
+			Input:        "              ",
+			OutputBuffer: `"              "`,
+		},
+		{
+			Name:         "the string null",
+			Input:        "null",
+			OutputBuffer: `"null"`,
+		},
+		{
+			Name:         "simple hello world",
+			Input:        "hello world",
+			OutputBuffer: `"hello world"`,
+		},
+		{
+			Name:         "quoted hello world",
+			Input:        `"hello world"`,
+			OutputBuffer: `"\"hello world\""`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		buf, err := json.Marshal(ol.NewOptionalString(testCase.Input))
+		autopilot.Ok(t, err)
+		autopilot.Equals(t, testCase.OutputBuffer, string(buf))
+	}
+}

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -230,12 +230,12 @@ func TestOptionalString(t *testing.T) {
 	}
 	testCases := []TestCase{
 		{
-			Name:         "empty input",
+			Name:         "empty string",
 			Input:        "",
-			OutputBuffer: `null`,
+			OutputBuffer: `""`,
 		},
 		{
-			Name:         "spaces",
+			Name:         "spaces string",
 			Input:        "              ",
 			OutputBuffer: `"              "`,
 		},
@@ -245,12 +245,12 @@ func TestOptionalString(t *testing.T) {
 			OutputBuffer: `"null"`,
 		},
 		{
-			Name:         "simple hello world",
+			Name:         "simple hello world string",
 			Input:        "hello world",
 			OutputBuffer: `"hello world"`,
 		},
 		{
-			Name:         "quoted hello world",
+			Name:         "quoted hello world string",
 			Input:        `"hello world"`,
 			OutputBuffer: `"\"hello world\""`,
 		},
@@ -261,4 +261,9 @@ func TestOptionalString(t *testing.T) {
 		autopilot.Ok(t, err)
 		autopilot.Equals(t, testCase.OutputBuffer, string(buf))
 	}
+
+	// for when field needs to be unset
+	buf, err := json.Marshal(ol.NewOptionalString())
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, `null`, string(buf))
 }

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -222,7 +222,7 @@ func TestNewIdentifierArray(t *testing.T) {
 	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }
 
-func TestOptionalString(t *testing.T) {
+func TestNullableString(t *testing.T) {
 	type TestCase struct {
 		Name         string
 		Input        string
@@ -257,13 +257,13 @@ func TestOptionalString(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		buf, err := json.Marshal(ol.NewOptionalString(testCase.Input))
+		buf, err := json.Marshal(ol.NewNullableString(testCase.Input))
 		autopilot.Ok(t, err)
 		autopilot.Equals(t, testCase.OutputBuffer, string(buf))
 	}
 
 	// for when field needs to be unset
-	buf, err := json.Marshal(ol.NewOptionalString())
+	buf, err := json.Marshal(ol.NewNullableString())
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, `null`, string(buf))
 }

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/relvacode/iso8601"
-
 	"github.com/hasura/go-graphql-client"
 
 	ol "github.com/opslevel/opslevel-go/v2024"
@@ -225,8 +223,8 @@ func TestNewIdentifierArray(t *testing.T) {
 	autopilot.Equals(t, ol.ID("Z2lkOi8vMTIzNDU2Nzg5"), *result[1].Id)
 }
 
-func TestNullValueString(t *testing.T) {
-	buf, err := json.Marshal(ol.NewNullValue[string]())
+func TestNewNullString(t *testing.T) {
+	buf, err := json.Marshal(ol.NewNull[string]())
 	if err != nil {
 		t.Errorf("got unexpected error: '%+v'", err)
 	}
@@ -235,118 +233,27 @@ func TestNullValueString(t *testing.T) {
 	}
 }
 
-func TestNullValueBool(t *testing.T) {
-	buf, err := json.Marshal(ol.NewNullValue[bool]())
-	if err != nil {
-		t.Errorf("got unexpected error: '%+v'", err)
-	}
-	if string(buf) != "null" {
-		t.Errorf("null value on this type did not marshal to null, got: '%s'", string(buf))
-	}
-}
-
-func TestNullValueInt(t *testing.T) {
-	buf, err := json.Marshal(ol.NewNullValue[int]())
-	if err != nil {
-		t.Errorf("got unexpected error: '%+v'", err)
-	}
-	if string(buf) != "null" {
-		t.Errorf("null value on this type did not marshal to null, got: '%s'", string(buf))
-	}
-}
-
-func TestNullValueTime(t *testing.T) {
-	buf, err := json.Marshal(ol.NewNullValue[iso8601.Time]())
-	if err != nil {
-		t.Errorf("got unexpected error: '%+v'", err)
-	}
-	if string(buf) != "null" {
-		t.Errorf("null value on this type did not marshal to null, got: '%s'", string(buf))
-	}
-}
-
-func TestNewNullableValue(t *testing.T) {
+func TestNewNullableWithValueString(t *testing.T) {
 	type TestCase struct {
 		Name         string
 		Value        any
 		OutputBuffer string
 	}
 	testCases := []TestCase{
-		// string
 		{
-			Name:         "empty string",
-			Value:        ol.NewNullableValue(""),
+			Name:         "empty string using constructor",
+			Value:        ol.NewNullableWithValue(""),
 			OutputBuffer: `""`,
 		},
 		{
-			Name:         "hello world string",
-			Value:        ol.NewNullableValue("hello world"),
+			Name:         "hello world string using constructor",
+			Value:        ol.NewNullableWithValue("hello world"),
 			OutputBuffer: `"hello world"`,
 		},
 		{
-			Name: "a string but with set null",
-			Value: ol.NullableValue[string]{
+			Name: "a valid string but with set null = true",
+			Value: &ol.Nullable[string]{
 				Value:   "abc123",
-				SetNull: true,
-			},
-			OutputBuffer: `null`,
-		},
-
-		// bool
-		{
-			Name:         "bool false",
-			Value:        ol.NewNullableValue(false),
-			OutputBuffer: `false`,
-		},
-		{
-			Name:         "bool true",
-			Value:        ol.NewNullableValue(true),
-			OutputBuffer: `true`,
-		},
-		{
-			Name: "a bool but with set null",
-			Value: ol.NullableValue[bool]{
-				Value:   true,
-				SetNull: true,
-			},
-			OutputBuffer: `null`,
-		},
-
-		// int
-		{
-			Name:         "integer 0",
-			Value:        ol.NewNullableValue(0),
-			OutputBuffer: `0`,
-		},
-		{
-			Name:         "integer 16",
-			Value:        ol.NewNullableValue(16),
-			OutputBuffer: `16`,
-		},
-		{
-			Name: "an integer but with set null",
-			Value: ol.NullableValue[int]{
-				Value:   32,
-				SetNull: true,
-			},
-			OutputBuffer: `null`,
-		},
-
-		// iso8601.Time
-		{
-			Name:         "zero value of date",
-			Value:        ol.NewNullableValue(iso8601.Time{}),
-			OutputBuffer: `"0001-01-01T00:00:00Z"`,
-		},
-		{
-			Name:         "valid date",
-			Value:        ol.NewNullableValue(ol.NewISO8601Date("2024-05-06T14:26:19.204501-04:00")),
-			OutputBuffer: `"2024-05-06T14:26:19.204501-04:00"`,
-		},
-		{
-			Name: "a date but with set null",
-			Value: ol.NullableValue[iso8601.Time]{
-				Value:   ol.NewISO8601DateNow(),
 				SetNull: true,
 			},
 			OutputBuffer: `null`,
@@ -356,7 +263,7 @@ func TestNewNullableValue(t *testing.T) {
 	for _, testCase := range testCases {
 		testName := fmt.Sprintf("%s with input: %+v", testCase.Name, testCase.Value)
 		t.Run(testName, func(t *testing.T) {
-			buf, err := json.Marshal(ol.NewNullableValue(testCase.Value))
+			buf, err := json.Marshal(testCase.Value)
 			if err != nil {
 				t.Errorf("got unexpected error: '%+v'", err)
 			}

--- a/service.go
+++ b/service.go
@@ -1,7 +1,6 @@
 package opslevel
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -673,21 +672,8 @@ func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) 
 		} `graphql:"serviceUpdate(input: $input)"`
 	}
 
-	var payload PayloadVariables
-	var err error
-	inputBytes, err := json.Marshal(input)
-	err = json.Unmarshal(inputBytes, &payload)
-	fmt.Println(err)
-
-	if lifecycle, ok := payload["lifecycleAlias"]; ok && lifecycle == "" {
-		payload["lifecycleAlias"] = NullString()
-	}
-	if tier, ok := payload["tierAlias"]; ok && tier == "" {
-		payload["tierAlias"] = NullString()
-	}
-
 	v := PayloadVariables{
-		"input": payload,
+		"input": input,
 	}
 	if err := client.Mutate(&m, v, WithName("ServiceUpdate")); err != nil {
 		return nil, err

--- a/service.go
+++ b/service.go
@@ -663,7 +663,7 @@ func (client *Client) ListServicesWithTier(tier string, variables *PayloadVariab
 	return &q.Account.Services, nil
 }
 
-// DEPRECATED: use NewUpdateService
+// DEPRECATED: use UpdateServiceV2
 func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) {
 	var m struct {
 		Payload struct {
@@ -684,7 +684,7 @@ func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) 
 	return &m.Payload.Service, FormatErrors(m.Payload.Errors)
 }
 
-func (client *Client) NewUpdateService(input NewServiceUpdateInput) (*Service, error) {
+func (client *Client) UpdateServiceV2(input ServiceUpdateInputV2) (*Service, error) {
 	var m struct {
 		Payload struct {
 			Service Service

--- a/service.go
+++ b/service.go
@@ -663,31 +663,7 @@ func (client *Client) ListServicesWithTier(tier string, variables *PayloadVariab
 	return &q.Account.Services, nil
 }
 
-// DEPRECATED: use UpdateServiceV2
-// TODO: don't deprecate this
-// change the input to be an INTERFACE, so that the old input type is also valid
-// write tests to ensure backwards compat.
-func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) {
-	var m struct {
-		Payload struct {
-			Service Service
-			Errors  []OpsLevelErrors
-		} `graphql:"serviceUpdate(input: $input)"`
-	}
-
-	v := PayloadVariables{
-		"input": input,
-	}
-	if err := client.Mutate(&m, v, WithName("ServiceUpdate")); err != nil {
-		return nil, err
-	}
-	if err := m.Payload.Service.Hydrate(client); err != nil {
-		return &m.Payload.Service, err
-	}
-	return &m.Payload.Service, FormatErrors(m.Payload.Errors)
-}
-
-func (client *Client) UpdateServiceV2(input ServiceUpdateInputV2) (*Service, error) {
+func (client *Client) UpdateService(input ServiceUpdater) (*Service, error) {
 	var m struct {
 		Payload struct {
 			Service Service

--- a/service.go
+++ b/service.go
@@ -663,6 +663,7 @@ func (client *Client) ListServicesWithTier(tier string, variables *PayloadVariab
 	return &q.Account.Services, nil
 }
 
+// DEPRECATED: use NewUpdateService
 func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) {
 	var m struct {
 		Payload struct {
@@ -670,6 +671,27 @@ func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) 
 			Errors  []OpsLevelErrors
 		} `graphql:"serviceUpdate(input: $input)"`
 	}
+
+	v := PayloadVariables{
+		"input": input,
+	}
+	if err := client.Mutate(&m, v, WithName("ServiceUpdate")); err != nil {
+		return nil, err
+	}
+	if err := m.Payload.Service.Hydrate(client); err != nil {
+		return &m.Payload.Service, err
+	}
+	return &m.Payload.Service, FormatErrors(m.Payload.Errors)
+}
+
+func (client *Client) NewUpdateService(input NewServiceUpdateInput) (*Service, error) {
+	var m struct {
+		Payload struct {
+			Service Service
+			Errors  []OpsLevelErrors
+		} `graphql:"serviceUpdate(input: $input)"`
+	}
+
 	v := PayloadVariables{
 		"input": input,
 	}

--- a/service.go
+++ b/service.go
@@ -664,6 +664,9 @@ func (client *Client) ListServicesWithTier(tier string, variables *PayloadVariab
 }
 
 // DEPRECATED: use UpdateServiceV2
+// TODO: don't deprecate this
+// change the input to be an INTERFACE, so that the old input type is also valid
+// write tests to ensure backwards compat.
 func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) {
 	var m struct {
 		Payload struct {

--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -672,8 +673,21 @@ func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) 
 		} `graphql:"serviceUpdate(input: $input)"`
 	}
 
+	var payload PayloadVariables
+	var err error
+	inputBytes, err := json.Marshal(input)
+	err = json.Unmarshal(inputBytes, &payload)
+	fmt.Println(err)
+
+	if lifecycle, ok := payload["lifecycleAlias"]; ok && lifecycle == "" {
+		payload["lifecycleAlias"] = NullString()
+	}
+	if tier, ok := payload["tierAlias"]; ok && tier == "" {
+		payload["tierAlias"] = NullString()
+	}
+
 	v := PayloadVariables{
-		"input": input,
+		"input": payload,
 	}
 	if err := client.Mutate(&m, v, WithName("ServiceUpdate")); err != nil {
 		return nil, err

--- a/service_test.go
+++ b/service_test.go
@@ -294,11 +294,11 @@ func TestUpdateService(t *testing.T) {
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier("some_system"),
 				Id:             ol.NewID("123456789"),
-				Name:           ol.NewNullableValue[string]("Hello World", false),
-				Description:    ol.NewNullableValue("The quick brown fox", false),
-				Framework:      ol.NewNullableValue("django", false),
-				TierAlias:      ol.NewNullableValue("tier_4", false),
-				LifecycleAlias: ol.NewNullableValue("pre-alpha", false),
+				Name:           ol.NewNullableValue[string]("Hello World"),
+				Description:    ol.NewNullableValue("The quick brown fox"),
+				Framework:      ol.NewNullableValue("django"),
+				TierAlias:      ol.NewNullableValue("tier_4"),
+				LifecycleAlias: ol.NewNullableValue("pre-alpha"),
 			},
 		},
 
@@ -310,9 +310,9 @@ func TestUpdateService(t *testing.T) {
 				Parent:         ol.NewIdentifier(),
 				Id:             ol.NewID("123456789"),
 				Description:    ol.NewNullValue[string](),
-				Framework:      ol.NewNullableValue("framework in the request body should be null", true),
-				TierAlias:      ol.NewNullableValue("same", true),
-				LifecycleAlias: ol.NewNullableValue("", true),
+				Framework:      ol.NewNullValue[string](),
+				TierAlias:      ol.NewNullValue[string](),
+				LifecycleAlias: ol.NewNullValue[string](),
 			},
 		},
 
@@ -331,8 +331,8 @@ func TestUpdateService(t *testing.T) {
 			Vars: zeroVars,
 			Input: ol.ServiceUpdateInputV2{
 				Id:          ol.NewID("123456789"),
-				Description: ol.NewNullableValue("", false),
-				Framework:   ol.NewNullableValue("", false),
+				Description: ol.NewNullableValue(""),
+				Framework:   ol.NewNullableValue(""),
 			},
 		},
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -294,7 +294,7 @@ func TestNewUpdateService(t *testing.T) {
 	client := BestTestClient(t, "service/new_update", testRequest)
 
 	// Act
-	result, err := client.UpdateServiceV2(ol.ServiceUpdateInputV2{
+	result, err := client.UpdateService(ol.ServiceUpdateInputV2{
 		Id: ol.NewID("123456789"),
 	})
 
@@ -316,32 +316,6 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 	result, err := client.UpdateService(ol.ServiceUpdateInput{
 		Id:     ol.NewID("123456789"),
 		Parent: ol.NewIdentifier("FooSystem"),
-	})
-
-	// Assert
-	autopilot.Ok(t, err)
-	autopilot.Equals(t, "Foo", result.Name)
-}
-
-func TestNewUpdateServiceWithFields(t *testing.T) {
-	// Arrange
-	testRequest := autopilot.NewTestRequest(
-		`mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
-		`{"input":{"description": null, "id": "123456789", "language": null, "lifecycleAlias": "pre-alpha", "parent": {"alias": "FooSystem"}, "tierAlias": null}}`,
-		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
-	)
-
-	client := BestTestClient(t, "service/new_update_with_fields", testRequest)
-
-	// Act
-	result, err := client.UpdateServiceV2(ol.ServiceUpdateInputV2{
-		Description:    ol.NewOptionalString(""), // will set to an empty string -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		Framework:      nil,                      // will do nothing - not included in request body
-		Id:             ol.NewID("123456789"),
-		Language:       ol.NewOptionalString(), // will unset the field - becomes `null` in request body
-		LifecycleAlias: ol.NewOptionalString("pre-alpha"),
-		Parent:         ol.NewIdentifier("FooSystem"),
-		TierAlias:      ol.NewOptionalString(), // will unset the field - becomes `null` in request body
 	})
 
 	// Assert

--- a/service_test.go
+++ b/service_test.go
@@ -292,11 +292,11 @@ func TestUpdateService(t *testing.T) {
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier("some_system"),
 				Id:             ol.NewID("123456789"),
-				Name:           ol.NewOptionalString("Hello World"),
-				Description:    ol.NewOptionalString("The quick brown fox"),
-				Framework:      ol.NewOptionalString("django"),
-				TierAlias:      ol.NewOptionalString("tier_4"),
-				LifecycleAlias: ol.NewOptionalString("pre-alpha"),
+				Name:           ol.NewNullableString("Hello World"),
+				Description:    ol.NewNullableString("The quick brown fox"),
+				Framework:      ol.NewNullableString("django"),
+				TierAlias:      ol.NewNullableString("tier_4"),
+				LifecycleAlias: ol.NewNullableString("pre-alpha"),
 			},
 		},
 
@@ -307,10 +307,10 @@ func TestUpdateService(t *testing.T) {
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier(),
 				Id:             ol.NewID("123456789"),
-				Description:    ol.NewOptionalString(""),
-				Framework:      ol.NewOptionalString(),
-				TierAlias:      ol.NewOptionalString(),
-				LifecycleAlias: ol.NewOptionalString(),
+				Description:    ol.NewNullableString(""),
+				Framework:      ol.NewNullableString(),
+				TierAlias:      ol.NewNullableString(),
+				LifecycleAlias: ol.NewNullableString(),
 			},
 		},
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -294,11 +294,11 @@ func TestUpdateService(t *testing.T) {
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier("some_system"),
 				Id:             ol.NewID("123456789"),
-				Name:           ol.NewNullableWithValue[string]("Hello World"),
-				Description:    ol.NewNullableWithValue("The quick brown fox"),
-				Framework:      ol.NewNullableWithValue("django"),
-				TierAlias:      ol.NewNullableWithValue("tier_4"),
-				LifecycleAlias: ol.NewNullableWithValue("pre-alpha"),
+				Name:           ol.NewNullableFrom[string]("Hello World"),
+				Description:    ol.NewNullableFrom("The quick brown fox"),
+				Framework:      ol.NewNullableFrom("django"),
+				TierAlias:      ol.NewNullableFrom("tier_4"),
+				LifecycleAlias: ol.NewNullableFrom("pre-alpha"),
 			},
 		},
 
@@ -331,8 +331,8 @@ func TestUpdateService(t *testing.T) {
 			Vars: zeroVars,
 			Input: ol.ServiceUpdateInputV2{
 				Id:          ol.NewID("123456789"),
-				Description: ol.NewNullableWithValue(""),
-				Framework:   ol.NewNullableWithValue(""),
+				Description: ol.NewNullableFrom(""),
+				Framework:   ol.NewNullableFrom(""),
 			},
 		},
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -267,6 +267,7 @@ func TestCreateServiceWithParentSystem(t *testing.T) {
 func TestUpdateService(t *testing.T) {
 	addVars := `{"input":{"description": "The quick brown fox", "framework": "django", "id": "123456789", "lifecycleAlias": "pre-alpha", "name": "Hello World", "parent": {"alias": "some_system"}, "tierAlias": "tier_4"}}`
 	delVars := `{"input":{"description": null, "framework": null, "id": "123456789", "lifecycleAlias": null, "parent": null, "tierAlias": null}}`
+	delVarsV1DoesNotWorkExceptOnParent := `{"input":{"id": "123456789", "parent": null}}`
 	zeroVars := `{"input":{"description": "", "framework": "", "id": "123456789"}}`
 	type TestCase struct {
 		Name  string
@@ -274,9 +275,8 @@ func TestUpdateService(t *testing.T) {
 		Input ol.ServiceUpdater
 	}
 	testCases := []TestCase{
-		// add fields
 		{
-			Name: "add fields",
+			Name: "add fields v1",
 			Vars: addVars,
 			Input: ol.ServiceUpdateInput{
 				Parent:         ol.NewIdentifier("some_system"),
@@ -289,7 +289,7 @@ func TestUpdateService(t *testing.T) {
 			},
 		},
 		{
-			Name: "add fields (new update input)",
+			Name: "add fields v2",
 			Vars: addVars,
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier("some_system"),
@@ -301,10 +301,20 @@ func TestUpdateService(t *testing.T) {
 				LifecycleAlias: ol.NewNullableFrom("pre-alpha"),
 			},
 		},
-
-		// unsetting fields does not work properly on old update input...
 		{
-			Name: "unset fields (new update input)",
+			Name: "unset fields v1 - does not work except on parent",
+			Vars: delVarsV1DoesNotWorkExceptOnParent,
+			Input: ol.ServiceUpdateInput{
+				Parent:         ol.NewIdentifier(),
+				Id:             ol.NewID("123456789"),
+				Description:    nil,
+				Framework:      nil,
+				TierAlias:      nil,
+				LifecycleAlias: nil,
+			},
+		},
+		{
+			Name: "unset fields v2 - works on all including parent",
 			Vars: delVars,
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier(),
@@ -315,10 +325,8 @@ func TestUpdateService(t *testing.T) {
 				LifecycleAlias: ol.NewNull[string](),
 			},
 		},
-
-		// should still be able to set fields to empty string
 		{
-			Name: "zero fields",
+			Name: "set fields to zero value v1",
 			Vars: zeroVars,
 			Input: ol.ServiceUpdateInput{
 				Id:          ol.NewID("123456789"),
@@ -327,7 +335,7 @@ func TestUpdateService(t *testing.T) {
 			},
 		},
 		{
-			Name: "zero fields (new update input)",
+			Name: "set fields to zero value v2",
 			Vars: zeroVars,
 			Input: ol.ServiceUpdateInputV2{
 				Id:          ol.NewID("123456789"),

--- a/service_test.go
+++ b/service_test.go
@@ -286,7 +286,7 @@ func TestUpdateService(t *testing.T) {
 func TestNewUpdateService(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation ServiceUpdate($input:NewServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`mutation ServiceUpdate($input:ServiceUpdateInputV2!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
 		`{"input":{"id": "123456789"}}`,
 		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
 	)
@@ -294,7 +294,7 @@ func TestNewUpdateService(t *testing.T) {
 	client := BestTestClient(t, "service/new_update", testRequest)
 
 	// Act
-	result, err := client.NewUpdateService(ol.NewServiceUpdateInput{
+	result, err := client.UpdateServiceV2(ol.ServiceUpdateInputV2{
 		Id: ol.NewID("123456789"),
 	})
 
@@ -327,7 +327,7 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 func TestNewUpdateServiceWithFields(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation ServiceUpdate($input:NewServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`mutation ServiceUpdate($input:ServiceUpdateInputV2!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
 		`{"input":{"id": "123456789", "language": null, "lifecycleAlias": "pre-alpha", "parent": {"alias": "FooSystem"}, "tierAlias": null}}`,
 		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
 	)
@@ -335,7 +335,7 @@ func TestNewUpdateServiceWithFields(t *testing.T) {
 	client := BestTestClient(t, "service/new_update_with_fields", testRequest)
 
 	// Act
-	result, err := client.NewUpdateService(ol.NewServiceUpdateInput{
+	result, err := client.UpdateServiceV2(ol.ServiceUpdateInputV2{
 		Framework:      nil, // will do nothing - not included in request body
 		Id:             ol.NewID("123456789"),
 		Language:       ol.NewNullString(), // will unset the field - becomes `null` in request body

--- a/service_test.go
+++ b/service_test.go
@@ -318,7 +318,7 @@ func TestUpdateService(t *testing.T) {
 
 		// should still be able to set fields to empty string
 		{
-			Name: "zero fields (new update input)",
+			Name: "zero fields",
 			Vars: zeroVars,
 			Input: ol.ServiceUpdateInput{
 				Id:          ol.NewID("123456789"),

--- a/service_test.go
+++ b/service_test.go
@@ -283,6 +283,26 @@ func TestUpdateService(t *testing.T) {
 	autopilot.Equals(t, "Foo", result.Name)
 }
 
+func TestNewUpdateService(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation ServiceUpdate($input:NewServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`{"input":{"id": "123456789"}}`,
+		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
+	)
+
+	client := BestTestClient(t, "service/new_update", testRequest)
+
+	// Act
+	result, err := client.NewUpdateService(ol.NewServiceUpdateInput{
+		Id: ol.NewID("123456789"),
+	})
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Foo", result.Name)
+}
+
 func TestUpdateServiceWithSystem(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
@@ -297,6 +317,31 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 	result, err := client.UpdateService(ol.ServiceUpdateInput{
 		Id:     ol.NewID("123456789"),
 		Parent: ol.NewIdentifier("FooSystem"),
+	})
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Foo", result.Name)
+}
+
+func TestNewUpdateServiceWithFields(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation ServiceUpdate($input:NewServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`{"input":{"id": "123456789", "language": null, "lifecycleAlias": "pre-alpha", "parent": {"alias": "FooSystem"}, "tierAlias": null}}`,
+		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
+	)
+
+	client := BestTestClient(t, "service/new_update_with_fields", testRequest)
+
+	// Act
+	result, err := client.NewUpdateService(ol.NewServiceUpdateInput{
+		Framework:      nil, // will do nothing - not included in request body
+		Id:             ol.NewID("123456789"),
+		Language:       ol.NewNullString(), // will unset the field - becomes `null` in request body
+		LifecycleAlias: ol.NewOptionalString("pre-alpha"),
+		Parent:         ol.NewIdentifier("FooSystem"),
+		TierAlias:      ol.NewOptionalString(""), // will unset the field - becomes `null` in request body
 	})
 
 	// Assert

--- a/service_test.go
+++ b/service_test.go
@@ -324,31 +324,6 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 	autopilot.Equals(t, "Foo", result.Name)
 }
 
-func TestNewUpdateServiceTestNull(t *testing.T) {
-	// Arrange
-	testRequest := autopilot.NewTestRequest(
-		`mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
-		`{"input":{"id": "123456789", "language": "", "lifecycleAlias": null, "parent": null, "tierAlias": null}}`,
-		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
-	)
-
-	client := BestTestClient(t, "service/new_update_with_fields", testRequest)
-
-	// Act
-	result, err := client.UpdateService(ol.ServiceUpdateInput{
-		Framework:      nil, // will do nothing - not included in request body
-		Id:             ol.NewID("123456789"),
-		Language:       ol.RefOf(""),       // should be unset
-		LifecycleAlias: ol.RefOf(""),       // should be unset
-		Parent:         ol.NewIdentifier(), // should be unset
-		TierAlias:      ol.RefOf(""),       // should be unset
-	})
-
-	// Assert
-	autopilot.Ok(t, err)
-	autopilot.Equals(t, "Foo", result.Name)
-}
-
 func TestNewUpdateServiceWithFields(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(

--- a/service_test.go
+++ b/service_test.go
@@ -286,7 +286,7 @@ func TestUpdateService(t *testing.T) {
 func TestNewUpdateService(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation ServiceUpdate($input:ServiceUpdateInputV2!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
 		`{"input":{"id": "123456789"}}`,
 		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
 	)
@@ -312,7 +312,6 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 	)
 
 	client := BestTestClient(t, "service/update_with_system", testRequest)
-
 	// Act
 	result, err := client.UpdateService(ol.ServiceUpdateInput{
 		Id:     ol.NewID("123456789"),
@@ -327,8 +326,8 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 func TestNewUpdateServiceWithFields(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation ServiceUpdate($input:ServiceUpdateInputV2!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
-		`{"input":{"id": "123456789", "language": null, "lifecycleAlias": "pre-alpha", "parent": {"alias": "FooSystem"}, "tierAlias": null}}`,
+		`mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`{"input":{"description": null, "id": "123456789", "language": null, "lifecycleAlias": "pre-alpha", "parent": {"alias": "FooSystem"}, "tierAlias": null}}`,
 		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
 	)
 
@@ -336,12 +335,13 @@ func TestNewUpdateServiceWithFields(t *testing.T) {
 
 	// Act
 	result, err := client.UpdateServiceV2(ol.ServiceUpdateInputV2{
-		Framework:      nil, // will do nothing - not included in request body
+		Description:    ol.NewOptionalString(""), // will set to an empty string -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+		Framework:      nil,                      // will do nothing - not included in request body
 		Id:             ol.NewID("123456789"),
-		Language:       ol.NewNullString(), // will unset the field - becomes `null` in request body
+		Language:       ol.NewOptionalString(), // will unset the field - becomes `null` in request body
 		LifecycleAlias: ol.NewOptionalString("pre-alpha"),
 		Parent:         ol.NewIdentifier("FooSystem"),
-		TierAlias:      ol.NewOptionalString(""), // will unset the field - becomes `null` in request body
+		TierAlias:      ol.NewOptionalString(), // will unset the field - becomes `null` in request body
 	})
 
 	// Assert

--- a/service_test.go
+++ b/service_test.go
@@ -324,6 +324,31 @@ func TestUpdateServiceWithSystem(t *testing.T) {
 	autopilot.Equals(t, "Foo", result.Name)
 }
 
+func TestNewUpdateServiceTestNull(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation ServiceUpdate($input:ServiceUpdateInput!){serviceUpdate(input: $input){service{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},managedAliases,name,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }},totalCount},tags{nodes{id,key,value},{{ template "pagination_request" }},totalCount},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,url,service{id,aliases}},{{ template "pagination_request" }},totalCount}},errors{message,path}}}`,
+		`{"input":{"id": "123456789", "language": "", "lifecycleAlias": null, "parent": null, "tierAlias": null}}`,
+		`{"data": {"serviceUpdate": { "service": {{ template "service_1" }}, "errors": [] }}}`,
+	)
+
+	client := BestTestClient(t, "service/new_update_with_fields", testRequest)
+
+	// Act
+	result, err := client.UpdateService(ol.ServiceUpdateInput{
+		Framework:      nil, // will do nothing - not included in request body
+		Id:             ol.NewID("123456789"),
+		Language:       ol.RefOf(""),       // should be unset
+		LifecycleAlias: ol.RefOf(""),       // should be unset
+		Parent:         ol.NewIdentifier(), // should be unset
+		TierAlias:      ol.RefOf(""),       // should be unset
+	})
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Foo", result.Name)
+}
+
 func TestNewUpdateServiceWithFields(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(

--- a/service_test.go
+++ b/service_test.go
@@ -294,11 +294,11 @@ func TestUpdateService(t *testing.T) {
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier("some_system"),
 				Id:             ol.NewID("123456789"),
-				Name:           ol.NewNullableValue[string]("Hello World"),
-				Description:    ol.NewNullableValue("The quick brown fox"),
-				Framework:      ol.NewNullableValue("django"),
-				TierAlias:      ol.NewNullableValue("tier_4"),
-				LifecycleAlias: ol.NewNullableValue("pre-alpha"),
+				Name:           ol.NewNullableWithValue[string]("Hello World"),
+				Description:    ol.NewNullableWithValue("The quick brown fox"),
+				Framework:      ol.NewNullableWithValue("django"),
+				TierAlias:      ol.NewNullableWithValue("tier_4"),
+				LifecycleAlias: ol.NewNullableWithValue("pre-alpha"),
 			},
 		},
 
@@ -309,10 +309,10 @@ func TestUpdateService(t *testing.T) {
 			Input: ol.ServiceUpdateInputV2{
 				Parent:         ol.NewIdentifier(),
 				Id:             ol.NewID("123456789"),
-				Description:    ol.NewNullValue[string](),
-				Framework:      ol.NewNullValue[string](),
-				TierAlias:      ol.NewNullValue[string](),
-				LifecycleAlias: ol.NewNullValue[string](),
+				Description:    ol.NewNull[string](),
+				Framework:      ol.NewNull[string](),
+				TierAlias:      ol.NewNull[string](),
+				LifecycleAlias: ol.NewNull[string](),
 			},
 		},
 
@@ -331,8 +331,8 @@ func TestUpdateService(t *testing.T) {
 			Vars: zeroVars,
 			Input: ol.ServiceUpdateInputV2{
 				Id:          ol.NewID("123456789"),
-				Description: ol.NewNullableValue(""),
-				Framework:   ol.NewNullableValue(""),
+				Description: ol.NewNullableWithValue(""),
+				Framework:   ol.NewNullableWithValue(""),
 			},
 		},
 	}


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/356

### Why?

We cannot unset tier alias, lifecycle alias in services because it can't tell the difference between those attributes being set to `null` or not included (since those fields are `*string` with `omitempty`).

This uses the same pattern as in `IdentifierInput` where if ID and alias are not set, it will JSON marshal into `null`.

## Changelog

- [x] Introduce `NullableValue[T]` (and constructors)
- [x] Deprecate `ServiceUpdateInput`, add `ServiceUpdateInputV2` (they are interchangeable)
- [x] Make a `changie` entry
- [x] Add table tests for service update, covering new and old update input struct types
- [x] Add table tests for `NullableValue[T]`
- [x] Tophatting test with terraform issue
