### PR TITLE
fix: additional file content predicate references or pointers

### DIFF
--- a/.changes/unreleased/Bugfix-20240809-094438.yaml
+++ b/.changes/unreleased/Bugfix-20240809-094438.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Changed fileContentsPredicate references for CheckRepository PredicateInput types
+time: 2024-08-09T09:44:38.673802+02:00

--- a/check_repo_search.go
+++ b/check_repo_search.go
@@ -1,8 +1,8 @@
 package opslevel
 
 type RepositorySearchCheckFragment struct {
-	FileExtensions        []string  `graphql:"fileExtensions"`
-	FileContentsPredicate Predicate `graphql:"fileContentsPredicate"`
+	FileExtensions        []string   `graphql:"fileExtensions"`
+	FileContentsPredicate *Predicate `graphql:"fileContentsPredicate"`
 }
 
 func (client *Client) CreateCheckRepositorySearch(input CheckRepositorySearchCreateInput) (*Check, error) {

--- a/check_test.go
+++ b/check_test.go
@@ -458,7 +458,7 @@ func getCheckTestCases() map[string]TmpCheckTestCase {
 				input := ol.NewCheckCreateInputTypeOf[ol.CheckRepositoryGrepCreateInput](checkCreateInput)
 				input.DirectorySearch = ol.RefOf(true)
 				input.FilePaths = []string{"**/hello.go"}
-				input.FileContentsPredicate = *predicateInput
+				input.FileContentsPredicate = predicateInput
 				return c.CreateCheckRepositoryGrep(*input)
 			},
 		},
@@ -512,7 +512,7 @@ func getCheckTestCases() map[string]TmpCheckTestCase {
 			body: func(c *ol.Client) (*ol.Check, error) {
 				input := ol.NewCheckCreateInputTypeOf[ol.CheckRepositorySearchCreateInput](checkCreateInput)
 				input.FileExtensions = &[]string{"sbt", "py"}
-				input.FileContentsPredicate = *predicateInput
+				input.FileContentsPredicate = predicateInput
 				return c.CreateCheckRepositorySearch(*input)
 			},
 		},

--- a/input.go
+++ b/input.go
@@ -323,17 +323,17 @@ type CheckRepositoryFileUpdateInput struct {
 
 // CheckRepositoryGrepCreateInput specifies the input fields used to create a repo grep check.
 type CheckRepositoryGrepCreateInput struct {
-	Name                  string         `json:"name" yaml:"name" example:"example_name"`                                                // The display name of the check. (Required.)
-	Enabled               *bool          `json:"enabled,omitempty" yaml:"enabled,omitempty" example:"false"`                             // Whether the check is enabled or not. (Optional.)
-	EnableOn              *iso8601.Time  `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2024-01-05T01:00:00.000Z"`        // The date when the check will be automatically enabled. (Optional.)
-	CategoryId            ID             `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                 // The id of the category the check belongs to. (Required.)
-	LevelId               ID             `json:"levelId" yaml:"levelId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The id of the level the check belongs to. (Required.)
-	OwnerId               *ID            `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check. (Optional.)
-	FilterId              *ID            `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter of the check. (Optional.)
-	Notes                 *string        `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_notes"`                         // Additional information about the check. (Optional.)
-	DirectorySearch       *bool          `json:"directorySearch,omitempty" yaml:"directorySearch,omitempty" example:"false"`             // Whether the check looks for the existence of a directory instead of a file. (Optional.)
-	FilePaths             []string       `json:"filePaths" yaml:"filePaths" example:"['/usr/local/bin', '/home/opslevel']"`              // Restrict the search to certain file paths. (Required.)
-	FileContentsPredicate PredicateInput `json:"fileContentsPredicate" yaml:"fileContentsPredicate"`                                     // Condition to match the file content. (Required.)
+	Name                  string          `json:"name" yaml:"name" example:"example_name"`                                                // The display name of the check. (Required.)
+	Enabled               *bool           `json:"enabled,omitempty" yaml:"enabled,omitempty" example:"false"`                             // Whether the check is enabled or not. (Optional.)
+	EnableOn              *iso8601.Time   `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2024-01-05T01:00:00.000Z"`        // The date when the check will be automatically enabled. (Optional.)
+	CategoryId            ID              `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                 // The id of the category the check belongs to. (Required.)
+	LevelId               ID              `json:"levelId" yaml:"levelId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The id of the level the check belongs to. (Required.)
+	OwnerId               *ID             `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check. (Optional.)
+	FilterId              *ID             `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter of the check. (Optional.)
+	Notes                 *string         `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_notes"`                         // Additional information about the check. (Optional.)
+	DirectorySearch       *bool           `json:"directorySearch,omitempty" yaml:"directorySearch,omitempty" example:"false"`             // Whether the check looks for the existence of a directory instead of a file. (Optional.)
+	FilePaths             []string        `json:"filePaths" yaml:"filePaths" example:"['/usr/local/bin', '/home/opslevel']"`              // Restrict the search to certain file paths. (Required.)
+	FileContentsPredicate *PredicateInput `json:"fileContentsPredicate" yaml:"fileContentsPredicate"`                                     // Condition to match the file content. (Required.)
 }
 
 // CheckRepositoryGrepUpdateInput specifies the input fields used to update a repo file check.
@@ -379,16 +379,16 @@ type CheckRepositoryIntegratedUpdateInput struct {
 
 // CheckRepositorySearchCreateInput specifies the input fields used to create a repo search check.
 type CheckRepositorySearchCreateInput struct {
-	Name                  string         `json:"name" yaml:"name" example:"example_name"`                                                // The display name of the check. (Required.)
-	Enabled               *bool          `json:"enabled,omitempty" yaml:"enabled,omitempty" example:"false"`                             // Whether the check is enabled or not. (Optional.)
-	EnableOn              *iso8601.Time  `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2024-01-05T01:00:00.000Z"`        // The date when the check will be automatically enabled. (Optional.)
-	CategoryId            ID             `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                 // The id of the category the check belongs to. (Required.)
-	LevelId               ID             `json:"levelId" yaml:"levelId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The id of the level the check belongs to. (Required.)
-	OwnerId               *ID            `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check. (Optional.)
-	FilterId              *ID            `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter of the check. (Optional.)
-	Notes                 *string        `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_notes"`                         // Additional information about the check. (Optional.)
-	FileExtensions        *[]string      `json:"fileExtensions,omitempty" yaml:"fileExtensions,omitempty" example:"['go', 'py', 'rb']"`  // Restrict the search to files of given extensions. Extensions should contain only letters and numbers. For example: `['py', 'rb']`. (Optional.)
-	FileContentsPredicate PredicateInput `json:"fileContentsPredicate" yaml:"fileContentsPredicate"`                                     // Condition to match the text content. (Required.)
+	Name                  string          `json:"name" yaml:"name" example:"example_name"`                                                // The display name of the check. (Required.)
+	Enabled               *bool           `json:"enabled,omitempty" yaml:"enabled,omitempty" example:"false"`                             // Whether the check is enabled or not. (Optional.)
+	EnableOn              *iso8601.Time   `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2024-01-05T01:00:00.000Z"`        // The date when the check will be automatically enabled. (Optional.)
+	CategoryId            ID              `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                 // The id of the category the check belongs to. (Required.)
+	LevelId               ID              `json:"levelId" yaml:"levelId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The id of the level the check belongs to. (Required.)
+	OwnerId               *ID             `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check. (Optional.)
+	FilterId              *ID             `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter of the check. (Optional.)
+	Notes                 *string         `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_notes"`                         // Additional information about the check. (Optional.)
+	FileExtensions        *[]string       `json:"fileExtensions,omitempty" yaml:"fileExtensions,omitempty" example:"['go', 'py', 'rb']"`  // Restrict the search to files of given extensions. Extensions should contain only letters and numbers. For example: `['py', 'rb']`. (Optional.)
+	FileContentsPredicate *PredicateInput `json:"fileContentsPredicate" yaml:"fileContentsPredicate"`                                     // Condition to match the text content. (Required.)
 }
 
 // CheckRepositorySearchUpdateInput specifies the input fields used to update a repo search check.


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/opslevel-go/issues/448
https://github.com/OpsLevel/terraform-provider-opslevel/issues/428 - might be related?

## Changelog

- [x] List your changes here
- [x] Make a `changie` entry

Changed the `FileContentsPredicate *PredicateInput` to match the rest of the `input.go` file.

## Tophatting

```
go test
2024/08/09 09:48:34 http: panic serving 127.0.0.1:63748: error during json indenting: invalid character '{' looking for beginning of object key string
goroutine 128 [running]:
net/http.(*conn).serve.func1()
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/net/http/server.go:1903 +0xb0
panic({0x102aa80c0?, 0x1400049c9f0?})
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/runtime/panic.go:770 +0x124
github.com/opslevel/opslevel-go/v2024_test.Templated({0x10291eb94?, 0x0?})
	/Users/andrew.basson/dev/github/bassco/opslevel-go/clientGQL_test.go:43 +0x5c
github.com/opslevel/opslevel-go/v2024_test.GraphQLQueryTemplate({0x10291eb94, 0xbb})
	/Users/andrew.basson/dev/github/bassco/opslevel-go/clientGQL_test.go:60 +0x44
github.com/opslevel/opslevel-go/v2024_test.ABetterTestClient.GraphQLQueryTemplatedValidation.func4(0x140006a4240)
	/Users/andrew.basson/dev/github/bassco/opslevel-go/clientGQL_test.go:68 +0x34
github.com/rocktavious/autopilot/v2023.RegisterEndpoint.func1({0x102b68dd8, 0x1400018c540}, 0x140003afb18?)
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/packages/pkg/mod/github.com/rocktavious/autopilot/v2023@v2023.12.7/autopilot.go:97 +0x38
net/http.HandlerFunc.ServeHTTP(0x140002c7ba0?, {0x102b68dd8?, 0x1400018c540?}, 0x140003afb00?)
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/net/http/server.go:2171 +0x38
net/http.(*ServeMux).ServeHTTP(0x10?, {0x102b68dd8, 0x1400018c540}, 0x140006a4240)
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/net/http/server.go:2688 +0x1a4
net/http.serverHandler.ServeHTTP({0x102b67a48?}, {0x102b68dd8?, 0x1400018c540?}, 0x6?)
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/net/http/server.go:3142 +0xbc
net/http.(*conn).serve(0x14000480480, {0x102b69ea0, 0x140000b40f0})
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/net/http/server.go:2044 +0x508
created by net/http.(*Server).Serve in goroutine 35
	/Users/andrew.basson/.asdf/installs/golang/1.22.6/go/src/net/http/server.go:3290 +0x3f0
9:48AM DBG Caching 'Tier' lookup table from API ...
9:48AM DBG Caching 'Lifecycle' lookup table from API ...
9:48AM DBG Caching 'Team' lookup table from API ...
9:48AM DBG Caching 'Category' lookup table from API ...
9:48AM DBG Caching 'Level' lookup table from API ...
9:48AM DBG Caching 'Filter' lookup table from API ...
9:48AM DBG Caching 'Integration' lookup table from API ...
9:48AM DBG Caching 'Repository' lookup table from API ...
9:48AM DBG Caching 'InfrastructureSchema' lookup table from API ...
9:48AM DBG Caching 'Tier' lookup table from API ...
9:48AM DBG Caching 'Lifecycle' lookup table from API ...
9:48AM DBG Caching 'Team' lookup table from API ...
9:48AM DBG Caching 'Category' lookup table from API ...
9:48AM DBG Caching 'Level' lookup table from API ...
9:48AM DBG Caching 'Filter' lookup table from API ...
9:48AM DBG Caching 'Integration' lookup table from API ...
9:48AM DBG Caching 'Repository' lookup table from API ...
9:48AM DBG Caching 'InfrastructureSchema' lookup table from API ...
PASS
ok  	github.com/opslevel/opslevel-go/v2024	0.572s
```
