### PR TITLE
Update team to call out deprecation

### DIFF
--- a/team.go
+++ b/team.go
@@ -20,7 +20,7 @@ type Team struct {
 	Contacts       []Contact
 
 	HTMLUrl          string
-	Manager          User
+	Manager          User                       // Deprecated: Use .GetMemberships() and Memberships field instead.
 	Memberships      *TeamMembershipConnection
 	Name             string
 	ParentTeam       TeamId

--- a/team.go
+++ b/team.go
@@ -20,7 +20,7 @@ type Team struct {
 	Contacts       []Contact
 
 	HTMLUrl          string
-	Manager          User                       // Deprecated: Use .GetMemberships() and Memberships field instead.
+	Manager          User // Deprecated: Use .GetMemberships() and Memberships field instead.
 	Memberships      *TeamMembershipConnection
 	Name             string
 	ParentTeam       TeamId


### PR DESCRIPTION
Resolves #

### Problem

A customer was trying to use the 'Manager' field on the Team object and they were expecting to get multiple managers but this is only present on the Memberships field.

### Solution

Mark the field as deprecated so future users don't get confused.

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] ~Does this change require a Terraform schema change?~
  - If so what is the ticket or PR #
- [x] ~Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change~
