### PR TITLE
patch team ReconcileAliases to use Aliases, not ManagedAliases

### DIFF
--- a/team.go
+++ b/team.go
@@ -64,7 +64,7 @@ type TeamMembershipConnection struct {
 }
 
 func (team *Team) ReconcileAliases(client *Client, aliasesWanted []string) error {
-	aliasesToCreate, aliasesToDelete := extractAliases(team.ManagedAliases, aliasesWanted)
+	aliasesToCreate, aliasesToDelete := extractAliases(team.Aliases, aliasesWanted)
 
 	// reconcile wanted aliases with actual aliases
 	deleteErr := client.DeleteAliases(AliasOwnerTypeEnumTeam, aliasesToDelete)


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

In `ReconcileAliases()` in `team.go` - `team.ManagedAliases` needs to be `team.Aliases`

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

`task test`
