### PR TITLE
add GCP integration support

### DIFF
--- a/.changes/unreleased/Feature-20240808-123025.yaml
+++ b/.changes/unreleased/Feature-20240808-123025.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for Google Cloud Integrations
+time: 2024-08-08T12:30:25.219009-04:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,8 +11,17 @@ tasks:
       - task: test
 
   generate:
-    desc: Generate code based on public GraphQL Interface
+    desc: Generate code based on PUBLIC GraphQL Interface
     aliases: [gen]
+    cmds:
+      - go generate
+      - gofumpt -w .
+
+  generate-internal:
+    desc: Generate code based on INTERNAL internal GraphQL Interface
+    aliases: [gen-internal]
+    env:
+      GRAPHQL_VISIBILITY: "internal"
     cmds:
       - go generate
       - gofumpt -w .

--- a/cache_test.go
+++ b/cache_test.go
@@ -40,7 +40,7 @@ func TestCache(t *testing.T) {
 		`{"data":{"account":{ "filters":{ "nodes":[{{ template "filter_1" }}] } }}}`,
 	)
 	testRequestSeven := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
 		`{ "after": "", "first": 100 }`,
 		`{"data":{"account":{ "integrations":{ "nodes":[{{ template "integration_1" }}] } }}}`,
 	)

--- a/cache_test.go
+++ b/cache_test.go
@@ -40,7 +40,7 @@ func TestCache(t *testing.T) {
 		`{"data":{"account":{ "filters":{ "nodes":[{{ template "filter_1" }}] } }}}`,
 	)
 	testRequestSeven := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
 		`{ "after": "", "first": 100 }`,
 		`{"data":{"account":{ "integrations":{ "nodes":[{{ template "integration_1" }}] } }}}`,
 	)

--- a/gen.go
+++ b/gen.go
@@ -204,11 +204,15 @@ func main() {
 }
 
 func getRootSchema() (*GraphQLSchema, error) {
+	visibility, ok := os.LookupEnv("GRAPHQL_VISIBILITY")
+	if !ok {
+		visibility = "public"
+	}
 	token, ok := os.LookupEnv("OPSLEVEL_API_TOKEN")
 	if !ok {
 		return nil, fmt.Errorf("OPSLEVEL_API_TOKEN environment variable not set")
 	}
-	client := opslevel.NewGQLClient(opslevel.SetAPIToken(token), opslevel.SetAPIVisibility("public"))
+	client := opslevel.NewGQLClient(opslevel.SetAPIToken(token), opslevel.SetAPIVisibility(visibility))
 	schema, err := GetSchema(client)
 	if err != nil {
 		return nil, err

--- a/input.go
+++ b/input.go
@@ -724,6 +724,15 @@ type FilterUpdateInput struct {
 	Connective *ConnectiveEnum         `json:"connective,omitempty" yaml:"connective,omitempty" example:"or"` // The logical operator to be used in conjunction with predicates. (Optional.)
 }
 
+// GoogleCloudIntegrationInput specifies the input fields used to create and update a Google Cloud integration.
+type GoogleCloudIntegrationInput struct {
+	Name                  *string   `json:"name,omitempty" yaml:"name,omitempty" example:"example_name"`                                     // The name of the integration. (Optional.)
+	OwnershipTagKeys      *[]string `json:"ownershipTagKeys,omitempty" yaml:"ownershipTagKeys,omitempty" example:"['tag_key1', 'tag_key2']"` // An array of tag keys used to associate ownership from an integration. Max 5. (Optional.)
+	PrivateKey            *string   `json:"privateKey,omitempty" yaml:"privateKey,omitempty" example:"XXX_example_key_XXX"`                  // The private key for the service account that OpsLevel uses to access the Google Cloud account. (Optional.)
+	ClientEmail           *string   `json:"clientEmail,omitempty" yaml:"clientEmail,omitempty" example:"first.last@domain.com"`              // The service account email OpsLevel uses to access the Google Cloud account. (Optional.)
+	TagsOverrideOwnership *bool     `json:"tagsOverrideOwnership,omitempty" yaml:"tagsOverrideOwnership,omitempty" example:"false"`          // Allow tags imported from Google Cloud to override ownership set in OpsLevel directly. (Optional.)
+}
+
 // IdentifierInput specifies the input fields used to identify a resource.
 type IdentifierInput struct {
 	Id    *ID     `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the resource. (Optional.)

--- a/integration.go
+++ b/integration.go
@@ -27,12 +27,18 @@ type AzureResourcesIntegrationFragment struct {
 	TenantId              string   `graphql:"tenantId"`
 }
 
+type GoogleCloudProject struct {
+	ID   string `graphql:"id"`
+	Name string `graphql:"name"`
+	URL  string `graphql:"url"`
+}
+
 type GoogleCloudIntegrationFragment struct {
-	Aliases               []string `graphql:"aliases"`
-	ClientEmail           string   `graphql:"clientEmail"`
-	OwnershipTagKeys      []string `graphql:"ownershipTagKeys"`
-	Projects              []string `graphql:"projects"`
-	TagsOverrideOwnership bool     `graphql:"tagsOverrideOwnership"`
+	Aliases               []string             `graphql:"aliases"`
+	ClientEmail           string               `graphql:"clientEmail"`
+	OwnershipTagKeys      []string             `graphql:"ownershipTagKeys"`
+	Projects              []GoogleCloudProject `graphql:"projects"`
+	TagsOverrideOwnership bool                 `graphql:"tagsOverrideOwnership"`
 }
 
 type NewRelicIntegrationFragment struct {

--- a/integration.go
+++ b/integration.go
@@ -208,3 +208,32 @@ func (client *Client) UpdateIntegrationAzureResources(identifier string, input A
 	err := client.Mutate(&m, v, WithName("AzureResourcesIntegrationUpdate"))
 	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
+
+func (client *Client) CreateIntegrationGCP(input GoogleCloudIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload struct {
+			Integration *Integration
+			Errors      []OpsLevelErrors
+		} `graphql:"googleCloudIntegrationCreate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("GoogleCloudIntegrationCreate"))
+	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) UpdateIntegrationGCP(identifier string, input GoogleCloudIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload struct {
+			Integration *Integration
+			Errors      []OpsLevelErrors
+		} `graphql:"googleCloudIntegrationUpdate(integration: $integration input: $input)"`
+	}
+	v := PayloadVariables{
+		"integration": *NewIdentifier(identifier),
+		"input":       input,
+	}
+	err := client.Mutate(&m, v, WithName("GoogleCloudIntegrationUpdate"))
+	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}

--- a/integration.go
+++ b/integration.go
@@ -27,6 +27,14 @@ type AzureResourcesIntegrationFragment struct {
 	TenantId              string   `graphql:"tenantId"`
 }
 
+type GoogleCloudIntegrationFragment struct {
+	Aliases               []string `graphql:"aliases"`
+	ClientEmail           string   `graphql:"clientEmail"`
+	OwnershipTagKeys      []string `graphql:"ownershipTagKeys"`
+	Projects              []string `graphql:"projects"`
+	TagsOverrideOwnership bool     `graphql:"tagsOverrideOwnership"`
+}
+
 type NewRelicIntegrationFragment struct {
 	BaseUrl    string `graphql:"baseUrl"`
 	AccountKey string `graphql:"accountKey"`

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"input": { "iamRole": "arn:aws:iam::XXXX:role/aws-integration-role", "externalId": "123456789", "ownershipTagKeys": ["owner"] }}`,
 		`{"data": {
       "awsIntegrationCreate": {
@@ -46,7 +46,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 func TestCreateAzureResourcesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"input": { "name": "new azure resources", "tenantId": "12345678-1234-1234-1234-123456789abc", "subscriptionId": "12345678-1234-1234-1234-123456789def", "clientId": "XXX_client_id_XXX", "clientSecret": "XXX_client_secret_XXX"}}`,
 		`{"data": {
       "azureResourcesIntegrationCreate": {
@@ -84,7 +84,7 @@ func TestCreateAzureResourcesIntegration(t *testing.T) {
 func TestCreateGoogleCloudIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation GoogleCloudIntegrationCreate($input:GoogleCloudIntegrationInput!){googleCloudIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation GoogleCloudIntegrationCreate($input:GoogleCloudIntegrationInput!){googleCloudIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"input": { "name": "new gcp integration", "ownershipTagKeys": ["owner", "team", "opslevel_team"], "privateKey": "XXX_PRIVATE_KEY_XXX", "clientEmail": "helloworld@appspot.gserviceaccount.com", "tagsOverrideOwnership": true }}`,
 		`{"data": {
       "googleCloudIntegrationCreate": {
@@ -95,7 +95,7 @@ func TestCreateGoogleCloudIntegration(t *testing.T) {
           "createdAt": "2024-07-04T16:25:29.574450Z",
           "installedAt": "2024-07-04T16:25:28.541124Z",
           "ownershipTagKeys": ["owner", "team", "opslevel_team"],
-          "projects": ["my-project-1", "my-project-2"],
+          "projects": [{"id": "123", "name": "my-project-1", "url": "XXX_URL_XXX"}],
           "aliases": ["new_gcp_integration"],
           "clientEmail": "helloworld@appspot.gserviceaccount.com",
           "tagsOverrideOwnership": true
@@ -120,13 +120,15 @@ func TestCreateGoogleCloudIntegration(t *testing.T) {
 	autopilot.Equals(t, true, result.GoogleCloudIntegrationFragment.TagsOverrideOwnership)
 	autopilot.Equals(t, result.GoogleCloudIntegrationFragment.OwnershipTagKeys, []string{"owner", "team", "opslevel_team"})
 	autopilot.Equals(t, []string{"new_gcp_integration"}, result.GoogleCloudIntegrationFragment.Aliases)
-	autopilot.Equals(t, []string{"my-project-1", "my-project-2"}, result.Projects)
+	autopilot.Equals(t, []opslevel.GoogleCloudProject{
+		{ID: "123", Name: "my-project-1", URL: "XXX_URL_XXX"},
+	}, result.Projects)
 }
 
 func TestCreateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{ "input": { "apiKey": "123456789", "baseUrl": "https://api.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationCreate": {
@@ -157,7 +159,7 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}}}}`,
 		`{ {{ template "id1" }} }`,
 		`{"data": {
       "account": {
@@ -180,7 +182,7 @@ func TestGetIntegration(t *testing.T) {
 func TestGetMissingIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}}}}`,
 		`{ {{ template "id2" }} }`,
 		`{"data": { "account": { "integration": null }}}`,
 	)
@@ -194,12 +196,12 @@ func TestGetMissingIntegration(t *testing.T) {
 func TestListIntegrations(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "deploy_integration_response" }} }, { {{ template "payload_integration_response" }} } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 2 }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "kubernetes_integration_response" }} } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
 	)
@@ -219,7 +221,7 @@ func TestListIntegrations(t *testing.T) {
 func TestUpdateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "Dev2", "externalId": "123456789", "ownershipTagKeys": null }}`,
 		`{"data": {
       "awsIntegrationUpdate": {
@@ -254,7 +256,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 func TestUpdateAzureResourcesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "updated azure resources", "clientId": "updated client id", "clientSecret": "updated client secret" }}`,
 		`{"data": {
       "azureResourcesIntegrationUpdate": {
@@ -290,7 +292,7 @@ func TestUpdateAzureResourcesIntegration(t *testing.T) {
 func TestUpdateGoogleCloudIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation GoogleCloudIntegrationUpdate($input:GoogleCloudIntegrationInput!$integration:IdentifierInput!){googleCloudIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation GoogleCloudIntegrationUpdate($input:GoogleCloudIntegrationInput!$integration:IdentifierInput!){googleCloudIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{ "integration": { {{ template "id1" }} }, "input": { "name": "updated gcp", "ownershipTagKeys": ["team", "opslevel_team"], "privateKey": "XXX_PRIVATE_KEY_2_XXX", "clientEmail": "helloworld_2@appspot.gserviceaccount.com", "tagsOverrideOwnership": false }}`,
 		`{"data": {
       "googleCloudIntegrationUpdate": {
@@ -301,7 +303,7 @@ func TestUpdateGoogleCloudIntegration(t *testing.T) {
           "createdAt": "2024-07-04T16:25:29.574450Z",
           "installedAt": "2024-07-04T16:25:28.541124Z",
           "ownershipTagKeys": ["team", "opslevel_team"],
-          "projects": ["my-project-1", "my-project-2"],
+          "projects": [{"id": "123", "name": "my-project-1", "url": "XXX_URL_XXX"}],
           "aliases": ["new_gcp_integration", "updated_gcp"],
           "clientEmail": "helloworld_2@appspot.gserviceaccount.com",
           "tagsOverrideOwnership": false
@@ -326,13 +328,15 @@ func TestUpdateGoogleCloudIntegration(t *testing.T) {
 	autopilot.Equals(t, false, result.GoogleCloudIntegrationFragment.TagsOverrideOwnership)
 	autopilot.Equals(t, result.GoogleCloudIntegrationFragment.OwnershipTagKeys, []string{"team", "opslevel_team"})
 	autopilot.Equals(t, []string{"new_gcp_integration", "updated_gcp"}, result.GoogleCloudIntegrationFragment.Aliases)
-	autopilot.Equals(t, []string{"my-project-1", "my-project-2"}, result.Projects)
+	autopilot.Equals(t, []opslevel.GoogleCloudProject{
+		{ID: "123", Name: "my-project-1", URL: "XXX_URL_XXX"},
+	}, result.Projects)
 }
 
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"resource": { {{ template "id1" }} }, "input": { "baseUrl": "https://api-test.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationUpdate": {

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestCreateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AWSIntegrationCreate($input:AwsIntegrationInput!){awsIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"input": { "iamRole": "arn:aws:iam::XXXX:role/aws-integration-role", "externalId": "123456789", "ownershipTagKeys": ["owner"] }}`,
 		`{"data": {
       "awsIntegrationCreate": {
@@ -46,7 +46,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 func TestCreateAzureResourcesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AzureResourcesIntegrationCreate($input:AzureResourcesIntegrationInput!){azureResourcesIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"input": { "name": "new azure resources", "tenantId": "12345678-1234-1234-1234-123456789abc", "subscriptionId": "12345678-1234-1234-1234-123456789def", "clientId": "XXX_client_id_XXX", "clientSecret": "XXX_client_secret_XXX"}}`,
 		`{"data": {
       "azureResourcesIntegrationCreate": {
@@ -58,7 +58,7 @@ func TestCreateAzureResourcesIntegration(t *testing.T) {
           "installedAt": "2024-07-04T16:25:28.541124Z",
           "tenantId": "12345678-1234-1234-1234-123456789abc",
           "subscriptionId": "12345678-1234-1234-1234-123456789def",
-          "aliases": []
+          "aliases": ["new_azure_resources"]
         },
         "errors": []
       }}}`,
@@ -78,13 +78,13 @@ func TestCreateAzureResourcesIntegration(t *testing.T) {
 	autopilot.Equals(t, "new azure resources", result.Name)
 	autopilot.Equals(t, "12345678-1234-1234-1234-123456789abc", result.TenantId)
 	autopilot.Equals(t, "12345678-1234-1234-1234-123456789def", result.SubscriptionId)
-	autopilot.Equals(t, []string{}, result.Aliases)
+	autopilot.Equals(t, []string{"new_azure_resources"}, result.AzureResourcesIntegrationFragment.Aliases)
 }
 
 func TestCreateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationCreate($input:NewRelicIntegrationInput!){newRelicIntegrationCreate(input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
 		`{ "input": { "apiKey": "123456789", "baseUrl": "https://api.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationCreate": {
@@ -115,7 +115,7 @@ func TestCreateNewRelicIntegration(t *testing.T) {
 func TestGetIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}}}}`,
 		`{ {{ template "id1" }} }`,
 		`{"data": {
       "account": {
@@ -138,7 +138,7 @@ func TestGetIntegration(t *testing.T) {
 func TestGetMissingIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}}}}`,
+		`query IntegrationGet($id:ID!){account{integration(id: $id){id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}}}}`,
 		`{ {{ template "id2" }} }`,
 		`{"data": { "account": { "integration": null }}}`,
 	)
@@ -152,12 +152,12 @@ func TestGetMissingIntegration(t *testing.T) {
 func TestListIntegrations(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
 		`{{ template "pagination_initial_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "deploy_integration_response" }} }, { {{ template "payload_integration_response" }} } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 2 }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
+		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor},totalCount}}}`,
 		`{{ template "pagination_second_query_variables" }}`,
 		`{ "data": { "account": { "integrations": { "nodes": [ { {{ template "kubernetes_integration_response" }} } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
 	)
@@ -177,7 +177,7 @@ func TestListIntegrations(t *testing.T) {
 func TestUpdateAWSIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AWSIntegrationUpdate($input:AwsIntegrationInput!$integration:IdentifierInput!){awsIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "Dev2", "externalId": "123456789", "ownershipTagKeys": null }}`,
 		`{"data": {
       "awsIntegrationUpdate": {
@@ -212,7 +212,7 @@ func TestUpdateAWSIntegration(t *testing.T) {
 func TestUpdateAzureResourcesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation AzureResourcesIntegrationUpdate($input:AzureResourcesIntegrationInput!$integration:IdentifierInput!){azureResourcesIntegrationUpdate(integration: $integration input: $input){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"integration": { {{ template "id1" }} }, "input": { "name": "updated azure resources", "clientId": "updated client id", "clientSecret": "updated client secret" }}`,
 		`{"data": {
       "azureResourcesIntegrationUpdate": {
@@ -242,13 +242,13 @@ func TestUpdateAzureResourcesIntegration(t *testing.T) {
 	autopilot.Equals(t, "updated azure resources", result.Name)
 	autopilot.Equals(t, "12345678-1234-1234-1234-123456789abc", result.TenantId)
 	autopilot.Equals(t, "12345678-1234-1234-1234-123456789def", result.SubscriptionId)
-	autopilot.Equals(t, []string{"alias1", "alias2"}, result.Aliases)
+	autopilot.Equals(t, []string{"alias1", "alias2"}, result.AzureResourcesIntegrationFragment.Aliases)
 }
 
 func TestUpdateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey}},errors{message,path}}}`,
+		`mutation NewRelicIntegrationUpdate($input:NewRelicIntegrationInput!$resource:IdentifierInput!){newRelicIntegrationUpdate(input: $input resource: $resource){integration{id,name,type,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on NewRelicIntegration{baseUrl,accountKey},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects,tagsOverrideOwnership}},errors{message,path}}}`,
 		`{"resource": { {{ template "id1" }} }, "input": { "baseUrl": "https://api-test.newrelic.com/graphql" }}`,
 		`{"data": {
       "newRelicIntegrationUpdate": {

--- a/interfaces.go
+++ b/interfaces.go
@@ -64,6 +64,7 @@ type Integration struct {
 	AWSIntegrationFragment            `graphql:"... on AwsIntegration"`
 	AzureResourcesIntegrationFragment `graphql:"... on AzureResourcesIntegration"`
 	NewRelicIntegrationFragment       `graphql:"... on NewRelicIntegration"`
+	GoogleCloudIntegrationFragment    `graphql:"... on GoogleCloudIntegration"`
 }
 
 // ManualAlertSourceSync represents .


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/419

## Changelog

- [x] add `task gen-internal` that can generate the internal schema so we don't have to annoyingly go in and modify the client.go file every time
- [x] Add in input type, resource type
- [x] Add mutations
- [x] Make a `changie` entry

## Tophatting

See CLI PR - https://github.com/OpsLevel/cli/pull/312
