### PR TITLE
Db/update reconcile aliases funcs

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -34,8 +34,10 @@ func (d *Domain) ReconcileAliases(client *Client, aliasesWanted []string) error 
 
 	// update domain to reflect API updates
 	updatedDomain, getErr := client.GetDomain(string(d.Id))
-	d.Aliases = updatedDomain.Aliases
-	d.ManagedAliases = updatedDomain.ManagedAliases
+	if updatedDomain != nil {
+		d.Aliases = updatedDomain.Aliases
+		d.ManagedAliases = updatedDomain.ManagedAliases
+	}
 
 	return errors.Join(deleteErr, createErr, getErr)
 }

--- a/domain.go
+++ b/domain.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 )
@@ -25,27 +26,18 @@ type DomainConnection struct {
 }
 
 func (d *Domain) ReconcileAliases(client *Client, aliasesWanted []string) error {
-	var err error
+	aliasesToCreate, aliasesToDelete := extractAliases(d.Aliases, aliasesWanted)
 
-	aliasesToCreate, aliasesToDelete := extractAliases(d.ManagedAliases, aliasesWanted)
-	if err := client.DeleteAliases(AliasOwnerTypeEnumDomain, aliasesToDelete); err != nil {
-		return err
-	}
+	// reconcile wanted aliases with actual aliases
+	deleteErr := client.DeleteAliases(AliasOwnerTypeEnumDomain, aliasesToDelete)
+	_, createErr := client.CreateAliases(d.Id, aliasesToCreate)
 
-	// Update this domain's aliases
-	if len(aliasesToCreate) > 0 {
-		// Creating an alias retrieves the latest slice of aliases from the API
-		// This accounts for any aliases deleted above as well
-		d.ManagedAliases, err = client.CreateAliases(d.Id, aliasesToCreate)
-	} else {
-		// If no aliases are created but aliases may have been deleted,
-		// update this Domain struct's aliases by hand
-		d.ManagedAliases = slices.DeleteFunc(d.ManagedAliases, func(value string) bool {
-			return slices.Contains(aliasesToDelete, value)
-		})
-	}
+	// update domain to reflect API updates
+	updatedDomain, getErr := client.GetDomain(string(d.Id))
+	d.Aliases = updatedDomain.Aliases
+	d.ManagedAliases = updatedDomain.ManagedAliases
 
-	return err
+	return errors.Join(deleteErr, createErr, getErr)
 }
 
 func (domainId *DomainId) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {

--- a/infra.go
+++ b/infra.go
@@ -65,7 +65,9 @@ func (infrastructureResource *InfrastructureResource) ReconcileAliases(client *C
 
 	// update infrastructureResource to reflect API updates
 	updatedInfra, getErr := client.GetInfrastructure(infrastructureResource.Id)
-	infrastructureResource.Aliases = updatedInfra.Aliases
+	if updatedInfra != nil {
+		infrastructureResource.Aliases = updatedInfra.Aliases
+	}
 
 	return errors.Join(deleteErr, createErr, getErr)
 }

--- a/infra.go
+++ b/infra.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 )
@@ -56,27 +57,17 @@ type InfraInput struct {
 }
 
 func (infrastructureResource *InfrastructureResource) ReconcileAliases(client *Client, aliasesWanted []string) error {
-	var err error
-
 	aliasesToCreate, aliasesToDelete := extractAliases(infrastructureResource.Aliases, aliasesWanted)
-	if err := client.DeleteAliases(AliasOwnerTypeEnumInfrastructureResource, aliasesToDelete); err != nil {
-		return err
-	}
 
-	// Update this infrastructureResource's aliases
-	if len(aliasesToCreate) > 0 {
-		// Creating an alias retrieves the latest slice of aliases from the API
-		// This accounts for any aliases deleted above as well
-		infrastructureResource.Aliases, err = client.CreateAliases(ID(infrastructureResource.Id), aliasesToCreate)
-	} else {
-		// If no aliases are created but aliases may have been deleted,
-		// update this infrastructureResource struct's aliases by hand
-		infrastructureResource.Aliases = slices.DeleteFunc(infrastructureResource.Aliases, func(value string) bool {
-			return slices.Contains(aliasesToDelete, value)
-		})
-	}
+	// reconcile wanted aliases with actual aliases
+	deleteErr := client.DeleteAliases(AliasOwnerTypeEnumInfrastructureResource, aliasesToDelete)
+	_, createErr := client.CreateAliases(ID(infrastructureResource.Id), aliasesToCreate)
 
-	return err
+	// update infrastructureResource to reflect API updates
+	updatedInfra, getErr := client.GetInfrastructure(infrastructureResource.Id)
+	infrastructureResource.Aliases = updatedInfra.Aliases
+
+	return errors.Join(deleteErr, createErr, getErr)
 }
 
 func (infrastructureResource *InfrastructureResource) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {

--- a/infra_test.go
+++ b/infra_test.go
@@ -259,7 +259,13 @@ func TestInfraReconcileAliasesDeleteAll(t *testing.T) {
 		`{"input":{ "alias": "two", "ownerType": "infrastructure_resource" }}`,
 		`{"data": { "aliasDelete": {"errors": [] }}}`,
 	)
-	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
+	// get infrastructureResource
+	testRequestThree := autopilot.NewTestRequest(
+		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
+		`{"all": true, "input":{ {{ template "id1" }} }}`,
+		`{"data": { "account": { "infrastructureResource": { {{ template "id1" }}, "aliases": [] } }}}`,
+	)
+	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo, testRequestThree}
 	client := BestTestClient(t, "infra/reconcile_aliases_delete_all", requests...)
 
 	// Act
@@ -302,7 +308,13 @@ func TestInfraReconcileAliases(t *testing.T) {
 		`{"input":{ "alias": "three", "ownerId": "{{ template "id1_string" }}" }}`,
 		`{"data": { "aliasCreate": { "aliases": [ "one", "two", "three" ], "ownerId": "{{ template "id1_string" }}", "errors": [] }}}`,
 	)
-	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo, testRequestThree, testRequestFour}
+	// get infrastructureResource
+	testRequestFive := autopilot.NewTestRequest(
+		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
+		`{"all": true, "input":{ {{ template "id1" }} }}`,
+		`{"data": { "account": { "infrastructureResource": { {{ template "id1" }}, "aliases": ["one", "two", "three"] } }}}`,
+	)
+	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo, testRequestThree, testRequestFour, testRequestFive}
 	client := BestTestClient(t, "infra/reconcile_aliases", requests...)
 
 	// Act

--- a/scorecards.go
+++ b/scorecards.go
@@ -3,7 +3,6 @@ package opslevel
 import (
 	"errors"
 	"fmt"
-	"slices"
 )
 
 type ScorecardId struct {
@@ -37,29 +36,17 @@ type ScorecardCategoryConnection struct {
 }
 
 func (scorecard *ScorecardId) ReconcileAliases(client *Client, aliasesWanted []string) error {
-	var allErrors, err error
-
 	aliasesToCreate, aliasesToDelete := extractAliases(scorecard.Aliases, aliasesWanted)
-	allErrors = client.DeleteAliases(AliasOwnerTypeEnumScorecard, aliasesToDelete)
-	if allErrors != nil {
-		return allErrors
-	}
 
-	// Update this scorecard's aliases
-	if len(aliasesToCreate) > 0 {
-		// Creating an alias retrieves the latest slice of aliases from the API
-		// This accounts for any aliases deleted above as well
-		scorecard.Aliases, err = client.CreateAliases(scorecard.Id, aliasesToCreate)
-		allErrors = errors.Join(allErrors, err)
-	} else {
-		// If no aliases are created but aliases may have been deleted,
-		// update this Scorecard struct's aliases by hand
-		scorecard.Aliases = slices.DeleteFunc(scorecard.Aliases, func(value string) bool {
-			return slices.Contains(aliasesToDelete, value)
-		})
-	}
+	// reconcile wanted aliases with actual aliases
+	deleteErr := client.DeleteAliases(AliasOwnerTypeEnumScorecard, aliasesToDelete)
+	_, createErr := client.CreateAliases(scorecard.Id, aliasesToCreate)
 
-	return allErrors
+	// update scorecard to reflect API updates
+	updatedScorecard, getErr := client.GetScorecard(string(scorecard.Id))
+	scorecard.Aliases = updatedScorecard.Aliases
+
+	return errors.Join(deleteErr, createErr, getErr)
 }
 
 func (scorecard *Scorecard) ListCategories(client *Client, variables *PayloadVariables) (*ScorecardCategoryConnection, error) {

--- a/scorecards.go
+++ b/scorecards.go
@@ -44,7 +44,9 @@ func (scorecard *ScorecardId) ReconcileAliases(client *Client, aliasesWanted []s
 
 	// update scorecard to reflect API updates
 	updatedScorecard, getErr := client.GetScorecard(string(scorecard.Id))
-	scorecard.Aliases = updatedScorecard.Aliases
+	if updatedScorecard != nil {
+		scorecard.Aliases = updatedScorecard.Aliases
+	}
 
 	return errors.Join(deleteErr, createErr, getErr)
 }

--- a/scorecards_test.go
+++ b/scorecards_test.go
@@ -217,7 +217,13 @@ func TestScorecardReconcileAliasesDeleteAll(t *testing.T) {
 		`{"input":{ "alias": "two", "ownerType": "scorecard" }}`,
 		`{"data": { "aliasDelete": {"errors": [] }}}`,
 	)
-	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
+	// get service
+	testRequestThree := autopilot.NewTestRequest(
+		`{{ template "scorecard_get_request" }}`,
+		`{"input": { {{ template "id1" }} }}`,
+		`{ "data": { "account": { "scorecard": { {{ template "id1" }}, "aliases": [] }}}}`,
+	)
+	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo, testRequestThree}
 	client := BestTestClient(t, "scorecard/reconcile_aliases_delete_all", requests...)
 
 	// Act
@@ -260,7 +266,13 @@ func TestScorecardReconcileAliases(t *testing.T) {
 		`{"input":{ "alias": "three", "ownerId": "{{ template "id1_string" }}" }}`,
 		`{"data": { "aliasCreate": { "aliases": [ "one", "two", "three" ], "ownerId": "{{ template "id1_string" }}", "errors": [] }}}`,
 	)
-	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo, testRequestThree, testRequestFour}
+	// get service
+	testRequestFive := autopilot.NewTestRequest(
+		`{{ template "scorecard_get_request" }}`,
+		`{"input": { {{ template "id1" }} }}`,
+		`{ "data": { "account": { "scorecard": { {{ template "id1" }}, "aliases": ["one", "two", "three"] }}}}`,
+	)
+	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo, testRequestThree, testRequestFour, testRequestFive}
 	client := BestTestClient(t, "scorecard/reconcile_aliases", requests...)
 
 	// Act

--- a/service.go
+++ b/service.go
@@ -62,8 +62,10 @@ func (service *Service) ReconcileAliases(client *Client, aliasesWanted []string)
 
 	// update service to reflect API updates
 	updatedService, getErr := client.GetService(service.Id)
-	service.Aliases = updatedService.Aliases
-	service.ManagedAliases = updatedService.ManagedAliases
+	if updatedService != nil {
+		service.Aliases = updatedService.Aliases
+		service.ManagedAliases = updatedService.ManagedAliases
+	}
 
 	return errors.Join(deleteErr, createErr, getErr)
 }

--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -53,27 +54,18 @@ type ServiceDocumentsConnection struct {
 }
 
 func (service *Service) ReconcileAliases(client *Client, aliasesWanted []string) error {
-	var err error
+	aliasesToCreate, aliasesToDelete := extractAliases(service.Aliases, aliasesWanted)
 
-	aliasesToCreate, aliasesToDelete := extractAliases(service.ManagedAliases, aliasesWanted)
-	if err := client.DeleteAliases(AliasOwnerTypeEnumService, aliasesToDelete); err != nil {
-		return err
-	}
+	// reconcile wanted aliases with actual aliases
+	deleteErr := client.DeleteAliases(AliasOwnerTypeEnumService, aliasesToDelete)
+	_, createErr := client.CreateAliases(service.Id, aliasesToCreate)
 
-	// Update this service's aliases
-	if len(aliasesToCreate) > 0 {
-		// Creating an alias retrieves the latest slice of aliases from the API
-		// This accounts for any aliases deleted above as well
-		service.ManagedAliases, err = client.CreateAliases(service.Id, aliasesToCreate)
-	} else {
-		// If no aliases are created but aliases may have been deleted,
-		// update this Service struct's aliases by hand
-		service.ManagedAliases = slices.DeleteFunc(service.ManagedAliases, func(value string) bool {
-			return slices.Contains(aliasesToDelete, value)
-		})
-	}
+	// update service to reflect API updates
+	updatedService, getErr := client.GetService(service.Id)
+	service.Aliases = updatedService.Aliases
+	service.ManagedAliases = updatedService.ManagedAliases
 
-	return err
+	return errors.Join(deleteErr, createErr, getErr)
 }
 
 func (service *Service) ResourceId() ID {

--- a/system.go
+++ b/system.go
@@ -78,7 +78,9 @@ func (system *SystemId) ReconcileAliases(client *Client, aliasesWanted []string)
 
 	// update system to reflect API updates
 	updatedSystem, getErr := client.GetSystem(string(system.Id))
-	system.Aliases = updatedSystem.Aliases
+	if updatedSystem != nil {
+		system.Aliases = updatedSystem.Aliases
+	}
 
 	return errors.Join(deleteErr, createErr, getErr)
 }

--- a/team.go
+++ b/team.go
@@ -72,8 +72,10 @@ func (team *Team) ReconcileAliases(client *Client, aliasesWanted []string) error
 
 	// update team to reflect API updates
 	updatedTeam, getErr := client.GetTeam(team.Id)
-	team.Aliases = updatedTeam.Aliases
-	team.ManagedAliases = updatedTeam.ManagedAliases
+	if updatedTeam != nil {
+		team.Aliases = updatedTeam.Aliases
+		team.ManagedAliases = updatedTeam.ManagedAliases
+	}
 
 	return errors.Join(deleteErr, createErr, getErr)
 }

--- a/team.go
+++ b/team.go
@@ -1,6 +1,7 @@
 package opslevel
 
 import (
+	"errors"
 	"fmt"
 	"html"
 	"slices"
@@ -63,27 +64,18 @@ type TeamMembershipConnection struct {
 }
 
 func (team *Team) ReconcileAliases(client *Client, aliasesWanted []string) error {
-	var err error
-
 	aliasesToCreate, aliasesToDelete := extractAliases(team.ManagedAliases, aliasesWanted)
-	if err := client.DeleteAliases(AliasOwnerTypeEnumTeam, aliasesToDelete); err != nil {
-		return err
-	}
 
-	// Update this team's aliases
-	if len(aliasesToCreate) > 0 {
-		// Creating an alias retrieves the latest slice of aliases from the API
-		// This accounts for any aliases deleted above as well
-		team.ManagedAliases, err = client.CreateAliases(team.Id, aliasesToCreate)
-	} else {
-		// If no aliases are created but aliases may have been deleted,
-		// update this Team struct's aliases by hand
-		team.ManagedAliases = slices.DeleteFunc(team.ManagedAliases, func(value string) bool {
-			return slices.Contains(aliasesToDelete, value)
-		})
-	}
+	// reconcile wanted aliases with actual aliases
+	deleteErr := client.DeleteAliases(AliasOwnerTypeEnumTeam, aliasesToDelete)
+	_, createErr := client.CreateAliases(team.Id, aliasesToCreate)
 
-	return err
+	// update team to reflect API updates
+	updatedTeam, getErr := client.GetTeam(team.Id)
+	team.Aliases = updatedTeam.Aliases
+	team.ManagedAliases = updatedTeam.ManagedAliases
+
+	return errors.Join(deleteErr, createErr, getErr)
 }
 
 func (team *Team) ResourceId() ID {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Update ReconcileAliases functions:
- Added GetResource() calls to ReconcileAliases(). Result is used to update `<resource>.Aliases` and `<resource>.ManagedAliases` if applicable
- Errors are batched together and returned at end of function 

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

`task test`
