### PR TITLE
add has team interface for resource structs that have an `Owner TeamId`

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -64,6 +64,17 @@ func (customActionsTriggerDefinition *CustomActionsTriggerDefinition) ExtendedTe
 	return &q.Account.CustomActionsTriggerDefinition.ExtendedTeamAccess, nil
 }
 
+func (customActionsTriggerDefinition *CustomActionsTriggerDefinition) GetTeam(client *Client) (*Team, error) {
+	if customActionsTriggerDefinition.Owner.Id == "" {
+		return nil, nil
+	}
+	return client.GetTeam(customActionsTriggerDefinition.Owner.Id)
+}
+
+func (customActionsTriggerDefinition *CustomActionsTriggerDefinition) GetTeamId() TeamId {
+	return customActionsTriggerDefinition.Owner
+}
+
 type CustomActionsExternalActionsConnection struct {
 	Nodes      []CustomActionsExternalAction
 	PageInfo   PageInfo

--- a/repository.go
+++ b/repository.go
@@ -207,6 +207,17 @@ func (repository *Repository) GetTags(client *Client, variables *PayloadVariable
 	return repository.Tags, nil
 }
 
+func (repository *Repository) GetTeam(client *Client) (*Team, error) {
+	if repository.Owner.Id == "" {
+		return nil, nil
+	}
+	return client.GetTeam(repository.Owner.Id)
+}
+
+func (repository *Repository) GetTeamId() TeamId {
+	return repository.Owner
+}
+
 func (client *Client) ConnectServiceRepository(service *ServiceId, repository *Repository) (*ServiceRepository, error) {
 	input := ServiceRepositoryCreateInput{
 		Service:       *NewIdentifier(string(service.Id)),

--- a/scalar.go
+++ b/scalar.go
@@ -60,6 +60,12 @@ func NewIdentifier(value ...string) *IdentifierInput {
 	return &output
 }
 
+// NullIdentifier returns an IdentifierInput that can be used to unset a value
+func NullIdentifier(value ...string) *IdentifierInput {
+	var output IdentifierInput
+	return &output
+}
+
 func NewIdentifierArray(values []string) []IdentifierInput {
 	output := make([]IdentifierInput, 0)
 	for _, value := range values {

--- a/secrets.go
+++ b/secrets.go
@@ -13,6 +13,17 @@ type SecretsVaultsSecretConnection struct {
 	TotalCount int `graphql:"-"`
 }
 
+func (secret *Secret) GetTeam(client *Client) (*Team, error) {
+	if secret.Owner.Id == "" {
+		return nil, nil
+	}
+	return client.GetTeam(secret.Owner.Id)
+}
+
+func (secret *Secret) GetTeamId() TeamId {
+	return secret.Owner
+}
+
 func (client *Client) CreateSecret(alias string, input SecretInput) (*Secret, error) {
 	var m struct {
 		Payload struct {

--- a/service.go
+++ b/service.go
@@ -165,6 +165,17 @@ func (service *Service) GetTags(client *Client, variables *PayloadVariables) (*T
 	return service.Tags, nil
 }
 
+func (service *Service) GetTeam(client *Client) (*Team, error) {
+	if service.Owner.Id == "" {
+		return nil, nil
+	}
+	return client.GetTeam(service.Owner.Id)
+}
+
+func (service *Service) GetTeamId() TeamId {
+	return service.Owner
+}
+
 func (service *Service) GetTools(client *Client, variables *PayloadVariables) (*ToolConnection, error) {
 	var q struct {
 		Account struct {

--- a/team.go
+++ b/team.go
@@ -21,6 +21,11 @@ type TeamId struct {
 	Id    ID
 }
 
+type HasTeam interface {
+	GetTeam(client *Client) (*Team, error)
+	GetTeamId() TeamId
+}
+
 type Team struct {
 	TeamId
 


### PR DESCRIPTION
## Issues

Part of https://github.com/OpsLevel/team-platform/issues/344 AND https://github.com/OpsLevel/terraform-provider-opslevel/pull/333

## Changelog

- [x] Add `HasTeam` interface with 2 functions across 4 resources
- [ ] Terraform tophatting
- [ ] Changie
