### PR TITLE
Fix Infrastructure resource list graphql operation names

### DIFF
--- a/.changes/unreleased/Refactor-20240807-122518.yaml
+++ b/.changes/unreleased/Refactor-20240807-122518.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: Updated graphql operation names for infrastructure resources, and their schemas.
+time: 2024-08-07T12:25:18.367734-04:00

--- a/cache_test.go
+++ b/cache_test.go
@@ -50,7 +50,7 @@ func TestCache(t *testing.T) {
 		`{"data":{"account":{ "repositories":{ "hiddenCount": 0, "nodes":[{{ template "repository_1" }}] } }}}`,
 	)
 	testRequestNine := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceSchemaList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
 		`{ "after": "", "first": 100 }`,
 		`{"data":{"account":{ "infrastructureResourceSchemas":{ "nodes":[ {{ template "infra_schema_1" }} ] }}}}`,
 	)

--- a/infra.go
+++ b/infra.go
@@ -175,7 +175,7 @@ func (client *Client) ListInfrastructureSchemas(variables *PayloadVariables) (*I
 	if variables == nil {
 		variables = client.InitialPageVariablesPointer()
 	}
-	if err := client.Query(&q, *variables, WithName("IntegrationList")); err != nil {
+	if err := client.Query(&q, *variables, WithName("InfrastructureResourceSchemaList")); err != nil {
 		return nil, err
 	}
 	for q.Account.InfrastructureResourceSchemas.PageInfo.HasNextPage {
@@ -201,7 +201,7 @@ func (client *Client) ListInfrastructure(variables *PayloadVariables) (*Infrastr
 		variables = client.InitialPageVariablesPointer()
 		(*variables)["all"] = true
 	}
-	if err := client.Query(&q, *variables, WithName("IntegrationList")); err != nil {
+	if err := client.Query(&q, *variables, WithName("InfrastructureResourceList")); err != nil {
 		return nil, err
 	}
 	for q.Account.InfrastructureResource.PageInfo.HasNextPage {

--- a/infra_test.go
+++ b/infra_test.go
@@ -75,12 +75,12 @@ func TestGetInfra(t *testing.T) {
 func TestListInfraSchemas(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceSchemaList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "infrastructureResourceSchemas": { "nodes": [ {{ template "infra_schema_1" }}, {{ template "infra_schema_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceSchemaList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "infrastructureResourceSchemas": { "nodes": [ {{ template "infra_schema_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
@@ -101,12 +101,12 @@ func TestListInfraSchemas(t *testing.T) {
 func TestListInfra(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
 		`{ "after": "", "all": true, "first": 100 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_1" }}, {{ template "infra_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
 		`{ "after": "OA", "all": true, "first": 100 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ]  updated the operation name of the graphql requests. Noticed this scanning datadog. These names should be unique to help us identify costly requests. 
- [ ] Make a `changie` entry <- Should I still add one? This one is pretty transparent and only matters to us I believe.

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
