### PR TITLE
Fix Reconcile Tags

### DIFF
--- a/.changes/unreleased/Bugfix-20240826-110607.yaml
+++ b/.changes/unreleased/Bugfix-20240826-110607.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug with ReconcileTags not properly reconciling the tags due to incorrect
+  behavior of TagAssign mutation.
+time: 2024-08-26T11:06:07.874443-05:00

--- a/aliases_test.go
+++ b/aliases_test.go
@@ -47,7 +47,7 @@ func TestExtractAliases(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// Act
-			aliasesToCreate, aliasesToDelete := ol.ExtractAliases(tc.existingAliases, tc.aliasesWanted)
+			aliasesToCreate, aliasesToDelete := ol.TestExtractAliases(tc.existingAliases, tc.aliasesWanted)
 
 			// Assert
 			autopilot.Equals(t, aliasesToCreate, tc.expectedAliasesToCreate)

--- a/export_test.go
+++ b/export_test.go
@@ -5,7 +5,6 @@ package opslevel
 // Running `go help build` displays:
 // When compiling packages, build ignores files that end in '_test.go'.
 var (
-	ExtractAliases           = extractAliases
-	ExtractTagIdsToDelete    = extractTagIdsToDelete
-	ExtractTagInputsToCreate = extractTagInputsToCreate
+	TestExtractAliases = extractAliases
+	TestReconcileTags  = reconcileTags
 )

--- a/tags_test.go
+++ b/tags_test.go
@@ -14,7 +14,6 @@ var (
 	tagThree = ol.Tag{Id: id3, Key: "prod", Value: "true"}
 	tagFour  = ol.Tag{Id: id4, Key: "env", Value: "prod"}
 	tagFive  = ol.Tag{Id: id4, Key: "foo", Value: "baz"}
-	allTags  = []ol.Tag{tagOne, tagTwo, tagThree, tagFour}
 )
 
 type reconcileTagsTestCase struct {
@@ -28,15 +27,15 @@ func TestReconcileTags(t *testing.T) {
 	// Arrange
 	testCases := map[string]reconcileTagsTestCase{
 		"create all": {
-			current:  []ol.Tag{},
+			current:  noTags,
 			desired:  []ol.Tag{tagOne, tagTwo},
 			toCreate: []ol.Tag{tagOne, tagTwo},
-			toDelete: []ol.Tag{},
+			toDelete: noTags,
 		},
 		"delete all": {
 			current:  []ol.Tag{tagOne, tagTwo},
-			desired:  []ol.Tag{},
-			toCreate: []ol.Tag{},
+			desired:  noTags,
+			toCreate: noTags,
 			toDelete: []ol.Tag{tagOne, tagTwo},
 		},
 		"create one delete one": {
@@ -60,14 +59,14 @@ func TestReconcileTags(t *testing.T) {
 		"no create no delete": {
 			current:  []ol.Tag{tagOne, tagTwo},
 			desired:  []ol.Tag{tagOne, tagTwo},
-			toCreate: []ol.Tag{},
-			toDelete: []ol.Tag{},
+			toCreate: noTags,
+			toDelete: noTags,
 		},
 		"null": {
-			current:  []ol.Tag{},
-			desired:  []ol.Tag{},
-			toCreate: []ol.Tag{},
-			toDelete: []ol.Tag{},
+			current:  noTags,
+			desired:  noTags,
+			toCreate: noTags,
+			toDelete: noTags,
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
Resolves #

### Problem

Previously ReconcileTags was not properly reconciling the tags of a taggable resource, some tags weren't getting deleted and some tags were sticking around incorrectly.

### Solution

After deep discovery - we have determined that we need to use TagCreate and TagDelete directly and perform the reconciliation ourselves.  Additionally i've ensured via table tests `TestReconcileTags` that we cover all the different permutations of current tags and desired tags to ensure we perform the correct API calls.  Then i've added a test `TestReconcileTagsAPI` to ensure we actually make those API calls.

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Does this change require a Terraform schema change?
  - If so what is the ticket or PR # TBD
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
