### PR TITLE
update Predicate fields in AlertSource, RepoGrep, RepoSearch fragments

### DIFF
--- a/.changes/unreleased/Refactor-20240528-111118.yaml
+++ b/.changes/unreleased/Refactor-20240528-111118.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: BREAKING CHANGE - pointers of Predicate fields updated for AlertSourceUsageCheckFragment, RepositoryGrepCheckFragment, and RepositorySearchCheckFragment
+time: 2024-05-28T11:11:18.997688-05:00

--- a/check_alert_source_usage.go
+++ b/check_alert_source_usage.go
@@ -1,7 +1,7 @@
 package opslevel
 
 type AlertSourceUsageCheckFragment struct {
-	AlertSourceNamePredicate Predicate           `graphql:"alertSourceNamePredicate"`
+	AlertSourceNamePredicate *Predicate          `graphql:"alertSourceNamePredicate"`
 	AlertSourceType          AlertSourceTypeEnum `graphql:"alertSourceType"`
 }
 

--- a/check_repo_grep.go
+++ b/check_repo_grep.go
@@ -1,9 +1,9 @@
 package opslevel
 
 type RepositoryGrepCheckFragment struct {
-	DirectorySearch       bool       `graphql:"directorySearch"`
-	Filepaths             []string   `graphql:"filePaths"`
-	FileContentsPredicate *Predicate `graphql:"fileContentsPredicate"`
+	DirectorySearch       bool      `graphql:"directorySearch"`
+	Filepaths             []string  `graphql:"filePaths"`
+	FileContentsPredicate Predicate `graphql:"fileContentsPredicate"`
 }
 
 func (client *Client) CreateCheckRepositoryGrep(input CheckRepositoryGrepCreateInput) (*Check, error) {

--- a/check_repo_search.go
+++ b/check_repo_search.go
@@ -1,8 +1,8 @@
 package opslevel
 
 type RepositorySearchCheckFragment struct {
-	FileExtensions        []string   `graphql:"fileExtensions"`
-	FileContentsPredicate *Predicate `graphql:"fileContentsPredicate"`
+	FileExtensions        []string  `graphql:"fileExtensions"`
+	FileContentsPredicate Predicate `graphql:"fileContentsPredicate"`
 }
 
 func (client *Client) CreateCheckRepositorySearch(input CheckRepositorySearchCreateInput) (*Check, error) {


### PR DESCRIPTION
## Issues

Fixes related to [Terraform Testing](https://github.com/OpsLevel/team-platform/issues/346) work

## Changelog

Updating the Predicate fields in `AlertSourceUsageCheckFragment`, `RepositoryGrepCheckFragment`, and `RepositorySearchCheckFragment` to match what is defined in the GraphQL schema.

- [X] List your changes here
- [x] Make a `changie` entry

## Tophatting

`task test` - all tests pass
