### PR TITLE
add support for azure resources integration

### DIFF
--- a/.changes/unreleased/Feature-20240705-152434.yaml
+++ b/.changes/unreleased/Feature-20240705-152434.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for Azure Resource Integrations
+time: 2024-07-05T15:24:34.169459-04:00

--- a/cache_test.go
+++ b/cache_test.go
@@ -40,7 +40,7 @@ func TestCache(t *testing.T) {
 		`{"data":{"account":{ "filters":{ "nodes":[{{ template "filter_1" }}] } }}}`,
 	)
 	testRequestSeven := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
 		`{ "after": "", "first": 100 }`,
 		`{"data":{"account":{ "integrations":{ "nodes":[{{ template "integration_1" }}] } }}}`,
 	)

--- a/input.go
+++ b/input.go
@@ -45,11 +45,11 @@ type AwsIntegrationInput struct {
 
 // AzureResourcesIntegrationInput specifies the input fields used to create an Azure resources integration.
 type AzureResourcesIntegrationInput struct {
-	Name           *string `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                                        // The name of the integration. (Optional.)
-	TenantId       *ID     `json:"tenantId,omitempty" yaml:"tenantId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The tenant OpsLevel uses to access the Azure account. (Optional.)
-	SubscriptionId *ID     `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The subscription OpsLevel uses to access the Azure account. (Optional.)
-	ClientId       *ID     `json:"clientId,omitempty" yaml:"clientId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The client OpsLevel uses to access the Azure account. (Optional.)
-	ClientSecret   *string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty" example:""`                                    // The client secret OpsLevel uses to access the Azure account. (Optional.)
+	Name           *string `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                                             // The name of the integration. (Optional.)
+	TenantId       *string `json:"tenantId,omitempty" yaml:"tenantId,omitempty" example:"12345678-1234-1234-1234-123456789abc"`             // The tenant OpsLevel uses to access the Azure account. (Optional.)
+	SubscriptionId *string `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty" example:"12345678-1234-1234-1234-123456789def"` // The subscription OpsLevel uses to access the Azure account. (Optional.)
+	ClientId       *string `json:"clientId,omitempty" yaml:"clientId,omitempty"`                                                            // The client OpsLevel uses to access the Azure account. (Optional.)
+	ClientSecret   *string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`                                                    // The client secret OpsLevel uses to access the Azure account. (Optional.)
 }
 
 // CategoryCreateInput specifies the input fields used to create a category.

--- a/input.go
+++ b/input.go
@@ -39,8 +39,17 @@ type AwsIntegrationInput struct {
 	Name                     *string   `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                                     // The name of the integration. (Optional.)
 	IamRole                  *string   `json:"iamRole,omitempty" yaml:"iamRole,omitempty" example:"example_role"`                               // The IAM role OpsLevel uses in order to access the AWS account. (Optional.)
 	ExternalId               *string   `json:"externalId,omitempty" yaml:"externalId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`      // The External ID defined in the trust relationship to ensure OpsLevel is the only third party assuming this role (See https:/docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html for more details). (Optional.)
-	OwnershipTagKeys         *[]string `json:"ownershipTagKeys,omitempty" yaml:"ownershipTagKeys,omitempty" example:"['tag_key1', 'tag_key2']"` // An Array of tag keys used to associate ownership from an integration. Max 5. (Optional.)
+	OwnershipTagKeys         *[]string `json:"ownershipTagKeys,omitempty" yaml:"ownershipTagKeys,omitempty" example:"['tag_key1', 'tag_key2']"` // An array of tag keys used to associate ownership from an integration. Max 5. (Optional.)
 	AwsTagsOverrideOwnership *bool     `json:"awsTagsOverrideOwnership,omitempty" yaml:"awsTagsOverrideOwnership,omitempty" example:"false"`    // Allow tags imported from AWS to override ownership set in OpsLevel directly. (Optional.)
+}
+
+// AzureResourcesIntegrationInput specifies the input fields used to create an Azure resources integration.
+type AzureResourcesIntegrationInput struct {
+	Name           *string `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                                        // The name of the integration. (Optional.)
+	TenantId       *ID     `json:"tenantId,omitempty" yaml:"tenantId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The tenant OpsLevel uses to access the Azure account. (Optional.)
+	SubscriptionId *ID     `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The subscription OpsLevel uses to access the Azure account. (Optional.)
+	ClientId       *ID     `json:"clientId,omitempty" yaml:"clientId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The client OpsLevel uses to access the Azure account. (Optional.)
+	ClientSecret   *string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty" example:""`                                    // The client secret OpsLevel uses to access the Azure account. (Optional.)
 }
 
 // CategoryCreateInput specifies the input fields used to create a category.
@@ -853,14 +862,14 @@ type ServiceNoteUpdateInput struct {
 type ServiceRepositoryCreateInput struct {
 	Service       IdentifierInput `json:"service" yaml:"service"`                                                               // The identifier for the service. (Required.)
 	Repository    IdentifierInput `json:"repository" yaml:"repository"`                                                         // The identifier for the repository. (Required.)
-	BaseDirectory *string         `json:"baseDirectory,omitempty" yaml:"baseDirectory,omitempty" example:"/home/opslevel.yaml"` // The directory in the repository containing opslevel.yml. (Optional.)
+	BaseDirectory *string         `json:"baseDirectory,omitempty" yaml:"baseDirectory,omitempty" example:"/home/opslevel.yaml"` // The directory in the repository where service information exists, including the opslevel.yml file. This path is always returned without leading and trailing slashes. (Optional.)
 	DisplayName   *string         `json:"displayName,omitempty" yaml:"displayName,omitempty" example:"example_name"`            // The name displayed in the UI for the service repository. (Optional.)
 }
 
 // ServiceRepositoryUpdateInput specifies the input fields used to update a service repository.
 type ServiceRepositoryUpdateInput struct {
 	Id            ID      `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                               // The ID of the service repository to be updated. (Required.)
-	BaseDirectory *string `json:"baseDirectory,omitempty" yaml:"baseDirectory,omitempty" example:"/home/opslevel.yaml"` // The directory in the repository containing opslevel.yml. (Optional.)
+	BaseDirectory *string `json:"baseDirectory,omitempty" yaml:"baseDirectory,omitempty" example:"/home/opslevel.yaml"` // The directory in the repository where service information exists, including the opslevel.yml file. This path is always returned without leading and trailing slashes. (Optional.)
 	DisplayName   *string `json:"displayName,omitempty" yaml:"displayName,omitempty" example:"example_name"`            // The name displayed in the UI for the service repository. (Optional.)
 }
 

--- a/integration.go
+++ b/integration.go
@@ -22,12 +22,10 @@ type AWSIntegrationFragment struct {
 }
 
 type AzureResourcesIntegrationFragment struct {
-	TenantId                                             string        `graphql:"tenantId"`
-	SubscriptionId                                       string        `graphql:"subscriptionId"`
-	LastSyncedAt                                         *iso8601.Time `graphql:"lastSyncedAt"`
-	Aliases                                              []string      `graphql:"aliases"`
-	AllowManualSyncInfrastructureResources               bool          `graphql:"allowManualSyncInfrastructureResources"`
-	MinutesUntilManualSyncInfrastructureResourcesAllowed *int          `graphql:"minutesUntilManualSyncInfrastructureResourcesAllowed"`
+	TenantId       string        `graphql:"tenantId"`
+	SubscriptionId string        `graphql:"subscriptionId"`
+	LastSyncedAt   *iso8601.Time `graphql:"lastSyncedAt"`
+	Aliases        []string      `graphql:"aliases"`
 }
 
 type NewRelicIntegrationFragment struct {

--- a/integration.go
+++ b/integration.go
@@ -163,3 +163,32 @@ func (client *Client) DeleteIntegration(identifier string) error {
 	err := client.Mutate(&m, v, WithName("IntegrationDelete"))
 	return HandleErrors(err, m.Payload.Errors)
 }
+
+func (client *Client) CreateIntegrationAzureResources(input AzureResourcesIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload struct {
+			Integration *Integration
+			Errors      []OpsLevelErrors
+		} `graphql:"azureResourcesIntegrationCreate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("AzureResourcesIntegrationCreate"))
+	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) UpdateIntegrationAzureResources(identifier string, input AzureResourcesIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload struct {
+			Integration *Integration
+			Errors      []OpsLevelErrors
+		} `graphql:"azureResourcesIntegrationUpdate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"integration": *NewIdentifier(identifier),
+		"input":       input,
+	}
+	err := client.Mutate(&m, v, WithName("AzureResourcesIntegrationUpdate"))
+	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}

--- a/integration.go
+++ b/integration.go
@@ -3,6 +3,8 @@ package opslevel
 import (
 	"fmt"
 
+	"github.com/relvacode/iso8601"
+
 	"github.com/gosimple/slug"
 )
 
@@ -17,6 +19,15 @@ type AWSIntegrationFragment struct {
 	ExternalID           string   `graphql:"externalId"`
 	OwnershipTagOverride bool     `graphql:"awsTagsOverrideOwnership"`
 	OwnershipTagKeys     []string `graphql:"ownershipTagKeys"`
+}
+
+type AzureResourcesIntegrationFragment struct {
+	TenantId                                             string        `graphql:"tenantId"`
+	SubscriptionId                                       string        `graphql:"subscriptionId"`
+	LastSyncedAt                                         *iso8601.Time `graphql:"lastSyncedAt"`
+	Aliases                                              []string      `graphql:"aliases"`
+	AllowManualSyncInfrastructureResources               bool          `graphql:"allowManualSyncInfrastructureResources"`
+	MinutesUntilManualSyncInfrastructureResourcesAllowed *int          `graphql:"minutesUntilManualSyncInfrastructureResourcesAllowed"`
 }
 
 type NewRelicIntegrationFragment struct {
@@ -183,7 +194,7 @@ func (client *Client) UpdateIntegrationAzureResources(identifier string, input A
 		Payload struct {
 			Integration *Integration
 			Errors      []OpsLevelErrors
-		} `graphql:"azureResourcesIntegrationUpdate(input: $input)"`
+		} `graphql:"azureResourcesIntegrationUpdate(integration: $integration input: $input)"`
 	}
 	v := PayloadVariables{
 		"integration": *NewIdentifier(identifier),

--- a/integration_test.go
+++ b/integration_test.go
@@ -68,9 +68,9 @@ func TestCreateAzureResourcesIntegration(t *testing.T) {
 	// Act
 	result, err := client.CreateIntegrationAzureResources(opslevel.AzureResourcesIntegrationInput{
 		Name:           opslevel.RefOf("new azure resources"),
-		TenantId:       opslevel.NewID("12345678-1234-1234-1234-123456789abc"),
-		SubscriptionId: opslevel.NewID("12345678-1234-1234-1234-123456789def"),
-		ClientId:       opslevel.NewID("XXX_client_id_XXX"),
+		TenantId:       opslevel.RefOf("12345678-1234-1234-1234-123456789abc"),
+		SubscriptionId: opslevel.RefOf("12345678-1234-1234-1234-123456789def"),
+		ClientId:       opslevel.RefOf("XXX_client_id_XXX"),
 		ClientSecret:   opslevel.RefOf("XXX_client_secret_XXX"),
 	})
 	// Assert
@@ -238,7 +238,7 @@ func TestUpdateAzureResourcesIntegration(t *testing.T) {
 	// Act
 	result, err := client.UpdateIntegrationAzureResources(string(id1), opslevel.AzureResourcesIntegrationInput{
 		Name:         opslevel.RefOf("updated azure resources"),
-		ClientId:     opslevel.NewID("updated client id"),
+		ClientId:     opslevel.RefOf("updated client id"),
 		ClientSecret: opslevel.RefOf("updated client secret"),
 	})
 	// Assert

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"input": { "iamRole": "arn:aws:iam::XXXX:role/aws-integration-role", "externalId": "123456789", "ownershipTagKeys": ["owner"] }}`,
 		`{"data": {
       "awsIntegrationCreate": {
@@ -43,10 +43,54 @@ func TestCreateAWSIntegration(t *testing.T) {
 	autopilot.Equals(t, "AWS - XXXX", result.Name)
 }
 
+func TestCreateAzureResourcesIntegration(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`{"input": { "name": "new azure resources", "tenantId": "original tenant id", "subscriptionId": "original subscription id", "clientId": "original client id", "clientSecret": "original client secret"}}`,
+		`{"data": {
+      "azureResourcesIntegrationCreate": {
+        "integration": {
+          {{ template "id1" }},
+          "name": "new azure resources",
+          "type": "azureResources",
+          "createdAt": "2024-07-04T16:25:29.574450Z",
+          "installedAt": "2024-07-04T16:25:28.541124Z",
+          "tenantId": "original tenant id",
+          "subscriptionId": "original subscription id",
+          "lastSyncedAt": "2024-07-05T11:06:56.574450Z",
+          "aliases": ["alias1", "alias2"],
+          "allowManualSyncInfrastructureResources": true,
+          "minutesUntilManualSyncInfrastructureResourcesAllowed": 3
+        },
+        "errors": []
+      }}}`,
+	)
+	client := BestTestClient(t, "integration/create_azure_resources", testRequest)
+	// Act
+	result, err := client.CreateIntegrationAzureResources(opslevel.AzureResourcesIntegrationInput{
+		Name:           opslevel.RefOf("new azure resources"),
+		TenantId:       opslevel.NewID("original tenant id"),
+		SubscriptionId: opslevel.NewID("original subscription id"),
+		ClientId:       opslevel.NewID("original client id"),
+		ClientSecret:   opslevel.RefOf("original client secret"),
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, "new azure resources", result.Name)
+	autopilot.Equals(t, "original tenant id", result.TenantId)
+	autopilot.Equals(t, "original subscription id", result.SubscriptionId)
+	autopilot.Equals(t, "2024-07-05 11:06:56.57445 +0000 UTC", result.LastSyncedAt.String())
+	autopilot.Equals(t, []string{"alias1", "alias2"}, result.Aliases)
+	autopilot.Equals(t, true, result.AllowManualSyncInfrastructureResources)
+	autopilot.Equals(t, opslevel.RefOf(3), result.MinutesUntilManualSyncInfrastructureResourcesAllowed)
+}
+
 func TestCreateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{ "input": { "apiKey": "123456789", "baseUrl": "https://api.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationCreate": {
@@ -77,7 +121,7 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
 		`{ {{ template "id1" }} }`,
 		`{"data": {
       "account": {
@@ -100,7 +144,7 @@ func TestGetIntegration(t *testing.T) {
 func TestGetMissingIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
 		`{ {{ template "id2" }} }`,
 		`{"data": { "account": { "integration": null }}}`,
 	)
@@ -114,12 +158,12 @@ func TestGetMissingIntegration(t *testing.T) {
 func TestListIntegrations(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "deploy_integration_response" }} }, { {{ template "payload_integration_response" }} } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 2 }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "kubernetes_integration_response" }} } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
 	)
@@ -139,7 +183,7 @@ func TestListIntegrations(t *testing.T) {
 func TestUpdateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "Dev2", "externalId": "123456789", "ownershipTagKeys": null }}`,
 		`{"data": {
       "awsIntegrationUpdate": {
@@ -171,10 +215,57 @@ func TestUpdateAWSIntegration(t *testing.T) {
 	autopilot.Equals(t, "Dev2", result.Name)
 }
 
+func TestUpdateAzureResourcesIntegration(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`{"integration": { {{ template "id1" }} }, "input": { "name": "updated azure resources", "tenantId": "updated tenant id", "subscriptionId": "updated subscription id", "clientId": "updated client id", "clientSecret": "updated client secret" }}`,
+		`{"data": {
+      "azureResourcesIntegrationUpdate": {
+        "integration": {
+        {{ template "id1" }},
+        "name": "updated azure resources",
+        "type": "azureResources",
+        "createdAt": "2024-07-04T16:25:29.574450Z",
+        "tenantId": "updated tenant id",
+        "subscriptionId": "updated subscription id",
+        "lastSyncedAt": null,
+        "aliases": [],
+        "allowManualSyncInfrastructureResources": false,
+		"minutesUntilManualSyncInfrastructureResourcesAllowed": null
+      },
+      "errors": []
+    }}}`,
+	)
+	client := BestTestClient(t, "integration/update_azure_resources", testRequest)
+	// Act
+	result, err := client.UpdateIntegrationAzureResources(string(id1), opslevel.AzureResourcesIntegrationInput{
+		Name:           opslevel.RefOf("updated azure resources"),
+		TenantId:       opslevel.NewID("updated tenant id"),
+		SubscriptionId: opslevel.NewID("updated subscription id"),
+		ClientId:       opslevel.NewID("updated client id"),
+		ClientSecret:   opslevel.RefOf("updated client secret"),
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, "updated azure resources", result.Name)
+	autopilot.Equals(t, "updated tenant id", result.TenantId)
+	autopilot.Equals(t, "updated subscription id", result.SubscriptionId)
+	if result.LastSyncedAt != nil {
+		t.Errorf("expected last synced at to be null, got '%s'", result.LastSyncedAt)
+	}
+	autopilot.Equals(t, []string{}, result.Aliases)
+	autopilot.Equals(t, false, result.AllowManualSyncInfrastructureResources)
+	if result.LastSyncedAt != nil {
+		t.Errorf("expected minutes until manual sync allowed to be null, got '%d'", result.MinutesUntilManualSyncInfrastructureResourcesAllowed)
+	}
+}
+
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"resource": { {{ template "id1" }} }, "input": { "baseUrl": "https://api-test.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationUpdate": {

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"input": { "iamRole": "arn:aws:iam::XXXX:role/aws-integration-role", "externalId": "123456789", "ownershipTagKeys": ["owner"] }}`,
 		`{"data": {
       "awsIntegrationCreate": {
@@ -46,7 +46,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 func TestCreateAzureResourcesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"input": { "name": "new azure resources", "tenantId": "12345678-1234-1234-1234-123456789abc", "subscriptionId": "12345678-1234-1234-1234-123456789def", "clientId": "XXX_client_id_XXX", "clientSecret": "XXX_client_secret_XXX"}}`,
 		`{"data": {
       "azureResourcesIntegrationCreate": {
@@ -59,9 +59,7 @@ func TestCreateAzureResourcesIntegration(t *testing.T) {
           "tenantId": "12345678-1234-1234-1234-123456789abc",
           "subscriptionId": "12345678-1234-1234-1234-123456789def",
           "lastSyncedAt": null,
-          "aliases": [],
-          "allowManualSyncInfrastructureResources": false,
-          "minutesUntilManualSyncInfrastructureResourcesAllowed": null
+          "aliases": []
         },
         "errors": []
       }}}`,
@@ -85,16 +83,12 @@ func TestCreateAzureResourcesIntegration(t *testing.T) {
 		t.Errorf("expected last synced at to be null, got '%s'", result.LastSyncedAt)
 	}
 	autopilot.Equals(t, []string{}, result.Aliases)
-	autopilot.Equals(t, false, result.AllowManualSyncInfrastructureResources)
-	if result.MinutesUntilManualSyncInfrastructureResourcesAllowed != nil {
-		t.Errorf("expected minutes until manual sync allowed to be null, got '%d'", result.MinutesUntilManualSyncInfrastructureResourcesAllowed)
-	}
 }
 
 func TestCreateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{ "input": { "apiKey": "123456789", "baseUrl": "https://api.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationCreate": {
@@ -125,7 +119,7 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
 		`{ {{ template "id1" }} }`,
 		`{"data": {
       "account": {
@@ -148,7 +142,7 @@ func TestGetIntegration(t *testing.T) {
 func TestGetMissingIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
 		`{ {{ template "id2" }} }`,
 		`{"data": { "account": { "integration": null }}}`,
 	)
@@ -162,12 +156,12 @@ func TestGetMissingIntegration(t *testing.T) {
 func TestListIntegrations(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "deploy_integration_response" }} }, { {{ template "payload_integration_response" }} } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 2 }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},{{ template "pagination_request" }},totalCount}}}`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "kubernetes_integration_response" }} } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
 	)
@@ -187,7 +181,7 @@ func TestListIntegrations(t *testing.T) {
 func TestUpdateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "Dev2", "externalId": "123456789", "ownershipTagKeys": null }}`,
 		`{"data": {
       "awsIntegrationUpdate": {
@@ -222,7 +216,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 func TestUpdateAzureResourcesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "updated azure resources", "clientId": "updated client id", "clientSecret": "updated client secret" }}`,
 		`{"data": {
       "azureResourcesIntegrationUpdate": {
@@ -235,9 +229,7 @@ func TestUpdateAzureResourcesIntegration(t *testing.T) {
           "tenantId": "12345678-1234-1234-1234-123456789abc",
           "subscriptionId": "12345678-1234-1234-1234-123456789def",
           "lastSyncedAt": "2024-07-05T11:06:56.574450Z",
-          "aliases": ["alias1", "alias2"],
-          "allowManualSyncInfrastructureResources": true,
-          "minutesUntilManualSyncInfrastructureResourcesAllowed": 3
+          "aliases": ["alias1", "alias2"]
       },
       "errors": []
     }}}`,
@@ -257,14 +249,12 @@ func TestUpdateAzureResourcesIntegration(t *testing.T) {
 	autopilot.Equals(t, "12345678-1234-1234-1234-123456789def", result.SubscriptionId)
 	autopilot.Equals(t, "2024-07-05 11:06:56.57445 +0000 UTC", result.LastSyncedAt.String())
 	autopilot.Equals(t, []string{"alias1", "alias2"}, result.Aliases)
-	autopilot.Equals(t, true, result.AllowManualSyncInfrastructureResources)
-	autopilot.Equals(t, opslevel.RefOf(3), result.MinutesUntilManualSyncInfrastructureResourcesAllowed)
 }
 
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases,allowManualSyncInfrastructureResources,minutesUntilManualSyncInfrastructureResourcesAllowed},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{tenantId,subscriptionId,lastSyncedAt,aliases},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
 		`{"resource": { {{ template "id1" }} }, "input": { "baseUrl": "https://api-test.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationUpdate": {

--- a/interfaces.go
+++ b/interfaces.go
@@ -60,8 +60,9 @@ type Integration struct {
 	CreatedAt   iso8601.Time `graphql:"createdAt"`   // The time this integration was created.
 	InstalledAt iso8601.Time `graphql:"installedAt"` // The time that this integration was successfully installed, if null, this indicates the integration was not completed installed.
 
-	AWSIntegrationFragment      `graphql:"... on AwsIntegration"`
-	NewRelicIntegrationFragment `graphql:"... on NewRelicIntegration"`
+	AWSIntegrationFragment            `graphql:"... on AwsIntegration"`
+	AzureResourcesIntegrationFragment `graphql:"... on AzureResourcesIntegration"`
+	NewRelicIntegrationFragment       `graphql:"... on NewRelicIntegration"`
 }
 
 // ManualAlertSourceSync represents .


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/414

## Changelog

- [x] Add azure resources graphql fragment
- [x] Add azure resources new client functions 
- [x] Update integrations.go tests
- [x] Update cache.go tests
- [x] Make a `changie` entry

## Tophatting

Running create integration query on staging3:

![image](https://github.com/OpsLevel/opslevel-go/assets/37668804/9aa7e706-915a-45e6-b7fe-b52766302942)

Running update integration query on staging3:

![image](https://github.com/OpsLevel/opslevel-go/assets/37668804/c819c05f-08ce-43d3-9895-2c6519086eb1)


