### PR TITLE
fix validation for filter predicate

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -35,7 +35,9 @@ func (filterPredicate *FilterPredicate) Validate() error {
 		PredicateTypeEnumEndsWith,
 		PredicateTypeEnumStartsWith,
 	}
-	if filterPredicate.CaseSensitive != nil && !slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
+	if filterPredicate.CaseSensitive != nil &&
+		*filterPredicate.CaseSensitive &&
+		!slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
 		return fmt.Errorf("FilterPredicate type '%s' cannot have CaseSensitive value set.", filterPredicate.Type)
 	}
 	return nil


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Enforce `filterPredicate.Type` is a `caseSensitiveTypes` only when `filterPredicate.CaseSensitive` is true

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
