### PR TITLE
make Predicate in repo_search a pointer like other checks

### DIFF
--- a/.changes/unreleased/Bugfix-20240517-155327.yaml
+++ b/.changes/unreleased/Bugfix-20240517-155327.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: make FileContentsPredicate a pointer in RepositorySearchCheckFragment to allow unsetting
+time: 2024-05-17T15:53:27.468499-05:00

--- a/check_repo_search.go
+++ b/check_repo_search.go
@@ -1,8 +1,8 @@
 package opslevel
 
 type RepositorySearchCheckFragment struct {
-	FileExtensions        []string  `graphql:"fileExtensions"`
-	FileContentsPredicate Predicate `graphql:"fileContentsPredicate"`
+	FileExtensions        []string   `graphql:"fileExtensions"`
+	FileContentsPredicate *Predicate `graphql:"fileContentsPredicate"`
 }
 
 func (client *Client) CreateCheckRepositorySearch(input CheckRepositorySearchCreateInput) (*Check, error) {


### PR DESCRIPTION
## Issues

This is the only check that had a non-pointer `Predicate` in a Fragment. This caused issues in the Terraform provider.

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

`task test`
