### PR TITLE
enable unsetting predicates of type PredicateUpdateInput with custom …

### DIFF
--- a/.changes/unreleased/Bugfix-20240610-103024.yaml
+++ b/.changes/unreleased/Bugfix-20240610-103024.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: enable unsetting predicates of type PredicateUpdateInput with custom JSON marshal
+time: 2024-06-10T10:30:24.454213-05:00

--- a/check_test.go
+++ b/check_test.go
@@ -583,14 +583,13 @@ func getCheckTestCases() map[string]TmpCheckTestCase {
 		"UpdateToolUsageNullPredicates": {
 			fixture: autopilot.NewTestRequest(
 				`mutation CheckToolUsageUpdate($input:CheckToolUsageUpdateInput!){checkToolUsageUpdate(input: $input){check{category{id,name},description,enableOn,enabled,filter{id,name,connective,htmlUrl,predicates{key,keyData,type,value,caseSensitive}},id,level{alias,description,id,index,name},name,notes: rawNotes,owner{... on Team{alias,id}},type,... on AlertSourceUsageCheck{alertSourceNamePredicate{type,value},alertSourceType},... on CustomEventCheck{integration{id,name,type},passPending,resultMessage,serviceSelector,successCondition},... on HasRecentDeployCheck{days},... on ManualCheck{updateFrequency{frequencyTimeScale,frequencyValue,startingDate},updateRequiresComment},... on RepositoryFileCheck{directorySearch,filePaths,fileContentsPredicate{type,value},useAbsoluteRoot},... on RepositoryGrepCheck{directorySearch,filePaths,fileContentsPredicate{type,value}},... on RepositorySearchCheck{fileExtensions,fileContentsPredicate{type,value}},... on ServiceOwnershipCheck{requireContactMethod,contactMethod,tagKey,tagPredicate{type,value}},... on ServicePropertyCheck{serviceProperty,propertyValuePredicate{type,value}},... on TagDefinedCheck{tagKey,tagPredicate{type,value}},... on ToolUsageCheck{toolCategory,toolNamePredicate{type,value},toolUrlPredicate{type,value},environmentPredicate{type,value}},... on HasDocumentationCheck{documentType,documentSubtype}},errors{message,path}}}`,
-				`{ "input": { "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE4", {{ template "check_base_vars" }}, "toolCategory": "metrics", "toolNamePredicate": null, "toolUrlPredicate": null, "environmentPredicate": null } }`,
+				`{ "input": { "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE4", {{ template "check_base_vars" }}, "toolCategory": "metrics", "toolUrlPredicate": null, "environmentPredicate": null } }`,
 				`{ "data": { "checkToolUsageUpdate": { "check": { "category": { "id": "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjA1", "name": "Performance" }, "description": "The service is using 'datadog' as a metrics tool in the 'production' environment.", "enabled": true, "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE4", "level": { "alias": "bronze", "description": "Services in this level satisfy critical checks. This is the minimum standard to ship to production.", "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzE3", "index": 1, "name": "Bronze" }, "name": "Hello World" }, "errors": [] } } }`,
 			),
 			endpoint: "check/update_tool_usage_null_predicates",
 			body: func(c *ol.Client) (*ol.Check, error) {
 				checkToolUsageUpdateInput := ol.NewCheckUpdateInputTypeOf[ol.CheckToolUsageUpdateInput](checkUpdateInput)
 				checkToolUsageUpdateInput.ToolCategory = ol.RefOf(ol.ToolCategoryMetrics)
-				checkToolUsageUpdateInput.ToolNamePredicate = &ol.PredicateUpdateInput{}
 				checkToolUsageUpdateInput.ToolUrlPredicate = &ol.PredicateUpdateInput{}
 				checkToolUsageUpdateInput.EnvironmentPredicate = &ol.PredicateUpdateInput{}
 				return c.UpdateCheckToolUsage(*checkToolUsageUpdateInput)

--- a/check_test.go
+++ b/check_test.go
@@ -580,6 +580,22 @@ func getCheckTestCases() map[string]TmpCheckTestCase {
 				return c.UpdateCheckToolUsage(*checkToolUsageUpdateInput)
 			},
 		},
+		"UpdateToolUsageNullPredicates": {
+			fixture: autopilot.NewTestRequest(
+				`mutation CheckToolUsageUpdate($input:CheckToolUsageUpdateInput!){checkToolUsageUpdate(input: $input){check{category{id,name},description,enableOn,enabled,filter{id,name,connective,htmlUrl,predicates{key,keyData,type,value,caseSensitive}},id,level{alias,description,id,index,name},name,notes: rawNotes,owner{... on Team{alias,id}},type,... on AlertSourceUsageCheck{alertSourceNamePredicate{type,value},alertSourceType},... on CustomEventCheck{integration{id,name,type},passPending,resultMessage,serviceSelector,successCondition},... on HasRecentDeployCheck{days},... on ManualCheck{updateFrequency{frequencyTimeScale,frequencyValue,startingDate},updateRequiresComment},... on RepositoryFileCheck{directorySearch,filePaths,fileContentsPredicate{type,value},useAbsoluteRoot},... on RepositoryGrepCheck{directorySearch,filePaths,fileContentsPredicate{type,value}},... on RepositorySearchCheck{fileExtensions,fileContentsPredicate{type,value}},... on ServiceOwnershipCheck{requireContactMethod,contactMethod,tagKey,tagPredicate{type,value}},... on ServicePropertyCheck{serviceProperty,propertyValuePredicate{type,value}},... on TagDefinedCheck{tagKey,tagPredicate{type,value}},... on ToolUsageCheck{toolCategory,toolNamePredicate{type,value},toolUrlPredicate{type,value},environmentPredicate{type,value}},... on HasDocumentationCheck{documentType,documentSubtype}},errors{message,path}}}`,
+				`{ "input": { "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE4", {{ template "check_base_vars" }}, "toolCategory": "metrics", "toolNamePredicate": null, "toolUrlPredicate": null, "environmentPredicate": null } }`,
+				`{ "data": { "checkToolUsageUpdate": { "check": { "category": { "id": "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjA1", "name": "Performance" }, "description": "The service is using 'datadog' as a metrics tool in the 'production' environment.", "enabled": true, "id": "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE4", "level": { "alias": "bronze", "description": "Services in this level satisfy critical checks. This is the minimum standard to ship to production.", "id": "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzE3", "index": 1, "name": "Bronze" }, "name": "Hello World" }, "errors": [] } } }`,
+			),
+			endpoint: "check/update_tool_usage_null_predicates",
+			body: func(c *ol.Client) (*ol.Check, error) {
+				checkToolUsageUpdateInput := ol.NewCheckUpdateInputTypeOf[ol.CheckToolUsageUpdateInput](checkUpdateInput)
+				checkToolUsageUpdateInput.ToolCategory = ol.RefOf(ol.ToolCategoryMetrics)
+				checkToolUsageUpdateInput.ToolNamePredicate = &ol.PredicateUpdateInput{}
+				checkToolUsageUpdateInput.ToolUrlPredicate = &ol.PredicateUpdateInput{}
+				checkToolUsageUpdateInput.EnvironmentPredicate = &ol.PredicateUpdateInput{}
+				return c.UpdateCheckToolUsage(*checkToolUsageUpdateInput)
+			},
+		},
 		"GetCheck": {
 			fixture: autopilot.NewTestRequest(
 				`query CheckGet($id:ID!){account{check(id: $id){category{id,name},description,enableOn,enabled,filter{id,name,connective,htmlUrl,predicates{key,keyData,type,value,caseSensitive}},id,level{alias,description,id,index,name},name,notes: rawNotes,owner{... on Team{alias,id}},type,... on AlertSourceUsageCheck{alertSourceNamePredicate{type,value},alertSourceType},... on CustomEventCheck{integration{id,name,type},passPending,resultMessage,serviceSelector,successCondition},... on HasRecentDeployCheck{days},... on ManualCheck{updateFrequency{frequencyTimeScale,frequencyValue,startingDate},updateRequiresComment},... on RepositoryFileCheck{directorySearch,filePaths,fileContentsPredicate{type,value},useAbsoluteRoot},... on RepositoryGrepCheck{directorySearch,filePaths,fileContentsPredicate{type,value}},... on RepositorySearchCheck{fileExtensions,fileContentsPredicate{type,value}},... on ServiceOwnershipCheck{requireContactMethod,contactMethod,tagKey,tagPredicate{type,value}},... on ServicePropertyCheck{serviceProperty,propertyValuePredicate{type,value}},... on TagDefinedCheck{tagKey,tagPredicate{type,value}},... on ToolUsageCheck{toolCategory,toolNamePredicate{type,value},toolUrlPredicate{type,value},environmentPredicate{type,value}},... on HasDocumentationCheck{documentType,documentSubtype}}}}`,

--- a/predicate.go
+++ b/predicate.go
@@ -26,3 +26,16 @@ func (p *Predicate) Validate() error {
 	}
 	return nil
 }
+
+func (p *PredicateUpdateInput) MarshalJSON() ([]byte, error) {
+	if p == nil || p.Type == nil || *p.Type == "" {
+		return []byte("null"), nil
+	}
+	var predicateAsJson string
+	if p.Value == nil {
+		predicateAsJson = fmt.Sprintf(`{"type": "%s"}`, *p.Type)
+	} else {
+		predicateAsJson = fmt.Sprintf(`{"type": "%s", "value": "%s"}`, *p.Type, *p.Value)
+	}
+	return []byte(predicateAsJson), nil
+}

--- a/predicate.go
+++ b/predicate.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 )
@@ -31,11 +32,13 @@ func (p *PredicateUpdateInput) MarshalJSON() ([]byte, error) {
 	if p == nil || p.Type == nil || *p.Type == "" {
 		return []byte("null"), nil
 	}
-	var predicateAsJson string
-	if p.Value == nil {
-		predicateAsJson = fmt.Sprintf(`{"type":"%s"}`, *p.Type)
-	} else {
-		predicateAsJson = fmt.Sprintf(`{"type":"%s","value":"%s"}`, *p.Type, *p.Value)
+	m := map[string]string{
+		"type": string(*p.Type),
 	}
-	return []byte(predicateAsJson), nil
+
+	if p.Value != nil {
+		m["value"] = *p.Value
+	}
+
+	return json.Marshal(m)
 }

--- a/predicate.go
+++ b/predicate.go
@@ -33,9 +33,9 @@ func (p *PredicateUpdateInput) MarshalJSON() ([]byte, error) {
 	}
 	var predicateAsJson string
 	if p.Value == nil {
-		predicateAsJson = fmt.Sprintf(`{"type": "%s"}`, *p.Type)
+		predicateAsJson = fmt.Sprintf(`{"type":"%s"}`, *p.Type)
 	} else {
-		predicateAsJson = fmt.Sprintf(`{"type": "%s", "value": "%s"}`, *p.Type, *p.Value)
+		predicateAsJson = fmt.Sprintf(`{"type":"%s","value":"%s"}`, *p.Type, *p.Value)
 	}
 	return []byte(predicateAsJson), nil
 }

--- a/predicate_test.go
+++ b/predicate_test.go
@@ -1,0 +1,45 @@
+package opslevel_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	ol "github.com/opslevel/opslevel-go/v2024"
+	"github.com/rocktavious/autopilot/v2023"
+)
+
+func TestJsonMarshalPredicateUpdateInputNull(t *testing.T) {
+	// Arrange
+	predicateNull := "null"
+	outputNull := &ol.PredicateUpdateInput{}
+	// Act
+	marshalledNullPredicate, err := json.Marshal(outputNull)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, predicateNull, string(marshalledNullPredicate))
+}
+
+func TestJsonMarshalPredicateUpdateInputNoValue(t *testing.T) {
+	// Arrange
+	predicateNoValue := `{"type":"exists"}`
+	outputNoValue := &ol.PredicateUpdateInput{
+		Type: ol.RefOf(ol.PredicateTypeEnum("exists")),
+	}
+	// Act
+	marshalledNullPredicate, err := json.Marshal(outputNoValue)
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, predicateNoValue, string(marshalledNullPredicate))
+}
+
+func TestJsonMarshalPredicateUpdateInputWithValue(t *testing.T) {
+	// Arrange
+	predicateWithValue := `{"type":"contains","value":"go"}`
+	outputWithValue := &ol.PredicateUpdateInput{
+		Type:  ol.RefOf(ol.PredicateTypeEnum("contains")),
+		Value: ol.RefOf("go"),
+	}
+	// Act
+	marshalledNullPredicate, err := json.Marshal(outputWithValue)
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, predicateWithValue, string(marshalledNullPredicate))
+}


### PR DESCRIPTION
## Issues

Change needed for [Terraform provider fix](https://github.com/OpsLevel/terraform-provider-opslevel/pull/367)

## Changelog

Add `MarshalJSON()` to `PredicateUpdateInput` to enable unsetting predicates during update operations.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test` - tests pass
