### PR TITLE
Remove `locked` from AlertSource, InfrastructureResource

### DIFF
--- a/.changes/unreleased/Bugfix-20240813-123252.yaml
+++ b/.changes/unreleased/Bugfix-20240813-123252.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug where AlertSource and InfraResource querires failed because of `locked`
+  field
+time: 2024-08-13T12:32:52.744704-04:00

--- a/alert_source.go
+++ b/alert_source.go
@@ -5,7 +5,6 @@ type AlertSource struct {
 	ExternalId  string              `graphql:"externalId"`
 	Id          ID                  `graphql:"id"`
 	Integration IntegrationId       `graphql:"integration"`
-	Locked      bool                `graphql:"locked"`
 	Name        string              `graphql:"name"`
 	Type        AlertSourceTypeEnum `graphql:"type"`
 	Url         string              `graphql:"url"`

--- a/alert_source_test.go
+++ b/alert_source_test.go
@@ -10,7 +10,7 @@ import (
 func TestCreateAlertSourceService(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation AlertSourceServiceCreate($input:AlertSourceServiceCreateInput!){alertSourceServiceCreate(input: $input){alertSourceService{alertSource{description,externalId,id,integration{id,name,type},locked,name,type,url},id,service{id,aliases},status},errors{message,path}}}`,
+		`mutation AlertSourceServiceCreate($input:AlertSourceServiceCreateInput!){alertSourceServiceCreate(input: $input){alertSourceService{alertSource{description,externalId,id,integration{id,name,type},name,type,url},id,service{id,aliases},status},errors{message,path}}}`,
 		`{"input": { "alertSourceExternalIdentifier": { "externalId": "QWERTY", "type": "datadog" }, "service": { "alias": "example" }}}`,
 		`{"data": { "alertSourceServiceCreate": { "alertSourceService": { "service": { "aliases": ["example"] }}}}}`,
 	)
@@ -28,7 +28,7 @@ func TestCreateAlertSourceService(t *testing.T) {
 func TestGetAlertSourceWithExternalIdentifier(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query AlertSourceGet($externalIdentifier:AlertSourceExternalIdentifier!){account{alertSource(externalIdentifier: $externalIdentifier){description,externalId,id,integration{id,name,type},locked,name,type,url}}}`,
+		`query AlertSourceGet($externalIdentifier:AlertSourceExternalIdentifier!){account{alertSource(externalIdentifier: $externalIdentifier){description,externalId,id,integration{id,name,type},name,type,url}}}`,
 		`{"externalIdentifier": { "type": "datadog", "externalId": "12345678" }}`,
 		`{"data": {
         "account": {
@@ -41,7 +41,6 @@ func TestGetAlertSourceWithExternalIdentifier(t *testing.T) {
               "id": "Z2lkOi8vb3BzbGV2ZWwvSW50ZWdyYXRpb25zOjpQYWdlcmR1dHlJbnRlZ3JhdGlvbi8zMg",
               "type": "datadog"
             },
-            "locked": true,
             "name": "Example",
             "type": "datadog",
             "url": "https://example.com"
@@ -59,14 +58,13 @@ func TestGetAlertSourceWithExternalIdentifier(t *testing.T) {
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, "Example", result.Name)
 	autopilot.Equals(t, "test", result.Description)
-	autopilot.Equals(t, true, result.Locked)
 	autopilot.Equals(t, ol.AlertSourceTypeEnumDatadog, result.Type)
 }
 
 func TestGetAlertSource(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query AlertSourceGet($id:ID!){account{alertSource(id: $id){description,externalId,id,integration{id,name,type},locked,name,type,url}}}`,
+		`query AlertSourceGet($id:ID!){account{alertSource(id: $id){description,externalId,id,integration{id,name,type},name,type,url}}}`,
 		`{"id": "Z2lkOi8vb3BzbGV2ZWwvQWxlcnRTb3VyY2VzOjpQYWdlcmR1dHkvNjE" }`,
 		`{"data": {
         "account": {
@@ -79,7 +77,6 @@ func TestGetAlertSource(t *testing.T) {
               "id": "Z2lkOi8vb3BzbGV2ZWwvSW50ZWdyYXRpb25zOjpQYWdlcmR1dHlJbnRlZ3JhdGlvbi8zMg",
               "type": "datadog"
             },
-            "locked": false,
             "name": "Example",
             "type": "datadog",
             "url": "https://example.com"
@@ -93,7 +90,6 @@ func TestGetAlertSource(t *testing.T) {
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, "Example", result.Name)
 	autopilot.Equals(t, "test", result.Description)
-	autopilot.Equals(t, false, result.Locked)
 	autopilot.Equals(t, ol.AlertSourceTypeEnumDatadog, result.Type)
 }
 

--- a/infra.go
+++ b/infra.go
@@ -30,7 +30,6 @@ type InfrastructureResource struct {
 	Schema       string                             `json:"type" graphql:"type @include(if: $all)"`
 	ProviderType string                             `json:"providerResourceType" graphql:"providerResourceType @include(if: $all)"`
 	ProviderData InfrastructureResourceProviderData `json:"providerData" graphql:"providerData @include(if: $all)"`
-	Locked       bool                               `json:"locked" graphql:"locked"`
 	Owner        EntityOwner                        `json:"owner" graphql:"owner @include(if: $all)"`
 	OwnerLocked  bool                               `json:"ownerLocked" graphql:"ownerLocked @include(if: $all)"`
 	ParsedData   JSON                               `json:"data" scalar:"true" graphql:"data @include(if: $all)"`

--- a/infra_test.go
+++ b/infra_test.go
@@ -10,7 +10,7 @@ import (
 func TestCreateInfra(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation InfrastructureResourceCreate($all:Boolean!$input:InfrastructureResourceInput!){infrastructureResourceCreate(input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}`,
+		`mutation InfrastructureResourceCreate($all:Boolean!$input:InfrastructureResourceInput!){infrastructureResourceCreate(input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}`,
 		`{
     "all": true,
     "input": {
@@ -59,7 +59,7 @@ func TestCreateInfra(t *testing.T) {
 func TestGetInfra(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
+		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
 		`{"all": true, "input":{ {{ template "id1" }} }}`,
 		`{"data": { "account": { "infrastructureResource": {{ template "infra_1" }} }}}`,
 	)
@@ -101,12 +101,12 @@ func TestListInfraSchemas(t *testing.T) {
 func TestListInfra(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
 		`{ "after": "", "all": true, "first": 100 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_1" }}, {{ template "infra_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
+		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
 		`{ "after": "OA", "all": true, "first": 100 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
@@ -120,9 +120,6 @@ func TestListInfra(t *testing.T) {
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, 3, response.TotalCount)
 	autopilot.Equals(t, 3, response.TotalCount)
-	autopilot.Equals(t, true, result[0].Locked)
-	autopilot.Equals(t, false, result[1].Locked)
-	autopilot.Equals(t, false, result[2].Locked)
 	autopilot.Equals(t, "vpc-XXXXXXXXXX", result[1].Name)
 	autopilot.Equals(t, "production-demo", result[2].Name)
 }
@@ -130,7 +127,7 @@ func TestListInfra(t *testing.T) {
 func TestUpdateInfra(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}`,
+		`mutation InfrastructureResourceUpdate($all:Boolean!$identifier:IdentifierInput!$input:InfrastructureResourceInput!){infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input){infrastructureResource{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},warnings{message},errors{message,path}}}`,
 		`{"all": true, "identifier": { {{ template "id1" }}}, "input": { "ownerId": "{{ template "id1_string" }}", "schema": {"type": "Database"}, "data": "{\"endpoint\":\"https://google.com\",\"engine\":\"BigQuery\",\"name\":\"my-big-query\",\"replica\":false}" }}`,
 		`{"data": { "infrastructureResourceUpdate": { "infrastructureResource": {{ template "infra_1" }}, "warnings": [], "errors": [] }}}`,
 	)
@@ -265,7 +262,7 @@ func TestInfraReconcileAliasesDeleteAll(t *testing.T) {
 	)
 	// get infrastructureResource
 	testRequestThree := autopilot.NewTestRequest(
-		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
+		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
 		`{"all": true, "input":{ {{ template "id1" }} }}`,
 		`{"data": { "account": { "infrastructureResource": { {{ template "id1" }}, "aliases": [] } }}}`,
 	)
@@ -314,7 +311,7 @@ func TestInfraReconcileAliases(t *testing.T) {
 	)
 	// get infrastructureResource
 	testRequestFive := autopilot.NewTestRequest(
-		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},locked,owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
+		`query InfrastructureResourceGet($all:Boolean!$input:IdentifierInput!){account{infrastructureResource(input: $input){id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)}}}`,
 		`{"all": true, "input":{ {{ template "id1" }} }}`,
 		`{"data": { "account": { "infrastructureResource": { {{ template "id1" }}, "aliases": ["one", "two", "three"] } }}}`,
 	)

--- a/testdata/templates/infrastructure.tpl
+++ b/testdata/templates/infrastructure.tpl
@@ -7,7 +7,6 @@
     "owner": {
       {{ template "id1" }}
     },
-    "locked": true,
     "ownerLocked": false,
     "data": {
       "name": "my-big-query",
@@ -26,7 +25,6 @@
     "name": "vpc-XXXXXXXXXX",
     "type": "Network",
     "owner": null,
-    "locked": false,
     "ownerLocked": false,
     "data": {
       "name": "vpc-XXXXXXXXXX",


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/opslevel-go/pull/434 -- correction for this PR, these two resources don't support a `locked` field and never have.

## Changelog

- [x] Remove field, ensure tests pass
- [x] Make a `changie` entry

