### PR TITLE
add UniqueIdentifiers utility function to Domain, Service, and Team

### DIFF
--- a/.changes/unreleased/Feature-20240627-213556.yaml
+++ b/.changes/unreleased/Feature-20240627-213556.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add GetUniqueIdentifiers utility function to Domain, Service, and Team
+time: 2024-06-27T21:35:56.668062-05:00

--- a/.changes/unreleased/Feature-20240627-213556.yaml
+++ b/.changes/unreleased/Feature-20240627-213556.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: add GetUniqueIdentifiers utility function to Domain, Service, and Team
+body: add UniqueIdentifiers utility function to Domain, Service, and Team
 time: 2024-06-27T21:35:56.668062-05:00

--- a/domain.go
+++ b/domain.go
@@ -26,7 +26,7 @@ type DomainConnection struct {
 }
 
 // Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
-func (d *Domain) GetUniqueIdentifiers() []string {
+func (d *Domain) UniqueIdentifiers() []string {
 	uniqueIdentifiers := []string{}
 	for _, alias := range d.Aliases {
 		if !slices.Contains(d.ManagedAliases, alias) {

--- a/domain.go
+++ b/domain.go
@@ -25,6 +25,18 @@ type DomainConnection struct {
 	TotalCount int      `json:"totalCount" graphql:"-"`
 }
 
+// Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
+func (d *Domain) GetUniqueIdentifiers() []string {
+	uniqueIdentifiers := []string{}
+	for _, alias := range d.Aliases {
+		if !slices.Contains(d.ManagedAliases, alias) {
+			uniqueIdentifiers = append(uniqueIdentifiers, alias)
+		}
+	}
+
+	return uniqueIdentifiers
+}
+
 func (d *Domain) ReconcileAliases(client *Client, aliasesWanted []string) error {
 	aliasesToCreate, aliasesToDelete := extractAliases(d.Aliases, aliasesWanted)
 

--- a/service.go
+++ b/service.go
@@ -54,7 +54,7 @@ type ServiceDocumentsConnection struct {
 }
 
 // Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
-func (service *Service) GetUniqueIdentifiers() []string {
+func (service *Service) UniqueIdentifiers() []string {
 	uniqueIdentifiers := []string{}
 	for _, alias := range service.Aliases {
 		if !slices.Contains(service.ManagedAliases, alias) {

--- a/service.go
+++ b/service.go
@@ -53,6 +53,18 @@ type ServiceDocumentsConnection struct {
 	TotalCount int
 }
 
+// Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
+func (service *Service) GetUniqueIdentifiers() []string {
+	uniqueIdentifiers := []string{}
+	for _, alias := range service.Aliases {
+		if !slices.Contains(service.ManagedAliases, alias) {
+			uniqueIdentifiers = append(uniqueIdentifiers, alias)
+		}
+	}
+
+	return uniqueIdentifiers
+}
+
 func (service *Service) ReconcileAliases(client *Client, aliasesWanted []string) error {
 	aliasesToCreate, aliasesToDelete := extractAliases(service.Aliases, aliasesWanted)
 

--- a/team.go
+++ b/team.go
@@ -64,7 +64,7 @@ type TeamMembershipConnection struct {
 }
 
 // Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
-func (team *Team) GetUniqueIdentifiers() []string {
+func (team *Team) UniqueIdentifiers() []string {
 	uniqueIdentifiers := []string{}
 	for _, alias := range team.Aliases {
 		if !slices.Contains(team.ManagedAliases, alias) {

--- a/team.go
+++ b/team.go
@@ -63,6 +63,18 @@ type TeamMembershipConnection struct {
 	TotalCount int
 }
 
+// Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
+func (team *Team) GetUniqueIdentifiers() []string {
+	uniqueIdentifiers := []string{}
+	for _, alias := range team.Aliases {
+		if !slices.Contains(team.ManagedAliases, alias) {
+			uniqueIdentifiers = append(uniqueIdentifiers, alias)
+		}
+	}
+
+	return uniqueIdentifiers
+}
+
 func (team *Team) ReconcileAliases(client *Client, aliasesWanted []string) error {
 	aliasesToCreate, aliasesToDelete := extractAliases(team.Aliases, aliasesWanted)
 


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `UniqueIdentifiers()` to `Domain`, `Service`, and `Team` structs.
This returns a slice of strings with `Aliases` not found in `ManagedAliases`. These unique identifiers are what are used in URLs and are managed by OpsLevel and not the customer. Being able to isolate these will help manage aliases that customers can update.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
