### PR TITLE
tags with matching keys no longer lost on update

### DIFF
--- a/.changes/unreleased/Bugfix-20240821-135739.yaml
+++ b/.changes/unreleased/Bugfix-20240821-135739.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: tags with matching keys no longer lost on update, ReconcileTags() passes correct tags to tagAssign
+time: 2024-08-21T13:57:39.827615-05:00

--- a/export_test.go
+++ b/export_test.go
@@ -5,7 +5,6 @@ package opslevel
 // Running `go help build` displays:
 // When compiling packages, build ignores files that end in '_test.go'.
 var (
-	ExtractAliases           = extractAliases
-	ExtractTagIdsToDelete    = extractTagIdsToDelete
-	ExtractTagInputsToCreate = extractTagInputsToCreate
+	ExtractAliases        = extractAliases
+	ExtractTagIdsToDelete = extractTagIdsToDelete
 )

--- a/tags_test.go
+++ b/tags_test.go
@@ -61,49 +61,6 @@ func TestExtractTagIdsToDelete(t *testing.T) {
 	}
 }
 
-type extractTagInputsTestCase struct {
-	existingTags              []ol.Tag
-	expectedTagInputsToCreate []ol.TagInput
-	tagsWanted                []ol.Tag
-}
-
-func TestExtractTagInputsToCreate(t *testing.T) {
-	var noTagInputs []ol.TagInput
-	allTagInputs := []ol.TagInput{
-		{Key: tagOne.Key, Value: tagOne.Value},
-		{Key: tagTwo.Key, Value: tagTwo.Value},
-		{Key: tagThree.Key, Value: tagThree.Value},
-		{Key: tagFour.Key, Value: tagFour.Value},
-	}
-	// Arrange
-	testCases := map[string]extractTagInputsTestCase{
-		"create all": {
-			tagsWanted:                allTags,
-			existingTags:              noTags,
-			expectedTagInputsToCreate: allTagInputs,
-		},
-		"create none": {
-			tagsWanted:                noTags,
-			existingTags:              allTags,
-			expectedTagInputsToCreate: noTagInputs,
-		},
-		"create some": {
-			tagsWanted:                []ol.Tag{tagOne, tagTwo, tagThree},
-			existingTags:              []ol.Tag{tagOne, tagTwo},
-			expectedTagInputsToCreate: []ol.TagInput{{Key: tagThree.Key, Value: tagThree.Value}},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			// Act
-			tagInputsToCreate := ol.ExtractTagInputsToCreate(tc.existingTags, tc.tagsWanted)
-
-			// Assert
-			autopilot.Equals(t, tagInputsToCreate, tc.expectedTagInputsToCreate)
-		})
-	}
-}
-
 type tagHasSameKeyValueTestCase struct {
 	tagOne          ol.Tag
 	tagTwo          ol.Tag


### PR DESCRIPTION
## Issues

[Bug when adding new tags to an opslevel_service that already has existing tags](https://github.com/OpsLevel/terraform-provider-opslevel/issues/437)

## Changelog

Stop filtering existingTags out of tagsWanted during ReconcileTags(). 
When multiple tags with same key exist, they should all be passed to `tagAssign()`. As is, updating a service with tag `foo:bar` with both `foo:bar` and `foo:bar123` will not work. `foo:bar` already exists, is dropped, then tagAssign only includes `foo:bar123` which replaces `foo:bar`. These lost tags only occurs when the keys (e.g. `foo`) match

Remove `extractTagInputsToCreate()` as it's no longer needed

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
