### PR TITLE
Add typed error codes for better downstream client usage of error handling

### DIFF
--- a/.changes/unreleased/Feature-20250327-125544.yaml
+++ b/.changes/unreleased/Feature-20250327-125544.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add error codes for different types of error to support better client error handling
+time: 2025-03-27T12:55:44.683709-05:00

--- a/actions_test.go
+++ b/actions_test.go
@@ -224,14 +224,14 @@ func TestGetTriggerDefinition(t *testing.T) {
 func TestListTriggerDefinitions(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
-		`query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{{ template "custom_actions_trigger_request" }},{{ template "pagination_request" }},totalCount}}}`,
+		`query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{{ template "custom_actions_trigger_request" }},{{ template "pagination_request" }}}}}`,
 		`{{ template "pagination_initial_query_variables" }}`,
-		`{ "data": { "account": { "customActionsTriggerDefinitions": { "nodes": [ { {{ template "custom_action_trigger1_response" }} }, { {{ template "custom_action_trigger2_response" }} } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 2 }}}}`,
+		`{ "data": { "account": { "customActionsTriggerDefinitions": { "nodes": [ { {{ template "custom_action_trigger1_response" }} }, { {{ template "custom_action_trigger2_response" }} } ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
-		`query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{{ template "custom_actions_trigger_request" }},{{ template "pagination_request" }},totalCount}}}`,
+		`query TriggerDefinitionList($after:String!$first:Int!){account{customActionsTriggerDefinitions(after: $after, first: $first){nodes{{ template "custom_actions_trigger_request" }},{{ template "pagination_request" }}}}}`,
 		`{{ template "pagination_second_query_variables" }}`,
-		`{ "data": { "account": { "customActionsTriggerDefinitions": { "nodes": [ { {{ template "custom_action_trigger3_response" }} } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 }}}}`,
+		`{ "data": { "account": { "customActionsTriggerDefinitions": { "nodes": [ { {{ template "custom_action_trigger3_response" }} } ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
 

--- a/common.go
+++ b/common.go
@@ -1,13 +1,9 @@
 package opslevel
 
 import (
-	"errors"
-	"fmt"
 	"slices"
-	"strings"
 	"time"
 
-	"github.com/hasura/go-graphql-client"
 	"github.com/relvacode/iso8601"
 )
 
@@ -50,43 +46,6 @@ func RefOf[T NullableConstraint](value T) *Nullable[T] {
 
 func RefTo[T NullableConstraint](value T) *Nullable[T] {
 	return NewNullableFrom(value)
-}
-
-func HandleErrors(err error, errs []Error) error {
-	if err != nil {
-		return err
-	}
-	return FormatErrors(errs)
-}
-
-func FormatErrors(errs []Error) error {
-	if len(errs) == 0 {
-		return nil
-	}
-
-	allErrors := fmt.Errorf("OpsLevel API Errors:")
-	for _, err := range errs {
-		if len(err.Path) == 1 && err.Path[0] == "base" {
-			err.Path[0] = ""
-		}
-		newErr := fmt.Errorf("\t- '%s' %s", strings.Join(err.Path, "."), err.Message)
-		allErrors = errors.Join(allErrors, newErr)
-	}
-
-	return allErrors
-}
-
-// IsOpsLevelApiError checks if the error is returned by OpsLevel's API
-func IsOpsLevelApiError(err error) bool {
-	if _, ok := err.(graphql.Errors); !ok {
-		return false
-	}
-	for _, hasuraErr := range err.(graphql.Errors) {
-		if len(hasuraErr.Path) > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 func NewISO8601Date(datetime string) iso8601.Time {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,97 @@
+package opslevel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hasura/go-graphql-client"
+)
+
+type ErrorCode int
+
+const (
+	ErrorUnknown ErrorCode = iota
+	ErrorRequestError
+	ErrorAPIError
+	ErrorResourceNotFound
+)
+
+type ClientError struct {
+	error
+	ErrorCode ErrorCode
+}
+
+func NewClientError(code ErrorCode, message string, args ...any) error {
+	return &ClientError{
+		error:     fmt.Errorf(message, args...),
+		ErrorCode: code,
+	}
+}
+
+func HandleErrors(opts ...any) error {
+	output := (error)(nil)
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case error:
+			if !IsOpsLevelApiError(v) {
+				output = errors.Join(output, NewClientError(ErrorRequestError, v.Error()))
+			} else {
+				output = errors.Join(output, v)
+			}
+		case []Error:
+			output = errors.Join(output, HasAPIErrors(v))
+		}
+	}
+	return output
+}
+
+func HasAPIErrors(errs []Error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	message := "OpsLevel API Errors:"
+	for _, e := range errs {
+		if len(e.Path) == 1 && e.Path[0] == "base" {
+			e.Path[0] = ""
+		}
+		message += fmt.Sprintf("\n\t- '%s' %s", strings.Join(e.Path, "."), e.Message)
+	}
+
+	return NewClientError(ErrorAPIError, message)
+}
+
+func IsResourceFound(resource any) error {
+	// TODO: Also Check if ID is valid somehow `.Id == ""`
+	if resource == nil {
+		return NewClientError(ErrorResourceNotFound, "resource '%T' not found", resource)
+	}
+	if casted, ok := resource.(Identifiable); ok && casted.GetID() == "" {
+		return NewClientError(ErrorResourceNotFound, "resource '%T' not found", resource)
+	}
+	return nil
+}
+
+func ErrIs(err error, code ErrorCode) bool {
+	var clientErr *ClientError
+	if errors.As(err, &clientErr) {
+		if clientErr.ErrorCode == code {
+			return true
+		}
+	}
+	return false
+}
+
+// IsOpsLevelApiError checks if the error is returned by OpsLevel's API
+func IsOpsLevelApiError(err error) bool {
+	if _, ok := err.(graphql.Errors); !ok {
+		return false
+	}
+	for _, hasuraErr := range err.(graphql.Errors) {
+		if len(hasuraErr.Path) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@ func HasAPIErrors(errs []Error) error {
 		message += fmt.Sprintf("\n\t- '%s' %s", strings.Join(e.Path, "."), e.Message)
 	}
 
-	return NewClientError(ErrorAPIError, fmt.Errorf(message))
+	return NewClientError(ErrorAPIError, errors.New(message))
 }
 
 func IsResourceFound(resource any) error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package opslevel_test
 
 import (
+	"fmt"
 	"testing"
 
 	ol "github.com/opslevel/opslevel-go/v2025"
@@ -41,8 +42,8 @@ func TestHasAPIErrorsNoPath(t *testing.T) {
 
 func TestIsResourceFoundError(t *testing.T) {
 	// Arrange
-	err1 := ol.NewClientError(ol.ErrorResourceNotFound, "resource 'Example' not found")
-	err2 := ol.NewClientError(ol.ErrorAPIError, "resource 'Example' not found")
+	err1 := ol.NewClientError(ol.ErrorResourceNotFound, fmt.Errorf("resource 'Example' not found"))
+	err2 := ol.NewClientError(ol.ErrorAPIError, fmt.Errorf("resource 'Example' not found"))
 	// Act
 	// Assert
 	autopilot.Equals(t, true, ol.ErrIs(err1, ol.ErrorResourceNotFound))

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,32 +7,44 @@ import (
 	"github.com/rocktavious/autopilot/v2023"
 )
 
-func TestFormatErrorsWorks(t *testing.T) {
+func TestHasAPIErrorsWorks(t *testing.T) {
 	// Arrange
 	errs := []ol.Error{
 		{Message: "can't be blank", Path: []string{"resource", "id"}},
 		{Message: "is not a valid input", Path: []string{"id"}},
 	}
 	// Act
-	output := ol.FormatErrors(errs)
+	output := ol.HasAPIErrors(errs)
 	// Assert
+	autopilot.Equals(t, true, ol.ErrIs(output, ol.ErrorAPIError))
 	autopilot.Equals(t, `OpsLevel API Errors:
 	- 'resource.id' can't be blank
 	- 'id' is not a valid input`,
 		output.Error())
 }
 
-func TestFormatErrorsNoPath(t *testing.T) {
+func TestHasAPIErrorsNoPath(t *testing.T) {
 	// Arrange
 	errs := []ol.Error{
 		{Message: "can't be blank", Path: []string{"base"}},
 		{Message: "is not a valid input", Path: []string{""}},
 	}
 	// Act
-	output := ol.FormatErrors(errs)
+	output := ol.HasAPIErrors(errs)
 	// Assert
+	autopilot.Equals(t, true, ol.ErrIs(output, ol.ErrorAPIError))
 	autopilot.Equals(t, `OpsLevel API Errors:
 	- '' can't be blank
 	- '' is not a valid input`,
 		output.Error())
+}
+
+func TestIsResourceFoundError(t *testing.T) {
+	// Arrange
+	err1 := ol.NewClientError(ol.ErrorResourceNotFound, "resource 'Example' not found")
+	err2 := ol.NewClientError(ol.ErrorAPIError, "resource 'Example' not found")
+	// Act
+	// Assert
+	autopilot.Equals(t, true, ol.ErrIs(err1, ol.ErrorResourceNotFound))
+	autopilot.Equals(t, false, ol.ErrIs(err2, ol.ErrorResourceNotFound))
 }

--- a/scalar.go
+++ b/scalar.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+type Identifiable interface {
+	GetID() ID
+}
+
 type ID string
 
 func NewID(id ...string) *ID {
@@ -30,6 +34,10 @@ func (id *ID) MarshalJSON() ([]byte, error) {
 type Identifier struct {
 	Id      ID       `graphql:"id" json:"id"`
 	Aliases []string `graphql:"aliases" json:"aliases"`
+}
+
+func (s Identifier) GetID() ID {
+	return s.Id
 }
 
 func (identifierInput IdentifierInput) MarshalJSON() ([]byte, error) {

--- a/service.go
+++ b/service.go
@@ -321,7 +321,7 @@ func (client *Client) CreateService(input ServiceCreateInput) (*Service, error) 
 	if err := m.Payload.Service.Hydrate(client); err != nil {
 		return &m.Payload.Service, err
 	}
-	return &m.Payload.Service, FormatErrors(m.Payload.Errors)
+	return &m.Payload.Service, HandleErrors(m.Payload.Errors)
 }
 
 func (client *Client) GetServiceIdWithAlias(alias string) (*ServiceId, error) {
@@ -723,7 +723,7 @@ func (client *Client) UpdateService(input ServiceUpdateInput) (*Service, error) 
 	if err := m.Payload.Service.Hydrate(client); err != nil {
 		return &m.Payload.Service, err
 	}
-	return &m.Payload.Service, FormatErrors(m.Payload.Errors)
+	return &m.Payload.Service, HandleErrors(m.Payload.Errors)
 }
 
 func (client *Client) UpdateServiceNote(input ServiceNoteUpdateInput) (*Service, error) {
@@ -738,7 +738,7 @@ func (client *Client) UpdateServiceNote(input ServiceNoteUpdateInput) (*Service,
 		return nil, err
 	}
 
-	return &m.Payload.Service, FormatErrors(m.Payload.Errors)
+	return &m.Payload.Service, HandleErrors(m.Payload.Errors)
 }
 
 func (client *Client) DeleteService(identifier string) error {

--- a/team.go
+++ b/team.go
@@ -253,7 +253,7 @@ func (client *Client) CreateTeam(input TeamCreateInput) (*Team, error) {
 	if err := m.Payload.Team.Hydrate(client); err != nil {
 		return &m.Payload.Team, err
 	}
-	return &m.Payload.Team, FormatErrors(m.Payload.Errors)
+	return &m.Payload.Team, HandleErrors(m.Payload.Errors)
 }
 
 func (client *Client) AddMemberships(team *TeamId, memberships ...TeamMembershipUserInput) ([]TeamMembership, error) {
@@ -421,7 +421,7 @@ func (client *Client) UpdateTeam(input TeamUpdateInput) (*Team, error) {
 	if err := m.Payload.Team.Hydrate(client); err != nil {
 		return &m.Payload.Team, err
 	}
-	return &m.Payload.Team, FormatErrors(m.Payload.Errors)
+	return &m.Payload.Team, HandleErrors(m.Payload.Errors)
 }
 
 func (client *Client) UpdateContact(id ID, contact ContactInput) (*Contact, error) {


### PR DESCRIPTION
Resolves #

### Problem

https://github.com/OpsLevel/opslevel-go/issues/496

Downstream tools that use opslevel-go have no good way to detect errors of certain types easily to perform different logic.  This creates a bunch of boilerplate code in these downstream libraries.

### Solution

Leverage golang's ability to use `errors.As` and `errors.Is` by wrapping the errors and creating special error codes for different common problems to make error handling in downstream code easier and less boilerplate.

This PR only implements it in a handful of places to test the pattern out.  Once its proved working well a followup PR will come that propagates it everywhere.

Additionally this standardization will help future codegen efforts.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
