### PR TITLE
Add component CRUD functions

### DIFF
--- a/.changes/unreleased/Feature-20250128-154352.yaml
+++ b/.changes/unreleased/Feature-20250128-154352.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add aliases functions for CRUD components that use the old services CRUD functions
+time: 2025-01-28T15:43:52.087885-06:00

--- a/.changes/unreleased/Refactor-20250128-154312.yaml
+++ b/.changes/unreleased/Refactor-20250128-154312.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: 'BREAKING CHANGE: client.GetService now properly takes in an identifier and
+  calls the appropreate queries for alias or id'
+time: 2025-01-28T15:43:12.187193-06:00

--- a/actions.go
+++ b/actions.go
@@ -56,7 +56,7 @@ type CustomActionsTriggerDefinitionsConnection struct {
 
 func (client *Client) CreateWebhookAction(input CustomActionsWebhookActionCreateInput) (*CustomActionsExternalAction, error) {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			WebhookAction CustomActionsExternalAction
 			Errors        []Error
 		} `graphql:"customActionsWebhookActionCreate(input: $input)"`
@@ -110,7 +110,7 @@ func (client *Client) ListCustomActions(variables *PayloadVariables) (*CustomAct
 
 func (client *Client) UpdateWebhookAction(input CustomActionsWebhookActionUpdateInput) (*CustomActionsExternalAction, error) {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			WebhookAction CustomActionsExternalAction
 			Errors        []Error
 		} `graphql:"customActionsWebhookActionUpdate(input: $input)"`
@@ -124,9 +124,7 @@ func (client *Client) UpdateWebhookAction(input CustomActionsWebhookActionUpdate
 
 func (client *Client) DeleteWebhookAction(input string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"customActionsWebhookActionDelete(resource: $input)"`
+		Payload BasePayload `graphql:"customActionsWebhookActionDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(input),
@@ -137,10 +135,7 @@ func (client *Client) DeleteWebhookAction(input string) error {
 
 func (client *Client) CreateTriggerDefinition(input CustomActionsTriggerDefinitionCreateInput) (*CustomActionsTriggerDefinition, error) {
 	var m struct {
-		Payload struct {
-			TriggerDefinition CustomActionsTriggerDefinition
-			Errors            []Error
-		} `graphql:"customActionsTriggerDefinitionCreate(input: $input)"`
+		Payload CustomActionsTriggerDefinitionCreatePayload `graphql:"customActionsTriggerDefinitionCreate(input: $input)"`
 	}
 	if input.AccessControl == nil {
 		input.AccessControl = &CustomActionsTriggerDefinitionAccessControlEnumEveryone
@@ -198,10 +193,7 @@ func (client *Client) ListTriggerDefinitions(variables *PayloadVariables) (*Cust
 
 func (client *Client) UpdateTriggerDefinition(input CustomActionsTriggerDefinitionUpdateInput) (*CustomActionsTriggerDefinition, error) {
 	var m struct {
-		Payload struct {
-			TriggerDefinition CustomActionsTriggerDefinition
-			Errors            []Error
-		} `graphql:"customActionsTriggerDefinitionUpdate(input: $input)"`
+		Payload CustomActionsTriggerDefinitionUpdatePayload `graphql:"customActionsTriggerDefinitionUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -212,9 +204,7 @@ func (client *Client) UpdateTriggerDefinition(input CustomActionsTriggerDefiniti
 
 func (client *Client) DeleteTriggerDefinition(input string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"customActionsTriggerDefinitionDelete(resource: $input)"`
+		Payload BasePayload `graphql:"customActionsTriggerDefinitionDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(input),

--- a/alert_source.go
+++ b/alert_source.go
@@ -14,10 +14,7 @@ func NewAlertSource(kind AlertSourceTypeEnum, id string) *AlertSourceExternalIde
 
 func (client *Client) CreateAlertSourceService(input AlertSourceServiceCreateInput) (*AlertSourceService, error) {
 	var m struct {
-		Payload struct {
-			AlertSourceService AlertSourceService
-			Errors             []Error
-		} `graphql:"alertSourceServiceCreate(input: $input)"`
+		Payload AlertSourceServiceCreatePayload `graphql:"alertSourceServiceCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -56,9 +53,7 @@ func (client *Client) GetAlertSource(id ID) (*AlertSource, error) {
 
 func (client *Client) DeleteAlertSourceService(id ID) error {
 	var m struct {
-		Payload struct {
-			Errors []Error
-		} `graphql:"alertSourceServiceDelete(input: $input)"`
+		Payload BasePayload `graphql:"alertSourceServiceDelete(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": AlertSourceDeleteInput{Id: id},

--- a/aliases.go
+++ b/aliases.go
@@ -61,11 +61,7 @@ func (client *Client) CreateAliases(ownerId ID, aliases []string) ([]string, err
 
 func (client *Client) CreateAlias(input AliasCreateInput) ([]string, error) {
 	var m struct {
-		Payload struct {
-			Aliases []string
-			OwnerId string
-			Errors  []Error
-		} `graphql:"aliasCreate(input: $input)"`
+		Payload AliasCreatePayload `graphql:"aliasCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -116,9 +112,9 @@ func (client *Client) DeleteAliases(aliasOwnerType AliasOwnerTypeEnum, aliases [
 
 func (client *Client) DeleteAlias(input AliasDeleteInput) error {
 	var m struct {
-		Payload struct {
-			Alias  string `graphql:"deletedAlias"`
-			Errors []Error
+		Payload struct { // TODO: we don't need this but removing it breaks alot of tests
+			Alias string `graphql:"deletedAlias"`
+			BasePayload
 		} `graphql:"aliasDelete(input: $input)"`
 	}
 	v := PayloadVariables{

--- a/aliases.go
+++ b/aliases.go
@@ -18,7 +18,7 @@ func (client *Client) GetAliasableResource(resourceType AliasOwnerTypeEnum, iden
 	switch resourceType {
 	case AliasOwnerTypeEnumService:
 		if IsID(identifier) {
-			aliasableResource, err = client.GetService(ID(identifier))
+			aliasableResource, err = client.GetService(identifier)
 		} else {
 			aliasableResource, err = client.GetServiceWithAlias(identifier)
 		}

--- a/category.go
+++ b/category.go
@@ -19,10 +19,7 @@ func (category *Category) Alias() string {
 
 func (client *Client) CreateCategory(input CategoryCreateInput) (*Category, error) {
 	var m struct {
-		Payload struct {
-			Category Category
-			Errors   []Error
-		} `graphql:"categoryCreate(input: $input)"`
+		Payload CategoryCreatePayload `graphql:"categoryCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -79,10 +76,7 @@ func (client *Client) ListCategories(variables *PayloadVariables) (*CategoryConn
 
 func (client *Client) UpdateCategory(input CategoryUpdateInput) (*Category, error) {
 	var m struct {
-		Payload struct {
-			Category Category
-			Errors   []Error
-		} `graphql:"categoryUpdate(input: $input)"`
+		Payload CategoryUpdatePayload `graphql:"categoryUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -93,9 +87,9 @@ func (client *Client) UpdateCategory(input CategoryUpdateInput) (*Category, erro
 
 func (client *Client) DeleteCategory(id ID) error {
 	var m struct {
-		Payload struct {
-			Id     ID `graphql:"deletedCategoryId"`
-			Errors []Error
+		Payload struct { // TODO: we don't need this but removing it breaks alot of tests
+			Id ID `graphql:"deletedCategoryId"`
+			BasePayload
 		} `graphql:"categoryDelete(input: $input)"`
 	}
 	v := PayloadVariables{

--- a/check.go
+++ b/check.go
@@ -127,12 +127,6 @@ func NewCheckUpdateInputTypeOf[T any](checkUpdateInput CheckUpdateInput) *T {
 	return newCheck
 }
 
-// CheckResponsePayload encompasses CheckCreatePayload and CheckUpdatePayload into 1 struct
-type CheckResponsePayload struct {
-	Check  Check
-	Errors []Error
-}
-
 func (client *Client) CreateCheck(input any) (*Check, error) {
 	switch v := input.(type) {
 	case *CheckAlertSourceUsageCreateInput:
@@ -265,9 +259,7 @@ func (client *Client) UpdateCheck(input any) (*Check, error) {
 
 func (client *Client) DeleteCheck(id ID) error {
 	var m struct {
-		Payload struct {
-			Errors []Error
-		} `graphql:"checkDelete(input: $input)"`
+		Payload BasePayload `graphql:"checkDelete(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": CheckDeleteInput{Id: RefOf(id)},

--- a/component.go
+++ b/component.go
@@ -1,5 +1,13 @@
 package opslevel
 
+type Component Service
+
+type ComponentCreateInput ServiceCreateInput
+
+type ComponentUpdateInput ServiceUpdateInput
+
+type ComponentConnection ServiceConnection
+
 type ComponentTypeConnection struct {
 	Nodes      []ComponentType `json:"nodes"`
 	PageInfo   PageInfo        `json:"pageInfo"`
@@ -20,6 +28,11 @@ func (client *Client) CreateComponentType(input ComponentTypeInput) (*ComponentT
 	return &m.Payload.ComponentType, HandleErrors(err, m.Payload.Errors)
 }
 
+func (client *Client) CreateComponent(input ComponentCreateInput) (*Component, error) {
+	resource, err := client.CreateService(ServiceCreateInput(input))
+	return any(resource).(*Component), err
+}
+
 func (client *Client) GetComponentType(identifier string) (*ComponentType, error) {
 	var q struct {
 		Account struct {
@@ -31,6 +44,11 @@ func (client *Client) GetComponentType(identifier string) (*ComponentType, error
 	}
 	err := client.Query(&q, v, WithName("ComponentTypeGet"))
 	return &q.Account.ComponentType, HandleErrors(err, nil)
+}
+
+func (client *Client) GetComponent(identifier string) (*Component, error) {
+	resource, err := client.GetService(identifier)
+	return any(resource).(*Component), err
 }
 
 func (client *Client) ListComponentTypes(variables *PayloadVariables) (*ComponentTypeConnection, error) {
@@ -58,6 +76,11 @@ func (client *Client) ListComponentTypes(variables *PayloadVariables) (*Componen
 	return &q.Account.ComponentTypes, nil
 }
 
+func (client *Client) ListComponents(variables *PayloadVariables) (*ComponentConnection, error) {
+	resource, err := client.ListServices(variables)
+	return any(resource).(*ComponentConnection), err
+}
+
 func (client *Client) UpdateComponentType(identifier string, input ComponentTypeInput) (*ComponentType, error) {
 	var m struct {
 		Payload struct {
@@ -73,6 +96,11 @@ func (client *Client) UpdateComponentType(identifier string, input ComponentType
 	return &m.Payload.ComponentType, HandleErrors(err, m.Payload.Errors)
 }
 
+func (client *Client) UpdateComponent(input ComponentUpdateInput) (*Component, error) {
+	resource, err := client.UpdateService(ServiceUpdateInput(input))
+	return any(resource).(*Component), err
+}
+
 func (client *Client) DeleteComponentType(identifier string) error {
 	var d struct {
 		Payload struct {
@@ -84,4 +112,8 @@ func (client *Client) DeleteComponentType(identifier string) error {
 	}
 	err := client.Mutate(&d, v, WithName("ComponentTypeDelete"))
 	return HandleErrors(err, d.Payload.Errors)
+}
+
+func (client *Client) DeleteComponent(identifier string) error {
+	return client.DeleteService(identifier)
 }

--- a/component.go
+++ b/component.go
@@ -16,10 +16,7 @@ type ComponentTypeConnection struct {
 
 func (client *Client) CreateComponentType(input ComponentTypeInput) (*ComponentType, error) {
 	var m struct {
-		Payload struct {
-			ComponentType ComponentType
-			Errors        []Error
-		} `graphql:"componentTypeCreate(input:$input)"`
+		Payload ComponentTypePayload `graphql:"componentTypeCreate(input:$input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -83,10 +80,7 @@ func (client *Client) ListComponents(variables *PayloadVariables) (*ComponentCon
 
 func (client *Client) UpdateComponentType(identifier string, input ComponentTypeInput) (*ComponentType, error) {
 	var m struct {
-		Payload struct {
-			ComponentType ComponentType
-			Errors        []Error
-		} `graphql:"componentTypeUpdate(componentType:$target,input:$input)"`
+		Payload ComponentTypePayload `graphql:"componentTypeUpdate(componentType:$target,input:$input)"`
 	}
 	v := PayloadVariables{
 		"target": *NewIdentifier(identifier),
@@ -103,9 +97,7 @@ func (client *Client) UpdateComponent(input ComponentUpdateInput) (*Component, e
 
 func (client *Client) DeleteComponentType(identifier string) error {
 	var d struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"componentTypeDelete(resource:$target)"`
+		Payload BasePayload `graphql:"componentTypeDelete(resource:$target)"`
 	}
 	v := PayloadVariables{
 		"target": *NewIdentifier(identifier),

--- a/dependencies.go
+++ b/dependencies.go
@@ -35,16 +35,13 @@ type ServiceDependentsConnection struct {
 
 func (client *Client) CreateServiceDependency(input ServiceDependencyCreateInput) (*ServiceDependency, error) {
 	var m struct {
-		Payload struct {
-			ServiceDependency *ServiceDependency
-			Errors            []Error
-		} `graphql:"serviceDependencyCreate(inputV2: $input)"`
+		Payload ServiceDependencyPayload `graphql:"serviceDependencyCreate(inputV2: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("ServiceDependencyCreate"))
-	return m.Payload.ServiceDependency, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.ServiceDependency, HandleErrors(err, m.Payload.Errors)
 }
 
 func (service *Service) GetDependencies(client *Client, variables *PayloadVariables) (*ServiceDependenciesConnection, error) {
@@ -115,9 +112,7 @@ func (service *Service) GetDependents(client *Client, variables *PayloadVariable
 
 func (client *Client) DeleteServiceDependency(id ID) error {
 	var m struct {
-		Payload struct {
-			Errors []Error
-		} `graphql:"serviceDependencyDelete(input: $input)"`
+		Payload BasePayload `graphql:"serviceDependencyDelete(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": DeleteInput{Id: id},

--- a/document.go
+++ b/document.go
@@ -14,10 +14,7 @@ type ServiceDocumentContent struct {
 
 func (client *Client) ServiceApiDocSettingsUpdate(service string, docPath string, docSource *ApiDocumentSourceEnum) (*Service, error) {
 	var m struct {
-		Payload struct {
-			Service Service
-			Errors  []Error
-		} `graphql:"serviceApiDocSettingsUpdate(service: $service, apiDocumentPath: $docPath, preferredApiDocumentSource: $docSource)"`
+		Payload ServiceUpdatePayload `graphql:"serviceApiDocSettingsUpdate(service: $service, apiDocumentPath: $docPath, preferredApiDocumentSource: $docSource)"`
 	}
 	v := PayloadVariables{
 		"service":   *NewIdentifier(service),

--- a/domain.go
+++ b/domain.go
@@ -129,10 +129,7 @@ func (domainId *DomainId) ChildSystems(client *Client, variables *PayloadVariabl
 
 func (domainId *DomainId) AssignSystem(client *Client, systems ...string) error {
 	var m struct {
-		Payload struct {
-			Domain Domain
-			Errors []Error
-		} `graphql:"domainChildAssign(domain:$domain, childSystems:$childSystems)"`
+		Payload DomainPayload `graphql:"domainChildAssign(domain:$domain, childSystems:$childSystems)"`
 	}
 	v := PayloadVariables{
 		"domain":       *NewIdentifier(string(domainId.Id)),
@@ -144,10 +141,7 @@ func (domainId *DomainId) AssignSystem(client *Client, systems ...string) error 
 
 func (client *Client) CreateDomain(input DomainInput) (*Domain, error) {
 	var m struct {
-		Payload struct {
-			Domain Domain
-			Errors []Error
-		} `graphql:"domainCreate(input:$input)"`
+		Payload DomainPayload `graphql:"domainCreate(input:$input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -196,10 +190,7 @@ func (client *Client) ListDomains(variables *PayloadVariables) (*DomainConnectio
 
 func (client *Client) UpdateDomain(identifier string, input DomainInput) (*Domain, error) {
 	var m struct {
-		Payload struct {
-			Domain Domain
-			Errors []Error
-		} `graphql:"domainUpdate(domain:$domain,input:$input)"`
+		Payload DomainPayload `graphql:"domainUpdate(domain:$domain,input:$input)"`
 	}
 	v := PayloadVariables{
 		"domain": *NewIdentifier(identifier),
@@ -211,9 +202,7 @@ func (client *Client) UpdateDomain(identifier string, input DomainInput) (*Domai
 
 func (client *Client) DeleteDomain(identifier string) error {
 	var d struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"domainDelete(resource: $input)"`
+		Payload BasePayload `graphql:"domainDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(identifier),

--- a/filters.go
+++ b/filters.go
@@ -191,10 +191,7 @@ func (filter *Filter) Alias() string {
 
 func (client *Client) CreateFilter(input FilterCreateInput) (*Filter, error) {
 	var m struct {
-		Payload struct {
-			Filter Filter
-			Errors []Error
-		} `graphql:"filterCreate(input: $input)"`
+		Payload FilterCreatePayload `graphql:"filterCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -246,10 +243,7 @@ func (client *Client) ListFilters(variables *PayloadVariables) (*FilterConnectio
 
 func (client *Client) UpdateFilter(input FilterUpdateInput) (*Filter, error) {
 	var m struct {
-		Payload struct {
-			Filter Filter
-			Errors []Error
-		} `graphql:"filterUpdate(input: $input)"`
+		Payload FilterUpdatePayload `graphql:"filterUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -260,7 +254,7 @@ func (client *Client) UpdateFilter(input FilterUpdateInput) (*Filter, error) {
 
 func (client *Client) DeleteFilter(id ID) error {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			Id     ID `graphql:"deletedId"`
 			Errors []Error
 		} `graphql:"filterDelete(input: $input)"`

--- a/infra.go
+++ b/infra.go
@@ -142,17 +142,14 @@ func (client *Client) CreateInfrastructure(input InfraInput) (*InfrastructureRes
 		}
 	}
 	var m struct {
-		Payload struct {
-			InfrastructureResource InfrastructureResource
-			Warnings               []Warning // TODO: handle warnings somehow
-			Errors                 []Error
-		} `graphql:"infrastructureResourceCreate(input: $input)"`
+		Payload InfrastructureResourcePayload `graphql:"infrastructureResourceCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": i,
 		"all":   true,
 	}
 	err := client.Mutate(&m, v, WithName("InfrastructureResourceCreate"))
+	// TODO: handle m.Payload.Warnings somehow
 	return &m.Payload.InfrastructureResource, HandleErrors(err, m.Payload.Errors)
 }
 
@@ -241,11 +238,7 @@ func (client *Client) UpdateInfrastructure(identifier string, input InfraInput) 
 		}
 	}
 	var m struct {
-		Payload struct {
-			InfrastructureResource InfrastructureResource
-			Warnings               []Warning // TODO: handle warnings somehow
-			Errors                 []Error
-		} `graphql:"infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input)"`
+		Payload InfrastructureResourcePayload `graphql:"infrastructureResourceUpdate(infrastructureResource: $identifier, input: $input)"`
 	}
 	v := PayloadVariables{
 		"identifier": *NewIdentifier(identifier),
@@ -253,14 +246,13 @@ func (client *Client) UpdateInfrastructure(identifier string, input InfraInput) 
 		"all":        true,
 	}
 	err := client.Mutate(&m, v, WithName("InfrastructureResourceUpdate"))
+	// TODO: handle m.Payload.Warnings somehow
 	return &m.Payload.InfrastructureResource, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) DeleteInfrastructure(identifier string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"infrastructureResourceDelete(resource: $input)"`
+		Payload BasePayload `graphql:"infrastructureResourceDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(identifier),

--- a/integration.go
+++ b/integration.go
@@ -68,10 +68,7 @@ func (integrationId *IntegrationId) Alias() string {
 
 func (client *Client) CreateIntegrationAWS(input AWSIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"awsIntegrationCreate(input: $input)"`
+		Payload IntegrationCreatePayload `graphql:"awsIntegrationCreate(input: $input)"`
 	}
 	// This is a default in the UI, so we must maintain it
 	if len(input.OwnershipTagKeys) == 0 {
@@ -81,36 +78,30 @@ func (client *Client) CreateIntegrationAWS(input AWSIntegrationInput) (*Integrat
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("AWSIntegrationCreate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) CreateEventIntegration(input EventIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"eventIntegrationCreate(input: $input)"`
+		Payload IntegrationCreatePayload `graphql:"eventIntegrationCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("EventIntegrationCreate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) CreateIntegrationNewRelic(input NewRelicIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"newRelicIntegrationCreate(input: $input)"`
+		Payload IntegrationCreatePayload `graphql:"newRelicIntegrationCreate(input: $input)"`
 	}
 
 	v := PayloadVariables{
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationCreate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) GetIntegration(id ID) (*Integration, error) {
@@ -159,53 +150,42 @@ func (client *Client) ListIntegrations(variables *PayloadVariables) (*Integratio
 
 func (client *Client) UpdateIntegrationAWS(identifier string, input AWSIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"awsIntegrationUpdate(integration: $integration input: $input)"`
+		Payload IntegrationUpdatePayload `graphql:"awsIntegrationUpdate(integration: $integration input: $input)"`
 	}
 	v := PayloadVariables{
 		"integration": *NewIdentifier(identifier),
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("AWSIntegrationUpdate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) UpdateEventIntegration(input EventIntegrationUpdateInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"eventIntegrationUpdate(input: $input)"`
+		Payload IntegrationUpdatePayload `graphql:"eventIntegrationUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("EventIntegrationUpdate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) UpdateIntegrationNewRelic(identifier string, input NewRelicIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"newRelicIntegrationUpdate(input: $input resource: $resource)"`
+		Payload IntegrationUpdatePayload `graphql:"newRelicIntegrationUpdate(input: $input resource: $resource)"`
 	}
 	v := PayloadVariables{
 		"resource": *NewIdentifier(identifier),
 		"input":    input,
 	}
 	err := client.Mutate(&m, v, WithName("NewRelicIntegrationUpdate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) DeleteIntegration(identifier string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"integrationDelete(resource: $input)"`
+		Payload BasePayload `graphql:"integrationDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(identifier),
@@ -216,72 +196,57 @@ func (client *Client) DeleteIntegration(identifier string) error {
 
 func (client *Client) CreateIntegrationAzureResources(input AzureResourcesIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"azureResourcesIntegrationCreate(input: $input)"`
+		Payload IntegrationCreatePayload `graphql:"azureResourcesIntegrationCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("AzureResourcesIntegrationCreate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) UpdateIntegrationAzureResources(identifier string, input AzureResourcesIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"azureResourcesIntegrationUpdate(integration: $integration input: $input)"`
+		Payload IntegrationUpdatePayload `graphql:"azureResourcesIntegrationUpdate(integration: $integration input: $input)"`
 	}
 	v := PayloadVariables{
 		"integration": *NewIdentifier(identifier),
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("AzureResourcesIntegrationUpdate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) CreateIntegrationGCP(input GoogleCloudIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"googleCloudIntegrationCreate(input: $input)"`
+		Payload IntegrationCreatePayload `graphql:"googleCloudIntegrationCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("GoogleCloudIntegrationCreate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) UpdateIntegrationGCP(identifier string, input GoogleCloudIntegrationInput) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"googleCloudIntegrationUpdate(integration: $integration input: $input)"`
+		Payload IntegrationUpdatePayload `graphql:"googleCloudIntegrationUpdate(integration: $integration input: $input)"`
 	}
 	v := PayloadVariables{
 		"integration": *NewIdentifier(identifier),
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("GoogleCloudIntegrationUpdate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) IntegrationReactivate(identifier string) (*Integration, error) {
 	var m struct {
-		Payload struct {
-			Integration *Integration
-			Errors      []Error
-		} `graphql:"integrationReactivate(integration: $integration)"`
+		Payload IntegrationReactivatePayload `graphql:"integrationReactivate(integration: $integration)"`
 	}
 	v := PayloadVariables{
 		"integration": *NewIdentifier(identifier),
 	}
 	err := client.Mutate(&m, v, WithName("IntegrationReactivate"))
-	return m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }

--- a/level.go
+++ b/level.go
@@ -36,10 +36,7 @@ func (conn *LevelConnection) Hydrate(client *Client) error {
 
 func (client *Client) CreateLevel(input LevelCreateInput) (*Level, error) {
 	var m struct {
-		Payload struct {
-			Level  Level
-			Errors []Error
-		} `graphql:"levelCreate(input: $input)"`
+		Payload LevelCreatePayload `graphql:"levelCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -86,10 +83,7 @@ func (client *Client) ListLevels() ([]Level, error) {
 
 func (client *Client) UpdateLevel(input LevelUpdateInput) (*Level, error) {
 	var m struct {
-		Payload struct {
-			Level  Level
-			Errors []Error
-		} `graphql:"levelUpdate(input: $input)"`
+		Payload LevelUpdatePayload `graphql:"levelUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -100,7 +94,7 @@ func (client *Client) UpdateLevel(input LevelUpdateInput) (*Level, error) {
 
 func (client *Client) DeleteLevel(id ID) error {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			Id     ID `graphql:"deletedLevelId"`
 			Errors []Error
 		} `graphql:"levelDelete(input: $input)"`

--- a/payload.go
+++ b/payload.go
@@ -1,0 +1,362 @@
+// Code generated; DO NOT EDIT.
+package opslevel
+
+type BasePayload struct {
+	Errors []Error // List of errors that occurred while executing the mutation (Required)
+}
+
+// AlertSourceServiceCreatePayload Return type for the `alertSourceServiceCreate` mutation
+type AlertSourceServiceCreatePayload struct {
+	AlertSourceService AlertSourceService // An alert source service representing a connection between a service and an alert source (Optional)
+	BasePayload
+}
+
+// AliasCreatePayload Return type for the `aliasCreate` mutation
+type AliasCreatePayload struct {
+	Aliases []string // All of the aliases attached to the resource (Optional)
+	OwnerId string   // The ID of the resource that had an alias attached (Optional)
+	BasePayload
+}
+
+// CategoryCreatePayload The return type of the `categoryCreate` mutation
+type CategoryCreatePayload struct {
+	Category Category // A category is used to group related checks in a rubric (Optional)
+	BasePayload
+}
+
+// CategoryUpdatePayload The return type of the `categoryUpdate` mutation
+type CategoryUpdatePayload struct {
+	Category Category // A category is used to group related checks in a rubric (Optional)
+	BasePayload
+}
+
+// CheckCopyPayload The result of a check copying operation
+type CheckCopyPayload struct {
+	TargetCategory Category // The category to which the checks have been copied (Optional)
+	BasePayload
+}
+
+// CheckResponsePayload The return type of a `checkCreate` mutation and `checkUpdate` mutation
+type CheckResponsePayload struct {
+	Check Check // The newly created check (Optional)
+	BasePayload
+}
+
+// ComponentTypePayload Return type for the `componentTypeCreate` mutation
+type ComponentTypePayload struct {
+	ComponentType ComponentType // The created component type (Optional)
+	BasePayload
+}
+
+// ContactCreatePayload The return type of a `contactCreate` mutation
+type ContactCreatePayload struct {
+	Contact Contact // A method of contact for a team (Optional)
+	BasePayload
+}
+
+// ContactUpdatePayload The return type of a `contactUpdate` mutation
+type ContactUpdatePayload struct {
+	Contact Contact // A method of contact for a team (Optional)
+	BasePayload
+}
+
+// CustomActionsTriggerDefinitionCreatePayload Return type for the `customActionsTriggerDefinitionCreate` mutation
+type CustomActionsTriggerDefinitionCreatePayload struct {
+	TriggerDefinition CustomActionsTriggerDefinition // The definition of a potential trigger for a custom action (Optional)
+	BasePayload
+}
+
+// CustomActionsTriggerDefinitionUpdatePayload Return type for the `customActionsTriggerDefinitionUpdate` mutation
+type CustomActionsTriggerDefinitionUpdatePayload struct {
+	TriggerDefinition CustomActionsTriggerDefinition // The definition of a potential trigger for a custom action (Optional)
+	BasePayload
+}
+
+// CustomActionsWebhookActionCreatePayload Return type for the `customActionsWebhookActionCreate` mutation
+type CustomActionsWebhookActionCreatePayload struct {
+	WebhookAction CustomActionsWebhookAction // An external webhook action to be triggered by a custom action (Optional)
+	BasePayload
+}
+
+// CustomActionsWebhookActionUpdatePayload The response returned after updating a Webhook Action
+type CustomActionsWebhookActionUpdatePayload struct {
+	WebhookAction CustomActionsWebhookAction // An external webhook action to be triggered by a custom action (Optional)
+	BasePayload
+}
+
+// DomainChildAssignPayload Return type for the `domainChildAssign` mutation
+type DomainChildAssignPayload struct {
+	Domain Domain // The domain after children have been assigned (Optional)
+	BasePayload
+}
+
+// DomainChildRemovePayload Return type for the `domainChildRemove` mutation
+type DomainChildRemovePayload struct {
+	Domain Domain // The domain after children have been removed (Optional)
+	BasePayload
+}
+
+// DomainPayload Return type for `domainCreate` and `domainUpdate` mutations
+type DomainPayload struct {
+	Domain Domain // A collection of related Systems (Optional)
+	BasePayload
+}
+
+// ExportConfigFilePayload The result of exporting an object as YAML
+type ExportConfigFilePayload struct {
+	Kind string // The GraphQL type that represents the exported object (Optional)
+	Yaml string // The YAML representation of the object (Optional)
+	BasePayload
+}
+
+// ExternalUuidMutationPayload Return type for the external UUID mutations
+type ExternalUuidMutationPayload struct {
+	ExternalUuid string // The updated external UUID of the resource (Optional)
+	BasePayload
+}
+
+// FilterCreatePayload The return type of a `filterCreatePayload` mutation
+type FilterCreatePayload struct {
+	Filter Filter // The newly created filter (Optional)
+	BasePayload
+}
+
+// FilterUpdatePayload The return type of the `filterUpdate` mutation
+type FilterUpdatePayload struct {
+	Filter Filter // The updated filter (Optional)
+	BasePayload
+}
+
+// ImportEntityFromBackstagePayload Results of importing an Entity from Backstage into OpsLevel
+type ImportEntityFromBackstagePayload struct {
+	ActionMessage string // The action taken by OpsLevel (ie: service created) (Required)
+	HtmlUrl       string // A link to the created or updated object in OpsLevel, if any (Optional)
+	BasePayload
+}
+
+// InfrastructureResourcePayload Return type for the `infrastructureResourceUpdate` mutation
+type InfrastructureResourcePayload struct {
+	InfrastructureResource InfrastructureResource // An Infrastructure Resource (Optional)
+	Warnings               []Warning              // The warnings of the mutation (Required)
+	BasePayload
+}
+
+// IntegrationCreatePayload The result of creating an integration
+type IntegrationCreatePayload struct {
+	Integration Integration // The newly created integration (Optional)
+	BasePayload
+}
+
+// IntegrationReactivatePayload The return type of a 'integrationReactivate' mutation
+type IntegrationReactivatePayload struct {
+	Integration Integration // The newly reactivated integration (Optional)
+	BasePayload
+}
+
+// IntegrationSourceObjectUpsertPayload The return type of a 'integrationSourceObjectUpsert' mutation
+type IntegrationSourceObjectUpsertPayload struct {
+	Integration Integration // The integration that the source object was upserted to (Optional)
+	BasePayload
+}
+
+// IntegrationUpdatePayload The return type of a 'integrationUpdate' mutation
+type IntegrationUpdatePayload struct {
+	Integration Integration // The newly updated integration (Optional)
+	BasePayload
+}
+
+// LevelCreatePayload The return type of the `levelCreate` mutation
+type LevelCreatePayload struct {
+	Level Level // A performance rating that is used to grade your services against (Optional)
+	BasePayload
+}
+
+// LevelUpdatePayload The return type of the `levelUpdate` mutation
+type LevelUpdatePayload struct {
+	Level Level // A performance rating that is used to grade your services against (Optional)
+	BasePayload
+}
+
+// NewRelicAccountsPayload
+type NewRelicAccountsPayload struct {
+	BasePayload
+}
+
+// PropertyDefinitionPayload The return type for property definition mutations
+type PropertyDefinitionPayload struct {
+	Definition PropertyDefinition // The property that was defined (Optional)
+	BasePayload
+}
+
+// PropertyPayload The payload for setting a property
+type PropertyPayload struct {
+	Property Property // The property that was set (Optional)
+	BasePayload
+}
+
+// PropertyUnassignPayload The payload for unassigning a property
+type PropertyUnassignPayload struct {
+	Definition PropertyDefinition // The definition of the property that was unassigned (Optional)
+	Owner      EntityOwnerService // The entity that the property was unassigned from (Optional)
+	BasePayload
+}
+
+// RepositoriesUpdatePayload Return type for the `repositoriesUpdate` mutation
+type RepositoriesUpdatePayload struct {
+	NotUpdatedRepositories []RepositoryOperationErrorPayload // The repository objects that were not updated along with the error that happened when attempting to update the repository (Optional)
+	UpdatedRepositories    []Repository                      // The identifiers of the updated repositories (Optional)
+	BasePayload
+}
+
+// RepositoryOperationErrorPayload Specifies the repository and error after attempting and failing to perform a CRUD operation on a repository
+type RepositoryOperationErrorPayload struct {
+	Error      string     // The error message after an operation was attempted (Optional)
+	Repository Repository // The repository on which an operation was attempted (Required)
+	BasePayload
+}
+
+// RepositoryUpdatePayload The return type of a `repositoryUpdate` mutation
+type RepositoryUpdatePayload struct {
+	Repository Repository // A repository contains code that pertains to a service (Optional)
+	BasePayload
+}
+
+// ScorecardPayload The type returned when creating a scorecard
+type ScorecardPayload struct {
+	Scorecard Scorecard // The created scorecard (Optional)
+	BasePayload
+}
+
+// SecretPayload Return type for secret operations
+type SecretPayload struct {
+	Secret Secret // A sensitive value (Optional)
+	BasePayload
+}
+
+// ServiceCreatePayload Return type for the `serviceCreate` mutation
+type ServiceCreatePayload struct {
+	Service Service // The newly created service (Optional)
+	BasePayload
+}
+
+// ServiceDependencyPayload Return type for the requested `serviceDependency`
+type ServiceDependencyPayload struct {
+	ServiceDependency ServiceDependency // A service dependency edge (Optional)
+	BasePayload
+}
+
+// ServiceLevelNotificationsPayload The return type of the service level notifications update mutation
+type ServiceLevelNotificationsPayload struct {
+	ServiceLevelNotifications ServiceLevelNotifications // The updated service level notification settings (Optional)
+	BasePayload
+}
+
+// ServiceNoteUpdatePayload Return type for the `serviceNoteUpdate` mutation
+type ServiceNoteUpdatePayload struct {
+	Service Service // A service represents software deployed in your production infrastructure (Optional)
+	BasePayload
+}
+
+// ServiceRepositoryCreatePayload Return type for the `serviceRepositoryCreate` mutation
+type ServiceRepositoryCreatePayload struct {
+	ServiceRepository ServiceRepository // A record of the connection between a service and a repository (Optional)
+	BasePayload
+}
+
+// ServiceRepositoryUpdatePayload The return type of the `serviceRepositoryUpdate` mutation
+type ServiceRepositoryUpdatePayload struct {
+	ServiceRepository ServiceRepository // The updated service repository (Optional)
+	BasePayload
+}
+
+// ServiceUpdatePayload Return type for the `serviceUpdate` mutation
+type ServiceUpdatePayload struct {
+	Service Service // The updated service (Optional)
+	BasePayload
+}
+
+// SystemChildAssignPayload Return type for the `systemChildAssign` mutation
+type SystemChildAssignPayload struct {
+	System System // The system after children have been assigned (Optional)
+	BasePayload
+}
+
+// SystemChildRemovePayload Return type for the `systemChildRemove` mutation
+type SystemChildRemovePayload struct {
+	System System // The system after children have been removed (Optional)
+	BasePayload
+}
+
+// SystemPayload Return type for the `systemCreate` and `systemUpdate` mutations
+type SystemPayload struct {
+	System System // A collection of related Services (Optional)
+	BasePayload
+}
+
+// TagAssignPayload The return type of a `tagAssign` mutation
+type TagAssignPayload struct {
+	Tags []Tag // The new tags that have been assigned to the resource (Optional)
+	BasePayload
+}
+
+// TagCreatePayload The return type of a `tagCreate` mutation
+type TagCreatePayload struct {
+	Tag Tag // The newly created tag (Optional)
+	BasePayload
+}
+
+// TagUpdatePayload The return type of a `tagUpdate` mutation
+type TagUpdatePayload struct {
+	Tag Tag // The newly updated tag (Optional)
+	BasePayload
+}
+
+// TeamCreatePayload The return type of a `teamCreate` mutation
+type TeamCreatePayload struct {
+	Team Team // A team belongs to your organization. Teams can own multiple services (Optional)
+	BasePayload
+}
+
+// TeamMembershipCreatePayload The response returned when creating memberships on teams
+type TeamMembershipCreatePayload struct {
+	Members     []User           // A list of users that are a member of the team (Optional)
+	Memberships []TeamMembership // A list of memberships on the team (Optional)
+	BasePayload
+}
+
+// TeamPropertyDefinitionPayload The return type for team property definition mutations
+type TeamPropertyDefinitionPayload struct {
+	Definition TeamPropertyDefinition // The team property that was defined (Optional)
+	BasePayload
+}
+
+// TeamUpdatePayload The return type of a `teamUpdate` mutation
+type TeamUpdatePayload struct {
+	Team Team // A team belongs to your organization. Teams can own multiple services (Optional)
+	BasePayload
+}
+
+// ToolCreatePayload The return type of a `toolCreate` mutation
+type ToolCreatePayload struct {
+	Tool Tool // A tool is used to support the operations of a service (Optional)
+	BasePayload
+}
+
+// ToolUpdatePayload The return type of a `toolUpdate` payload
+type ToolUpdatePayload struct {
+	Tool Tool // A tool is used to support the operations of a service (Optional)
+	BasePayload
+}
+
+// UserPayload The return type of user management mutations
+type UserPayload struct {
+	User User // A user is someone who belongs to an organization (Optional)
+	BasePayload
+}
+
+// UsersInvitePayload The return type of the users invite mutation
+type UsersInvitePayload struct {
+	Failed []string // The user identifiers which failed to successfully send an invite (Optional)
+	Users  []User   // The users that were successfully invited (Optional)
+	BasePayload
+}

--- a/property.go
+++ b/property.go
@@ -43,10 +43,7 @@ type ServicePropertiesConnection struct {
 
 func (client *Client) CreatePropertyDefinition(input PropertyDefinitionInput) (*PropertyDefinition, error) {
 	var m struct {
-		Payload struct {
-			Definition PropertyDefinition `graphql:"definition"`
-			Errors     []Error            `graphql:"errors"`
-		} `graphql:"propertyDefinitionCreate(input: $input)"`
+		Payload PropertyDefinitionPayload `graphql:"propertyDefinitionCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -57,10 +54,7 @@ func (client *Client) CreatePropertyDefinition(input PropertyDefinitionInput) (*
 
 func (client *Client) UpdatePropertyDefinition(identifier string, input PropertyDefinitionInput) (*PropertyDefinition, error) {
 	var m struct {
-		Payload struct {
-			Definition PropertyDefinition `graphql:"definition"`
-			Errors     []Error            `graphql:"errors"`
-		} `graphql:"propertyDefinitionUpdate(propertyDefinition: $propertyDefinition, input: $input)"`
+		Payload PropertyDefinitionPayload `graphql:"propertyDefinitionUpdate(propertyDefinition: $propertyDefinition, input: $input)"`
 	}
 	v := PayloadVariables{
 		"propertyDefinition": *NewIdentifier(identifier),
@@ -113,9 +107,7 @@ func (client *Client) ListPropertyDefinitions(variables *PayloadVariables) (*Pro
 
 func (client *Client) DeletePropertyDefinition(input string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"propertyDefinitionDelete(resource: $input)"`
+		Payload BasePayload `graphql:"propertyDefinitionDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(input),
@@ -140,10 +132,7 @@ func (client *Client) GetProperty(owner string, definition string) (*Property, e
 
 func (client *Client) PropertyAssign(input PropertyInput) (*Property, error) {
 	var m struct {
-		Payload struct {
-			Property Property `graphql:"property"`
-			Errors   []Error  `graphql:"errors"`
-		} `graphql:"propertyAssign(input: $input)"`
+		Payload PropertyPayload `graphql:"propertyAssign(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -154,9 +143,7 @@ func (client *Client) PropertyAssign(input PropertyInput) (*Property, error) {
 
 func (client *Client) PropertyUnassign(owner string, definition string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"propertyUnassign(owner: $owner, definition: $definition)"`
+		Payload BasePayload `graphql:"propertyUnassign(owner: $owner, definition: $definition)"`
 	}
 	v := PayloadVariables{
 		"owner":      *NewIdentifier(owner),

--- a/repository.go
+++ b/repository.go
@@ -202,10 +202,7 @@ func (client *Client) ConnectServiceRepository(service *ServiceId, repository *R
 
 func (client *Client) CreateServiceRepository(input ServiceRepositoryCreateInput) (*ServiceRepository, error) {
 	var m struct {
-		Payload struct {
-			ServiceRepository ServiceRepository
-			Errors            []Error
-		} `graphql:"serviceRepositoryCreate(input: $input)"`
+		Payload ServiceRepositoryCreatePayload `graphql:"serviceRepositoryCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -316,10 +313,7 @@ func (client *Client) ListRepositoriesWithTier(tier string, variables *PayloadVa
 
 func (client *Client) UpdateRepository(input RepositoryUpdateInput) (*Repository, error) {
 	var m struct {
-		Payload struct {
-			Repository Repository
-			Errors     []Error
-		} `graphql:"repositoryUpdate(input: $input)"`
+		Payload RepositoryUpdatePayload `graphql:"repositoryUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -330,10 +324,7 @@ func (client *Client) UpdateRepository(input RepositoryUpdateInput) (*Repository
 
 func (client *Client) UpdateServiceRepository(input ServiceRepositoryUpdateInput) (*ServiceRepository, error) {
 	var m struct {
-		Payload struct {
-			ServiceRepository ServiceRepository
-			Errors            []Error
-		} `graphql:"serviceRepositoryUpdate(input: $input)"`
+		Payload ServiceRepositoryUpdatePayload `graphql:"serviceRepositoryUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -344,7 +335,7 @@ func (client *Client) UpdateServiceRepository(input ServiceRepositoryUpdateInput
 
 func (client *Client) DeleteServiceRepository(id ID) error {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			Id     ID `graphql:"deletedId"`
 			Errors []Error
 		} `graphql:"serviceRepositoryDelete(input: $input)"`

--- a/scorecards.go
+++ b/scorecards.go
@@ -82,10 +82,7 @@ func (scorecard *Scorecard) ListCategories(client *Client, variables *PayloadVar
 
 func (client *Client) CreateScorecard(input ScorecardInput) (*Scorecard, error) {
 	var m struct {
-		Payload struct {
-			Scorecard Scorecard `graphql:"scorecard"`
-			Errors    []Error   `graphql:"errors"`
-		} `graphql:"scorecardCreate(input: $input)"`
+		Payload ScorecardPayload `graphql:"scorecardCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -140,10 +137,7 @@ func (client *Client) ListScorecards(variables *PayloadVariables) (*ScorecardCon
 
 func (client *Client) UpdateScorecard(identifier string, input ScorecardInput) (*Scorecard, error) {
 	var m struct {
-		Payload struct {
-			Scorecard Scorecard `graphql:"scorecard"`
-			Errors    []Error   `graphql:"errors"`
-		} `graphql:"scorecardUpdate(scorecard: $scorecard, input: $input)"`
+		Payload ScorecardPayload `graphql:"scorecardUpdate(scorecard: $scorecard, input: $input)"`
 	}
 	scorecard := *NewIdentifier(identifier)
 	v := PayloadVariables{
@@ -156,7 +150,7 @@ func (client *Client) UpdateScorecard(identifier string, input ScorecardInput) (
 
 func (client *Client) DeleteScorecard(identifier string) (*ID, error) {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: need to fix this
 			DeletedScorecardId ID      `graphql:"deletedScorecardId"`
 			Errors             []Error `graphql:"errors"`
 		} `graphql:"scorecardDelete(input: $input)"`

--- a/secrets.go
+++ b/secrets.go
@@ -8,10 +8,7 @@ type SecretsVaultsSecretConnection struct {
 
 func (client *Client) CreateSecret(alias string, input SecretInput) (*Secret, error) {
 	var m struct {
-		Payload struct {
-			Secret Secret
-			Errors []Error
-		} `graphql:"secretsVaultsSecretCreate(alias: $alias, input: $input)"`
+		Payload SecretPayload `graphql:"secretsVaultsSecretCreate(alias: $alias, input: $input)"`
 	}
 	v := PayloadVariables{
 		"alias": alias,
@@ -48,10 +45,7 @@ func (client *Client) ListSecretsVaultsSecret(variables *PayloadVariables) (*Sec
 
 func (client *Client) UpdateSecret(identifier string, secretInput SecretInput) (*Secret, error) {
 	var m struct {
-		Payload struct {
-			Secret Secret
-			Errors []Error
-		} `graphql:"secretsVaultsSecretUpdate(input: $input, secret: $secret)"`
+		Payload SecretPayload `graphql:"secretsVaultsSecretUpdate(input: $input, secret: $secret)"`
 	}
 	v := PayloadVariables{
 		"input":  secretInput,
@@ -63,9 +57,7 @@ func (client *Client) UpdateSecret(identifier string, secretInput SecretInput) (
 
 func (client *Client) DeleteSecret(identifier string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"secretsVaultsSecretDelete(resource: $input)"`
+		Payload BasePayload `graphql:"secretsVaultsSecretDelete(resource: $input)"`
 	}
 	v := PayloadVariables{"input": *NewIdentifier(identifier)}
 	err := client.Mutate(&m, v, WithName("SecretsVaultsSecretDelete"))

--- a/service.go
+++ b/service.go
@@ -310,10 +310,7 @@ func (service *Service) GetDocuments(client *Client, variables *PayloadVariables
 
 func (client *Client) CreateService(input ServiceCreateInput) (*Service, error) {
 	var m struct {
-		Payload struct {
-			Service Service
-			Errors  []Error
-		} `graphql:"serviceCreate(input: $input)"`
+		Payload ServiceCreatePayload `graphql:"serviceCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -714,10 +711,7 @@ func (client *Client) ListServicesWithTier(tier string, variables *PayloadVariab
 
 func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) {
 	var m struct {
-		Payload struct {
-			Service Service
-			Errors  []Error
-		} `graphql:"serviceUpdate(input: $input)"`
+		Payload ServiceUpdatePayload `graphql:"serviceUpdate(input: $input)"`
 	}
 
 	v := PayloadVariables{
@@ -734,10 +728,7 @@ func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) 
 
 func (client *Client) UpdateServiceNote(input ServiceNoteUpdateInput) (*Service, error) {
 	var m struct {
-		Payload struct {
-			Service Service
-			Errors  []Error
-		} `graphql:"serviceNoteUpdate(input: $input)"`
+		Payload ServiceUpdatePayload `graphql:"serviceNoteUpdate(input: $input)"`
 	}
 
 	v := PayloadVariables{
@@ -759,7 +750,7 @@ func (client *Client) DeleteService(identifier string) error {
 	}
 
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			Id     ID      `graphql:"deletedServiceId"`
 			Alias  string  `graphql:"deletedServiceAlias"`
 			Errors []Error `graphql:"errors"`

--- a/service.go
+++ b/service.go
@@ -75,7 +75,7 @@ func (service *Service) ReconcileAliases(client *Client, aliasesWanted []string)
 	_, createErr := client.CreateAliases(service.Id, aliasesToCreate)
 
 	// update service to reflect API updates
-	updatedService, getErr := client.GetService(service.Id)
+	updatedService, getErr := client.GetServiceId(service.Id)
 	if updatedService != nil {
 		service.Aliases = updatedService.Aliases
 		service.ManagedAliases = updatedService.ManagedAliases
@@ -358,7 +358,7 @@ func (client *Client) GetServiceWithAlias(alias string) (*Service, error) {
 	return &q.Account.Service, nil
 }
 
-func (client *Client) GetService(id ID) (*Service, error) {
+func (client *Client) GetServiceId(id ID) (*Service, error) {
 	var q struct {
 		Account struct {
 			Service Service `graphql:"service(id: $service)"`
@@ -374,6 +374,14 @@ func (client *Client) GetService(id ID) (*Service, error) {
 		return &q.Account.Service, err
 	}
 	return &q.Account.Service, nil
+}
+
+func (client *Client) GetService(identifier string) (*Service, error) {
+	if IsID(identifier) {
+		return client.GetServiceId(ID(identifier))
+	} else {
+		return client.GetServiceWithAlias(identifier)
+	}
 }
 
 func (client *Client) GetServiceCount() (int, error) {

--- a/system.go
+++ b/system.go
@@ -128,10 +128,7 @@ func (systemId *SystemId) ChildServices(client *Client, variables *PayloadVariab
 
 func (systemId *SystemId) AssignService(client *Client, services ...string) error {
 	var m struct {
-		Payload struct {
-			System System
-			Errors []Error
-		} `graphql:"systemChildAssign(system:$system, childServices:$childServices)"`
+		Payload SystemPayload `graphql:"systemChildAssign(system:$system, childServices:$childServices)"`
 	}
 	v := PayloadVariables{
 		"system":        *NewIdentifier(string(systemId.Id)),
@@ -143,10 +140,7 @@ func (systemId *SystemId) AssignService(client *Client, services ...string) erro
 
 func (client *Client) CreateSystem(input SystemInput) (*System, error) {
 	var m struct {
-		Payload struct {
-			System System
-			Errors []Error
-		} `graphql:"systemCreate(input:$input)"`
+		Payload SystemPayload `graphql:"systemCreate(input:$input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -195,10 +189,7 @@ func (client *Client) ListSystems(variables *PayloadVariables) (*SystemConnectio
 
 func (client *Client) UpdateSystem(identifier string, input SystemInput) (*System, error) {
 	var s struct {
-		Payload struct {
-			System System
-			Errors []Error
-		} `graphql:"systemUpdate(system:$system,input:$input)"`
+		Payload SystemPayload `graphql:"systemUpdate(system:$system,input:$input)"`
 	}
 	v := PayloadVariables{
 		"system": *NewIdentifier(identifier),
@@ -210,9 +201,7 @@ func (client *Client) UpdateSystem(identifier string, input SystemInput) (*Syste
 
 func (client *Client) DeleteSystem(identifier string) error {
 	var s struct {
-		Payload struct {
-			Errors []Error `graphql:"errors"`
-		} `graphql:"systemDelete(resource: $input)"`
+		Payload BasePayload `graphql:"systemDelete(resource: $input)"`
 	}
 	v := PayloadVariables{
 		"input": *NewIdentifier(identifier),

--- a/tags.go
+++ b/tags.go
@@ -39,7 +39,7 @@ func (client *Client) GetTaggableResource(resourceType TaggableResource, identif
 	switch resourceType {
 	case TaggableResourceService:
 		if IsID(identifier) {
-			taggableResource, err = client.GetService(ID(identifier))
+			taggableResource, err = client.GetService(identifier)
 		} else {
 			taggableResource, err = client.GetServiceWithAlias(identifier)
 		}

--- a/tags.go
+++ b/tags.go
@@ -113,10 +113,7 @@ func (client *Client) AssignTags(identifier string, tags map[string]string) ([]T
 
 func (client *Client) AssignTag(input TagAssignInput) ([]Tag, error) {
 	var m struct {
-		Payload struct {
-			Tags   []Tag
-			Errors []Error
-		} `graphql:"tagAssign(input: $input)"`
+		Payload TagAssignPayload `graphql:"tagAssign(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -153,10 +150,7 @@ func (client *Client) CreateTags(identifier string, tags map[string]string) ([]T
 
 func (client *Client) CreateTag(input TagCreateInput) (*Tag, error) {
 	var m struct {
-		Payload struct {
-			Tag    Tag `json:"tag"`
-			Errors []Error
-		} `graphql:"tagCreate(input: $input)"`
+		Payload TagCreatePayload `graphql:"tagCreate(input: $input)"`
 	}
 	if err := ValidateTagKey(input.Key); err != nil {
 		return nil, err
@@ -170,10 +164,7 @@ func (client *Client) CreateTag(input TagCreateInput) (*Tag, error) {
 
 func (client *Client) UpdateTag(input TagUpdateInput) (*Tag, error) {
 	var m struct {
-		Payload struct {
-			Tag    Tag
-			Errors []Error
-		} `graphql:"tagUpdate(input: $input)"`
+		Payload TagUpdatePayload `graphql:"tagUpdate(input: $input)"`
 	}
 	if err := ValidateTagKey(input.Key.Value); err != nil {
 		return nil, err
@@ -187,9 +178,7 @@ func (client *Client) UpdateTag(input TagUpdateInput) (*Tag, error) {
 
 func (client *Client) DeleteTag(id ID) error {
 	var m struct {
-		Payload struct {
-			Errors []Error
-		} `graphql:"tagDelete(input: $input)"`
+		Payload BasePayload `graphql:"tagDelete(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": TagDeleteInput{Id: id},

--- a/team.go
+++ b/team.go
@@ -242,10 +242,7 @@ func (team *Team) HasTag(key string, value string) bool {
 
 func (client *Client) CreateTeam(input TeamCreateInput) (*Team, error) {
 	var m struct {
-		Payload struct {
-			Team   Team
-			Errors []Error
-		} `graphql:"teamCreate(input: $input)"`
+		Payload TeamCreatePayload `graphql:"teamCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -261,7 +258,7 @@ func (client *Client) CreateTeam(input TeamCreateInput) (*Team, error) {
 
 func (client *Client) AddMemberships(team *TeamId, memberships ...TeamMembershipUserInput) ([]TeamMembership, error) {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: need to fix this
 			Memberships []TeamMembership `graphql:"memberships"`
 			Errors      []Error
 		} `graphql:"teamMembershipCreate(input: $input)"`
@@ -278,10 +275,7 @@ func (client *Client) AddMemberships(team *TeamId, memberships ...TeamMembership
 
 func (client *Client) AddContact(team string, contact ContactInput) (*Contact, error) {
 	var m struct {
-		Payload struct {
-			Contact Contact
-			Errors  []Error
-		} `graphql:"contactCreate(input: $input)"`
+		Payload ContactCreatePayload `graphql:"contactCreate(input: $input)"`
 	}
 	contactInput := ContactCreateInput{
 		Type:        contact.Type,
@@ -416,10 +410,7 @@ func (client *Client) ListTeamsWithManager(email string, variables *PayloadVaria
 
 func (client *Client) UpdateTeam(input TeamUpdateInput) (*Team, error) {
 	var m struct {
-		Payload struct {
-			Team   Team
-			Errors []Error
-		} `graphql:"teamUpdate(input: $input)"`
+		Payload TeamUpdatePayload `graphql:"teamUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -435,10 +426,7 @@ func (client *Client) UpdateTeam(input TeamUpdateInput) (*Team, error) {
 
 func (client *Client) UpdateContact(id ID, contact ContactInput) (*Contact, error) {
 	var m struct {
-		Payload struct {
-			Contact Contact
-			Errors  []Error
-		} `graphql:"contactUpdate(input: $input)"`
+		Payload ContactUpdatePayload `graphql:"contactUpdate(input: $input)"`
 	}
 	input := ContactUpdateInput{
 		Id:          id,
@@ -466,7 +454,7 @@ func (client *Client) DeleteTeam(identifier string) error {
 	}
 
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: fix this
 			Id     ID      `graphql:"deletedTeamId"`
 			Alias  string  `graphql:"deletedTeamAlias"`
 			Errors []Error `graphql:"errors"`
@@ -481,7 +469,7 @@ func (client *Client) DeleteTeam(identifier string) error {
 
 func (client *Client) RemoveMemberships(team *TeamId, memberships ...TeamMembershipUserInput) ([]User, error) {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: need to fix this
 			Members []User `graphql:"deletedMembers"`
 			Errors  []Error
 		} `graphql:"teamMembershipDelete(input: $input)"`
@@ -498,7 +486,7 @@ func (client *Client) RemoveMemberships(team *TeamId, memberships ...TeamMembers
 
 func (client *Client) RemoveContact(contact ID) error {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: need to fix this
 			Contact ID `graphql:"deletedContactId"`
 			Errors  []Error
 		} `graphql:"contactDelete(input: $input)"`

--- a/tools.go
+++ b/tools.go
@@ -8,10 +8,7 @@ type ToolConnection struct {
 
 func (client *Client) CreateTool(input ToolCreateInput) (*Tool, error) {
 	var m struct {
-		Payload struct {
-			Tool   Tool
-			Errors []Error
-		} `graphql:"toolCreate(input: $input)"`
+		Payload ToolCreatePayload `graphql:"toolCreate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -22,10 +19,7 @@ func (client *Client) CreateTool(input ToolCreateInput) (*Tool, error) {
 
 func (client *Client) UpdateTool(input ToolUpdateInput) (*Tool, error) {
 	var m struct {
-		Payload struct {
-			Tool   Tool
-			Errors []Error
-		} `graphql:"toolUpdate(input: $input)"`
+		Payload ToolUpdatePayload `graphql:"toolUpdate(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": input,
@@ -36,9 +30,7 @@ func (client *Client) UpdateTool(input ToolUpdateInput) (*Tool, error) {
 
 func (client *Client) DeleteTool(id ID) error {
 	var m struct {
-		Payload struct {
-			Errors []Error
-		} `graphql:"toolDelete(input: $input)"`
+		Payload BasePayload `graphql:"toolDelete(input: $input)"`
 	}
 	v := PayloadVariables{
 		"input": ToolDeleteInput{Id: id},

--- a/user.go
+++ b/user.go
@@ -100,7 +100,7 @@ func (user *User) Teams(client *Client, variables *PayloadVariables) (*TeamIdCon
 
 func (client *Client) InviteUser(email string, input UserInput, sendInvite bool) (*User, error) {
 	var m struct {
-		Payload struct {
+		Payload struct { // TODO: need to fix this
 			User   User
 			Errors []Error
 		} `graphql:"userInvite(email: $email input: $input, forceSendInvite: $forceSendInvite)"`
@@ -157,10 +157,7 @@ func (client *Client) ListUsers(variables *PayloadVariables) (*UserConnection, e
 
 func (client *Client) UpdateUser(user string, input UserInput) (*User, error) {
 	var m struct {
-		Payload struct {
-			User   User
-			Errors []Error
-		} `graphql:"userUpdate(user: $user input: $input)"`
+		Payload UserPayload `graphql:"userUpdate(user: $user input: $input)"`
 	}
 	v := PayloadVariables{
 		"user":  *NewUserIdentifier(user),
@@ -172,9 +169,7 @@ func (client *Client) UpdateUser(user string, input UserInput) (*User, error) {
 
 func (client *Client) DeleteUser(user string) error {
 	var m struct {
-		Payload struct {
-			Errors []Error
-		} `graphql:"userDelete(user: $user)"`
+		Payload BasePayload `graphql:"userDelete(user: $user)"`
 	}
 	v := PayloadVariables{
 		"user": *NewUserIdentifier(user),


### PR DESCRIPTION
Resolves #

### Problem

Its confusing to use the CRUD methods for service to create components

### Solution

We want to make it a little nicer for end users to know there are CRUD components but in the end they just federate out to the old services APIs for now.  This will give us a future handle to redirect them to newer APIs as needed.

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
