### PR TITLE
Kr/dry up connections

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -49,10 +49,18 @@ type CustomActionsExternalActionsConnection struct {
 	TotalCount int
 }
 
+func (s *CustomActionsExternalActionsConnection) GetNodes() any {
+	return s.Nodes
+}
+
 type CustomActionsTriggerDefinitionsConnection struct {
 	Nodes      []CustomActionsTriggerDefinition
 	PageInfo   PageInfo
 	TotalCount int `graphql:"-"`
+}
+
+func (s *CustomActionsTriggerDefinitionsConnection) GetNodes() any {
+	return s.Nodes
 }
 
 func (client *Client) CreateWebhookAction(input CustomActionsWebhookActionCreateInput) (*CustomActionsExternalAction, error) {

--- a/common.go
+++ b/common.go
@@ -89,3 +89,7 @@ func extractAliases(existingAliases, aliasesWanted []string) ([]string, []string
 	}
 	return aliasesToCreate, aliasesToDelete
 }
+
+type Connection interface {
+	GetNodes() any
+}

--- a/domain.go
+++ b/domain.go
@@ -12,6 +12,10 @@ type DomainConnection struct {
 	TotalCount int      `json:"totalCount" graphql:"-"`
 }
 
+func (s *DomainConnection) GetNodes() any {
+	return s.Nodes
+}
+
 // Returns unique identifiers created by OpsLevel, values in Aliases but not ManagedAliases
 func (d *Domain) UniqueIdentifiers() []string {
 	uniqueIdentifiers := []string{}

--- a/filters.go
+++ b/filters.go
@@ -185,6 +185,10 @@ type FilterConnection struct {
 	TotalCount int
 }
 
+func (s *FilterConnection) GetNodes() any {
+	return s.Nodes
+}
+
 func (filter *Filter) Alias() string {
 	return slug.Make(filter.Name)
 }

--- a/infra.go
+++ b/infra.go
@@ -42,6 +42,10 @@ type InfrastructureResourceConnection struct {
 	TotalCount int `graphql:"-"`
 }
 
+func (s *InfrastructureResourceConnection) GetNodes() any {
+	return s.Nodes
+}
+
 type InfraProviderInput struct {
 	Account string `json:"account" yaml:"account" default:"Dev - 123456789"`
 	Name    string `json:"name" yaml:"name" default:"Google"`

--- a/service.go
+++ b/service.go
@@ -49,6 +49,10 @@ type ServiceConnection struct {
 	TotalCount int
 }
 
+func (s *ServiceConnection) GetNodes() any {
+	return s.Nodes
+}
+
 type ServiceDocumentsConnection struct {
 	Nodes      []ServiceDocument
 	PageInfo   PageInfo

--- a/system.go
+++ b/system.go
@@ -12,6 +12,10 @@ type SystemConnection struct {
 	TotalCount int      `json:"totalCount" graphql:"-"`
 }
 
+func (s *SystemConnection) GetNodes() any {
+	return s.Nodes
+}
+
 func (systemId *SystemId) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {
 	var q struct {
 		Account struct {

--- a/team.go
+++ b/team.go
@@ -35,10 +35,18 @@ type TeamIdConnection struct {
 	TotalCount int
 }
 
+func (s *TeamIdConnection) GetNodes() any {
+	return s.Nodes
+}
+
 type TeamConnection struct {
 	Nodes      []Team
 	PageInfo   PageInfo
 	TotalCount int
+}
+
+func (s *TeamConnection) GetNodes() any {
+	return s.Nodes
 }
 
 type TeamMembershipConnection struct {

--- a/user.go
+++ b/user.go
@@ -11,6 +11,10 @@ type UserConnection struct {
 	TotalCount int
 }
 
+func (s *UserConnection) GetNodes() any {
+	return s.Nodes
+}
+
 func (user *User) ResourceId() ID {
 	return user.Id
 }


### PR DESCRIPTION
Resolves #

### Problem

Dealing with serializing the "nodes" of a connection type is painful and not easy in downstream tools

### Solution

Give connection types an interface they can implement so we can more easily serialize the "nodes" of a connection type.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
