### PR TITLE
Db/update filter predicate validation

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -43,9 +43,7 @@ func (filterPredicate *FilterPredicate) Validate() error {
 		PredicateTypeEnumEndsWith,
 		PredicateTypeEnumStartsWith,
 	}
-	if filterPredicate.CaseSensitive != nil &&
-		*filterPredicate.CaseSensitive &&
-		!slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
+	if filterPredicate.CaseSensitive != nil && !slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
 		return fmt.Errorf("FilterPredicate type '%s' cannot have CaseSensitive value set.", filterPredicate.Type)
 	}
 

--- a/filters.go
+++ b/filters.go
@@ -3,6 +3,7 @@ package opslevel
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	"github.com/gosimple/slug"
 )
@@ -40,6 +41,17 @@ func (filterPredicate *FilterPredicate) Validate() error {
 		!slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
 		return fmt.Errorf("FilterPredicate type '%s' cannot have CaseSensitive value set.", filterPredicate.Type)
 	}
+
+	numericTypes := []PredicateTypeEnum{
+		PredicateTypeEnumGreaterThanOrEqualTo,
+		PredicateTypeEnumLessThanOrEqualTo,
+	}
+	if slices.Contains(numericTypes, filterPredicate.Type) {
+		if _, err := strconv.Atoi(filterPredicate.Value); err != nil {
+			return fmt.Errorf("FilterPredicate type '%s' requires a numeric value. Given '%s'", filterPredicate.Type, filterPredicate.Value)
+		}
+	}
+
 	return nil
 }
 

--- a/filters.go
+++ b/filters.go
@@ -35,7 +35,9 @@ func (filterPredicate *FilterPredicate) Validate() error {
 		PredicateTypeEnumEndsWith,
 		PredicateTypeEnumStartsWith,
 	}
-	if filterPredicate.CaseSensitive != nil && !slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
+	if filterPredicate.CaseSensitive != nil &&
+		*filterPredicate.CaseSensitive &&
+		!slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
 		return fmt.Errorf("FilterPredicate type '%s' cannot have CaseSensitive value set.", filterPredicate.Type)
 	}
 	return nil

--- a/filters.go
+++ b/filters.go
@@ -3,7 +3,6 @@ package opslevel
 import (
 	"fmt"
 	"slices"
-	"strconv"
 
 	"github.com/gosimple/slug"
 )
@@ -29,9 +28,17 @@ type FilterPredicate struct {
 }
 
 func (filterPredicate *FilterPredicate) Validate() error {
+	// validation common to Predicate and FilterPredicate types
+	basicPredicate := Predicate{Type: filterPredicate.Type, Value: filterPredicate.Value}
+	if err := basicPredicate.Validate(); err != nil {
+		return err
+	}
+
+	// validation specific to FilterPredicate types
 	caseSensitiveTypes := []PredicateTypeEnum{
 		PredicateTypeEnumContains,
 		PredicateTypeEnumDoesNotContain,
+		PredicateTypeEnumDoesNotEqual,
 		PredicateTypeEnumEquals,
 		PredicateTypeEnumEndsWith,
 		PredicateTypeEnumStartsWith,
@@ -40,16 +47,6 @@ func (filterPredicate *FilterPredicate) Validate() error {
 		*filterPredicate.CaseSensitive &&
 		!slices.Contains(caseSensitiveTypes, filterPredicate.Type) {
 		return fmt.Errorf("FilterPredicate type '%s' cannot have CaseSensitive value set.", filterPredicate.Type)
-	}
-
-	numericTypes := []PredicateTypeEnum{
-		PredicateTypeEnumGreaterThanOrEqualTo,
-		PredicateTypeEnumLessThanOrEqualTo,
-	}
-	if slices.Contains(numericTypes, filterPredicate.Type) {
-		if _, err := strconv.Atoi(filterPredicate.Value); err != nil {
-			return fmt.Errorf("FilterPredicate type '%s' requires a numeric value. Given '%s'", filterPredicate.Type, filterPredicate.Value)
-		}
 	}
 
 	return nil

--- a/predicate.go
+++ b/predicate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 )
 
 type Predicate struct {
@@ -12,10 +13,6 @@ type Predicate struct {
 }
 
 func (p *Predicate) Validate() error {
-	if !slices.Contains(AllPredicateTypeEnum, string(p.Type)) {
-		return fmt.Errorf("Invalidate Predicate type '%s'. Expected one of '%v'", p.Type, AllPredicateTypeEnum)
-	}
-
 	predicatesWithNoValue := []PredicateTypeEnum{
 		PredicateTypeEnumDoesNotExist,
 		PredicateTypeEnumExists,
@@ -25,6 +22,17 @@ func (p *Predicate) Validate() error {
 	} else if !slices.Contains(predicatesWithNoValue, p.Type) && p.Value == "" {
 		return fmt.Errorf("Predicate type '%s' requires a value", p.Type)
 	}
+
+	numericTypes := []PredicateTypeEnum{
+		PredicateTypeEnumGreaterThanOrEqualTo,
+		PredicateTypeEnumLessThanOrEqualTo,
+	}
+	if slices.Contains(numericTypes, p.Type) {
+		if _, err := strconv.Atoi(p.Value); err != nil {
+			return fmt.Errorf("FilterPredicate type '%s' requires a numeric value. Given '%s'", p.Type, p.Value)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

For filter predicates of type `greater_than_or_equal_to` and `less_than_or_equal_to`, verify the predicate value is a number

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
