### PR TITLE
undo breaking changes to service input struct tags

### DIFF
--- a/.changes/unreleased/Refactor-20240719-135145.yaml
+++ b/.changes/unreleased/Refactor-20240719-135145.yaml
@@ -1,3 +1,0 @@
-kind: Refactor
-body: reverted change json and yaml struct tags on ServiceUpdateInput and ServiceUpdateInputV2 structs to what they were previously when ServiceUpdateInput was initially created and to ensure they match
-time: 2024-07-19T13:51:45.789647-05:00

--- a/input.go
+++ b/input.go
@@ -874,9 +874,9 @@ type ServiceUpdateInput struct {
 	Description           *string          `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
 	Language              *string          `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
 	Framework             *string          `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *string          `json:"tier,omitempty" yaml:"tier,omitempty" example:"example_alias"`                           // The software tier that the service belongs to. (Optional.)
-	OwnerInput            *IdentifierInput `json:"owner,omitempty" yaml:"owner,omitempty"`                                                 // The owner for the service. (Optional.)
-	LifecycleAlias        *string          `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty" example:"example_alias"`                 // The lifecycle stage of the service. (Optional.)
+	TierAlias             *string          `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	OwnerInput            *IdentifierInput `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
+	LifecycleAlias        *string          `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
 	SkipAliasesValidation *bool            `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 

--- a/new_input.go
+++ b/new_input.go
@@ -19,9 +19,9 @@ type ServiceUpdateInputV2 struct {
 	Description           *Nullable[string] `json:"description,omitempty" yaml:"description,omitempty" example:"example_description"`       // A brief description of the service. (Optional.)
 	Language              *Nullable[string] `json:"language,omitempty" yaml:"language,omitempty" example:"example_language"`                // The primary programming language that the service is written in. (Optional.)
 	Framework             *Nullable[string] `json:"framework,omitempty" yaml:"framework,omitempty" example:"example_framework"`             // The primary software development framework that the service uses. (Optional.)
-	TierAlias             *Nullable[string] `json:"tier,omitempty" yaml:"tier,omitempty" example:"example_alias"`                           // The software tier that the service belongs to. (Optional.)
-	OwnerInput            *IdentifierInput  `json:"owner,omitempty" yaml:"owner,omitempty"`                                                 // The owner for the service. (Optional.)
-	LifecycleAlias        *Nullable[string] `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty" example:"example_alias"`                 // The lifecycle stage of the service. (Optional.)
+	TierAlias             *Nullable[string] `json:"tierAlias,omitempty" yaml:"tierAlias,omitempty" example:"example_alias"`                 // The software tier that the service belongs to. (Optional.)
+	OwnerInput            *IdentifierInput  `json:"ownerInput,omitempty" yaml:"ownerInput,omitempty"`                                       // The owner for the service. (Optional.)
+	LifecycleAlias        *Nullable[string] `json:"lifecycleAlias,omitempty" yaml:"lifecycleAlias,omitempty" example:"example_alias"`       // The lifecycle stage of the service. (Optional.)
 	SkipAliasesValidation *bool             `json:"skipAliasesValidation,omitempty" yaml:"skipAliasesValidation,omitempty" example:"false"` // Allows updating a service with invalid aliases. (Optional.)
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -266,8 +266,8 @@ func TestCreateServiceWithParentSystem(t *testing.T) {
 }
 
 func TestUpdateService(t *testing.T) {
-	addVars := `{"input":{"description": "The quick brown fox", "framework": "django", "id": "123456789", "lifecycle": "pre-alpha", "name": "Hello World", "parent": {"alias": "some_system"}, "tier": "tier_4"}}`
-	delVars := `{"input":{"description": null, "framework": null, "id": "123456789", "lifecycle": null, "parent": null, "tier": null}}`
+	addVars := `{"input":{"description": "The quick brown fox", "framework": "django", "id": "123456789", "lifecycleAlias": "pre-alpha", "name": "Hello World", "parent": {"alias": "some_system"}, "tierAlias": "tier_4"}}`
+	delVars := `{"input":{"description": null, "framework": null, "id": "123456789", "lifecycleAlias": null, "parent": null, "tierAlias": null}}`
 	delVarsV1DoesNotWorkExceptOnParent := `{"input":{"id": "123456789", "parent": null}}`
 	zeroVars := `{"input":{"description": "", "framework": "", "id": "123456789"}}`
 	type TestCase struct {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Undo changes from [this PR](https://github.com/OpsLevel/opslevel-go/pull/433). The struct tags are being set back to the way they were since at least [v2022.8.25](https://github.com/OpsLevel/opslevel-go/blob/v2022.8.25/service.go#L60-L62)

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
