### PR TITLE
add Alias type to match GraphQL scalar type and its behavior

### DIFF
--- a/.changes/unreleased/Feature-20240504-210301.yaml
+++ b/.changes/unreleased/Feature-20240504-210301.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add String scalar type to JSON marshal empty strings as null
+time: 2024-05-04T21:03:01.090245-05:00

--- a/.changes/unreleased/Feature-20240504-210301.yaml
+++ b/.changes/unreleased/Feature-20240504-210301.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: add String scalar type to JSON marshal empty strings as null
+body: add Alias scalar type to JSON marshal empty strings as null
 time: 2024-05-04T21:03:01.090245-05:00

--- a/input.go
+++ b/input.go
@@ -874,9 +874,9 @@ type ServiceUpdateInput struct {
 	Description           *string          `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
 	Language              *string          `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
 	Framework             *string          `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *String          `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	TierAlias             *Alias           `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
 	OwnerInput            *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
-	LifecycleAlias        *String          `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
+	LifecycleAlias        *Alias           `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
 	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 

--- a/input.go
+++ b/input.go
@@ -874,9 +874,9 @@ type ServiceUpdateInput struct {
 	Description           *string          `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
 	Language              *string          `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
 	Framework             *string          `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *string          `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	TierAlias             *String          `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
 	OwnerInput            *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
-	LifecycleAlias        *string          `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
+	LifecycleAlias        *String          `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
 	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 

--- a/scalar.go
+++ b/scalar.go
@@ -7,20 +7,20 @@ import (
 	"strings"
 )
 
-// String matches OpsLevel's GraphQL API behavior. Empty strings are JSON marshalled to null.
-type String string
+// Alias matches OpsLevel's GraphQL API behavior. Empty strings are JSON marshalled to null.
+type Alias string
 
-func NewString(value ...string) *String {
-	var output String
+func NewString(value ...string) *Alias {
+	var output Alias
 	if len(value) == 1 {
-		output = String(value[0])
+		output = Alias(value[0])
 	}
 	return &output
 }
 
-func (s String) GetGraphQLType() string { return "String" }
+func (s Alias) GetGraphQLType() string { return "String" }
 
-func (s *String) MarshalJSON() ([]byte, error) {
+func (s *Alias) MarshalJSON() ([]byte, error) {
 	if *s == "" {
 		return []byte("null"), nil
 	}

--- a/scalar.go
+++ b/scalar.go
@@ -7,6 +7,26 @@ import (
 	"strings"
 )
 
+// String matches OpsLevel's GraphQL API behavior. Empty strings are JSON marshalled to null.
+type String string
+
+func NewString(value ...string) *String {
+	var output String
+	if len(value) == 1 {
+		output = String(value[0])
+	}
+	return &output
+}
+
+func (s String) GetGraphQLType() string { return "String" }
+
+func (s *String) MarshalJSON() ([]byte, error) {
+	if *s == "" {
+		return []byte("null"), nil
+	}
+	return []byte(strconv.Quote(string(*s))), nil
+}
+
 type ID string
 
 func NewID(id ...string) *ID {


### PR DESCRIPTION
## Issues

[fix unsetting service lifecycleAlias and tierAlias fields](https://github.com/OpsLevel/team-platform/issues/356)

## Changelog

Add `String` type to match GraphQL scalar - just like we do with the `ID` scalar defined in our GraphQL schema.
`String` can replace all `string` instances if we want.

This change is in service of [this terraform provider PR](https://github.com/OpsLevel/terraform-provider-opslevel/pull/330).

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - tests pass
