### PR TITLE
add Systems field to Cacher struct and related caching operations

### DIFF
--- a/.changes/unreleased/Feature-20240821-150044.yaml
+++ b/.changes/unreleased/Feature-20240821-150044.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add Systems to Cacher struct, and related caching operations
+time: 2024-08-21T15:00:44.097316-05:00


### PR DESCRIPTION
## Issues

[Add a system cache to opslevel-go](https://github.com/OpsLevel/team-platform/issues/295)

## Changelog

Add `Systems` field to `Cacher` struct and add `TryGetSystems()`, `doCacheSystems()`, and `CacheSystems()` member functions. With tests.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
