### PR TITLE
Breaking change log needed after GCP integration support was added (ambiguous selector error)

### DIFF
--- a/.changes/unreleased/Refactor-20240809-144622.yaml
+++ b/.changes/unreleased/Refactor-20240809-144622.yaml
@@ -1,3 +1,3 @@
 kind: Refactor
-body: BREAKING CHANGE - fields on Integration structs must be accessed through the Fragment struct to avoid `ambiguous selector` errors
+body: BREAKING CHANGE - explicitly access "Aliases", "OwnershipTagKeys", and "TagsOverrideOwnership" fields on Integration's nested Fragment structs to avoid `ambiguous selector` errors
 time: 2024-08-09T14:46:22.462174-04:00

--- a/.changes/unreleased/Refactor-20240809-144622.yaml
+++ b/.changes/unreleased/Refactor-20240809-144622.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: BREAKING CHANGE - fields on Integration structs must be accessed through the Fragment struct to avoid `ambiguous selector` errors
+time: 2024-08-09T14:46:22.462174-04:00

--- a/.changes/unreleased/Refactor-20240809-144622.yaml
+++ b/.changes/unreleased/Refactor-20240809-144622.yaml
@@ -1,3 +1,3 @@
 kind: Refactor
-body: BREAKING CHANGE - explicitly access "Aliases", "OwnershipTagKeys", and "TagsOverrideOwnership" fields on Integration's nested Fragment structs to avoid `ambiguous selector` errors
+body: BREAKING CHANGE - must explicitly access `Aliases`, `OwnershipTagKeys`, `TagsOverrideOwnership` on Integration nested Fragment structs to avoid `ambiguous selector` errors
 time: 2024-08-09T14:46:22.462174-04:00


### PR DESCRIPTION
In the new release code referencing fields like `integration.Aliases` will need to specify which fragment is being used to access that field e.g. `integration.GoogleCloudIntegrationFragment.Aliases` to avoid ambiguous selector errors

Example of the error here - https://github.com/OpsLevel/terraform-provider-opslevel/actions/runs/10322515945/job/28577896480

```
Error: opslevel/resource_opslevel_integration_azure_resources.go:53:69: ambiguous selector azureResourcesIntegration.Aliases
Error: opslevel/resource_opslevel_integration_azure_resources.go:71:83: ambiguous selector azureResourcesIntegration.TagsOverrideOwnership (typecheck)
package opslevel
Error: main.go:9:2: could not import github.com/opslevel/terraform-provider-opslevel/opslevel (-: # github.com/opslevel/terraform-provider-opslevel/opslevel
Error: opslevel/resource_opslevel_integration_azure_resources.go:53:69: ambiguous selector azureResourcesIntegration.Aliases
Error: opslevel/resource_opslevel_integration_azure_resources.go:71:83: ambiguous selector azureResourcesIntegration.TagsOverrideOwnership) (typecheck)
	"github.com/opslevel/terraform-provider-opslevel/opslevel"
	^
Error: opslevel/resource_opslevel_filter_test.go:7:13: could not import github.com/opslevel/terraform-provider-opslevel/opslevel (-: # github.com/opslevel/terraform-provider-opslevel/opslevel
Error: opslevel/resource_opslevel_integration_azure_resources.go:53:69: ambiguous selector azureResourcesIntegration.Aliases
Error: opslevel/resource_opslevel_integration_azure_resources.go:71:83: ambiguous selector azureResourcesIntegration.TagsOverrideOwnership) (typecheck)
	opsleveltf "github.com/opslevel/terraform-provider-opslevel/opslevel"
	           ^

```