### PR TITLE
Replace a bunch of confusing/unnecessary loops with ifs

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -30,7 +30,7 @@ func (customActionsTriggerDefinition *CustomActionsTriggerDefinition) ExtendedTe
 		return nil, err
 	}
 
-	for q.Account.CustomActionsTriggerDefinition.ExtendedTeamAccess.PageInfo.HasNextPage {
+	if q.Account.CustomActionsTriggerDefinition.ExtendedTeamAccess.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.CustomActionsTriggerDefinition.ExtendedTeamAccess.PageInfo.End
 		resp, err := customActionsTriggerDefinition.ExtendedTeamAccess(client, variables)
 		if err != nil {
@@ -94,7 +94,7 @@ func (client *Client) ListCustomActions(variables *PayloadVariables) (*CustomAct
 	if err := client.Query(&q, *variables, WithName("ExternalActionList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Actions.PageInfo.HasNextPage {
+	if q.Account.Actions.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Actions.PageInfo.End
 		resp, err := client.ListCustomActions(variables)
 		if err != nil {
@@ -174,7 +174,7 @@ func (client *Client) ListTriggerDefinitions(variables *PayloadVariables) (*Cust
 		return nil, HandleErrors(err)
 	}
 	q.Account.Definitions.TotalCount = len(q.Account.Definitions.Nodes)
-	for q.Account.Definitions.PageInfo.HasNextPage {
+	if q.Account.Definitions.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Definitions.PageInfo.End
 		resp, err := client.ListTriggerDefinitions(variables)
 		if err != nil {

--- a/category.go
+++ b/category.go
@@ -61,7 +61,7 @@ func (client *Client) ListCategories(variables *PayloadVariables) (*CategoryConn
 	if err := client.Query(&q, *variables, WithName("CategoryList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Rubric.Categories.PageInfo.HasNextPage {
+	if q.Account.Rubric.Categories.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Rubric.Categories.PageInfo.End
 		resp, err := client.ListCategories(variables)
 		if err != nil {

--- a/check.go
+++ b/check.go
@@ -202,7 +202,7 @@ func (client *Client) ListChecks(variables *PayloadVariables) (*CheckConnection,
 	if err := client.Query(&q, *variables, WithName("CheckList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Rubric.Checks.PageInfo.HasNextPage {
+	if q.Account.Rubric.Checks.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Rubric.Checks.PageInfo.End
 		resp, err := client.ListChecks(variables)
 		if err != nil {

--- a/component.go
+++ b/component.go
@@ -40,7 +40,7 @@ func (s *ComponentType) GetProperties(client *Client, v *PayloadVariables) (*Pro
 	s.Properties.Nodes = append(s.Properties.Nodes, q.Account.ComponentType.Properties.Nodes...)
 	s.Properties.PageInfo = q.Account.ComponentType.Properties.PageInfo
 	s.Properties.TotalCount += q.Account.ComponentType.Properties.TotalCount
-	for s.Properties.PageInfo.HasNextPage {
+	if s.Properties.PageInfo.HasNextPage {
 		(*v)["after"] = s.Properties.PageInfo.End
 		_, err := s.GetProperties(client, v)
 		if err != nil {
@@ -96,7 +96,7 @@ func (client *Client) ListComponentTypes(variables *PayloadVariables) (*Componen
 	if err := client.Query(&q, *variables, WithName("ComponentTypeList")); err != nil {
 		return nil, err
 	}
-	for q.Account.ComponentTypes.PageInfo.HasNextPage {
+	if q.Account.ComponentTypes.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.ComponentTypes.PageInfo.End
 		resp, err := client.ListComponentTypes(variables)
 		if err != nil {

--- a/dependencies.go
+++ b/dependencies.go
@@ -67,7 +67,7 @@ func (service *Service) GetDependencies(client *Client, variables *PayloadVariab
 	}
 	service.Dependencies.Edges = append(service.Dependencies.Edges, q.Account.Service.Dependencies.Edges...)
 	service.Dependencies.PageInfo = q.Account.Service.Dependencies.PageInfo
-	for service.Dependencies.PageInfo.HasNextPage {
+	if service.Dependencies.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Dependencies.PageInfo.End
 		_, err := service.GetDependencies(client, variables)
 		if err != nil {
@@ -100,7 +100,7 @@ func (service *Service) GetDependents(client *Client, variables *PayloadVariable
 	}
 	service.Dependents.Edges = append(service.Dependents.Edges, q.Account.Service.Dependents.Edges...)
 	service.Dependents.PageInfo = q.Account.Service.Dependents.PageInfo
-	for service.Dependents.PageInfo.HasNextPage {
+	if service.Dependents.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Dependents.PageInfo.End
 		_, err := service.GetDependents(client, variables)
 		if err != nil {

--- a/domain.go
+++ b/domain.go
@@ -60,7 +60,7 @@ func (domainId *DomainId) GetTags(client *Client, variables *PayloadVariables) (
 	if err := client.Query(&q, *variables, WithName("DomainTagsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Domain.Tags.PageInfo.HasNextPage {
+	if q.Account.Domain.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Domain.Tags.PageInfo.End
 		resp, err := domainId.GetTags(client, variables)
 		if err != nil {
@@ -114,7 +114,7 @@ func (domainId *DomainId) ChildSystems(client *Client, variables *PayloadVariabl
 	if err := client.Query(&q, *variables, WithName("DomainChildSystemsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Domain.ChildSystems.PageInfo.HasNextPage {
+	if q.Account.Domain.ChildSystems.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Domain.ChildSystems.PageInfo.End
 		resp, err := domainId.ChildSystems(client, variables)
 		if err != nil {
@@ -175,7 +175,7 @@ func (client *Client) ListDomains(variables *PayloadVariables) (*DomainConnectio
 	if err := client.Query(&q, *variables, WithName("DomainsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Domains.PageInfo.HasNextPage {
+	if q.Account.Domains.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Domains.PageInfo.End
 		resp, err := client.ListDomains(variables)
 		if err != nil {

--- a/filters.go
+++ b/filters.go
@@ -228,7 +228,7 @@ func (client *Client) ListFilters(variables *PayloadVariables) (*FilterConnectio
 	if err := client.Query(&q, *variables, WithName("FilterList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Filters.PageInfo.HasNextPage {
+	if q.Account.Filters.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Filters.PageInfo.End
 		resp, err := client.ListFilters(variables)
 		if err != nil {

--- a/infra.go
+++ b/infra.go
@@ -91,7 +91,7 @@ func (infrastructureResource *InfrastructureResource) GetTags(client *Client, va
 	if err := client.Query(&q, *variables, WithName("InfrastructureResourceTags")); err != nil {
 		return nil, err
 	}
-	for q.Account.InfrastructureResource.Tags.PageInfo.HasNextPage {
+	if q.Account.InfrastructureResource.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.InfrastructureResource.Tags.PageInfo.End
 		resp, err := infrastructureResource.GetTags(client, variables)
 		if err != nil {
@@ -182,7 +182,7 @@ func (client *Client) ListInfrastructureSchemas(variables *PayloadVariables) (*I
 	if err := client.Query(&q, *variables, WithName("InfrastructureResourceSchemaList")); err != nil {
 		return nil, err
 	}
-	for q.Account.InfrastructureResourceSchemas.PageInfo.HasNextPage {
+	if q.Account.InfrastructureResourceSchemas.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.InfrastructureResourceSchemas.PageInfo.End
 		resp, err := client.ListInfrastructureSchemas(variables)
 		if err != nil {
@@ -208,7 +208,7 @@ func (client *Client) ListInfrastructure(variables *PayloadVariables) (*Infrastr
 	if err := client.Query(&q, *variables, WithName("InfrastructureResourceList")); err != nil {
 		return nil, err
 	}
-	for q.Account.InfrastructureResource.PageInfo.HasNextPage {
+	if q.Account.InfrastructureResource.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.InfrastructureResource.PageInfo.End
 		resp, err := client.ListInfrastructure(variables)
 		if err != nil {

--- a/integration.go
+++ b/integration.go
@@ -135,7 +135,7 @@ func (client *Client) ListIntegrations(variables *PayloadVariables) (*Integratio
 	if err := client.Query(&q, *variables, WithName("IntegrationList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Integrations.PageInfo.HasNextPage {
+	if q.Account.Integrations.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Integrations.PageInfo.End
 		resp, err := client.ListIntegrations(variables)
 		if err != nil {

--- a/level.go
+++ b/level.go
@@ -24,7 +24,7 @@ func (conn *LevelConnection) Hydrate(client *Client) error {
 		"first": client.pageSize,
 	}
 	q.Account.Rubric.Levels.PageInfo = conn.PageInfo
-	for q.Account.Rubric.Levels.PageInfo.HasNextPage {
+	if q.Account.Rubric.Levels.PageInfo.HasNextPage {
 		v["after"] = q.Account.Rubric.Levels.PageInfo.End
 		if err := client.Query(&q, v); err != nil {
 			return err

--- a/maturity.go
+++ b/maturity.go
@@ -58,7 +58,7 @@ func (client *Client) ListServicesMaturity(variables *PayloadVariables) (*Servic
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesMaturity(variables)
 		if err != nil {

--- a/property.go
+++ b/property.go
@@ -93,7 +93,7 @@ func (client *Client) ListPropertyDefinitions(variables *PayloadVariables) (*Pro
 	if err := client.Query(&q, *variables, WithName("PropertyDefinitionList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Definitions.PageInfo.HasNextPage {
+	if q.Account.Definitions.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Definitions.PageInfo.End
 		resp, err := client.ListPropertyDefinitions(variables)
 		if err != nil {
@@ -178,7 +178,7 @@ func (service *Service) GetProperties(client *Client, variables *PayloadVariable
 	}
 	service.Properties.Nodes = append(service.Properties.Nodes, q.Account.Service.Properties.Nodes...)
 	service.Properties.PageInfo = q.Account.Service.Properties.PageInfo
-	for service.Properties.PageInfo.HasNextPage {
+	if service.Properties.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Properties.PageInfo.End
 		resp, err := service.GetProperties(client, variables)
 		if err != nil {

--- a/repository.go
+++ b/repository.go
@@ -141,7 +141,7 @@ func (repository *Repository) GetServices(client *Client, variables *PayloadVari
 	repository.Services.Edges = append(repository.Services.Edges, q.Account.Repository.Services.Edges...)
 	repository.Services.PageInfo = q.Account.Repository.Services.PageInfo
 	repository.Services.TotalCount += q.Account.Repository.Services.TotalCount
-	for repository.Services.PageInfo.HasNextPage {
+	if repository.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = repository.Services.PageInfo.End
 		_, err := repository.GetServices(client, variables)
 		if err != nil {
@@ -180,7 +180,7 @@ func (repository *Repository) GetTags(client *Client, variables *PayloadVariable
 	}
 	repository.Tags.PageInfo = q.Account.Repository.Tags.PageInfo
 	repository.Tags.TotalCount += q.Account.Repository.Tags.TotalCount
-	for repository.Tags.PageInfo.HasNextPage {
+	if repository.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = repository.Tags.PageInfo.End
 		_, err := repository.GetTags(client, variables)
 		if err != nil {
@@ -260,7 +260,7 @@ func (client *Client) ListRepositories(variables *PayloadVariables) (*Repository
 	if err := client.Query(&q, *variables, WithName("RepositoryList")); err != nil {
 		return &q.Account.Repositories, err
 	}
-	for q.Account.Repositories.PageInfo.HasNextPage {
+	if q.Account.Repositories.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Repositories.PageInfo.End
 		resp, err := client.ListRepositories(variables)
 		if err != nil {
@@ -292,7 +292,7 @@ func (client *Client) ListRepositoriesWithTier(tier string, variables *PayloadVa
 	if err := client.Query(&q, *variables, WithName("RepositoryListWithTier")); err != nil {
 		return &q.Account.Repositories, err
 	}
-	for q.Account.Repositories.PageInfo.HasNextPage {
+	if q.Account.Repositories.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Repositories.PageInfo.End
 		resp, err := client.ListRepositoriesWithTier(tier, variables)
 		if err != nil {

--- a/scorecards.go
+++ b/scorecards.go
@@ -66,7 +66,7 @@ func (scorecard *Scorecard) ListCategories(client *Client, variables *PayloadVar
 		return nil, err
 	}
 
-	for q.Account.Scorecard.Categories.PageInfo.HasNextPage {
+	if q.Account.Scorecard.Categories.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Scorecard.Categories.PageInfo.End
 		resp, err := scorecard.ListCategories(client, variables)
 		if err != nil {
@@ -122,7 +122,7 @@ func (client *Client) ListScorecards(variables *PayloadVariables) (*ScorecardCon
 	if err := client.Query(&q, *variables, WithName("ScorecardsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Scorecards.PageInfo.HasNextPage {
+	if q.Account.Scorecards.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Scorecards.PageInfo.End
 		resp, err := client.ListScorecards(variables)
 		if err != nil {

--- a/secrets.go
+++ b/secrets.go
@@ -30,7 +30,7 @@ func (client *Client) ListSecretsVaultsSecret(variables *PayloadVariables) (*Sec
 	if err := client.Query(&q, *variables, WithName("SecretList")); err != nil {
 		return nil, err
 	}
-	for q.Account.SecretsVaultsSecrets.PageInfo.HasNextPage {
+	if q.Account.SecretsVaultsSecrets.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.SecretsVaultsSecrets.PageInfo.End
 		resp, err := client.ListSecretsVaultsSecret(variables)
 		if err != nil {

--- a/service.go
+++ b/service.go
@@ -192,7 +192,7 @@ func (service *Service) GetTags(client *Client, variables *PayloadVariables) (*T
 	}
 	service.Tags.PageInfo = q.Account.Service.Tags.PageInfo
 	service.Tags.TotalCount += q.Account.Service.Tags.TotalCount
-	for service.Tags.PageInfo.HasNextPage {
+	if service.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Tags.PageInfo.End
 		_, err := service.GetTags(client, variables)
 		if err != nil {
@@ -231,7 +231,7 @@ func (service *Service) GetTools(client *Client, variables *PayloadVariables) (*
 	service.Tools.Nodes = append(service.Tools.Nodes, q.Account.Service.Tools.Nodes...)
 	service.Tools.PageInfo = q.Account.Service.Tools.PageInfo
 	service.Tools.TotalCount += q.Account.Service.Tools.TotalCount
-	for service.Tools.PageInfo.HasNextPage {
+	if service.Tools.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Tools.PageInfo.End
 		_, err := service.GetTools(client, variables)
 		if err != nil {
@@ -266,7 +266,7 @@ func (service *Service) GetRepositories(client *Client, variables *PayloadVariab
 	service.Repositories.Edges = append(service.Repositories.Edges, q.Account.Service.Repositories.Edges...)
 	service.Repositories.PageInfo = q.Account.Service.Repositories.PageInfo
 	service.Repositories.TotalCount += q.Account.Service.Repositories.TotalCount
-	for service.Repositories.PageInfo.HasNextPage {
+	if service.Repositories.PageInfo.HasNextPage {
 		(*variables)["after"] = service.Repositories.PageInfo.End
 		_, err := service.GetRepositories(client, variables)
 		if err != nil {
@@ -295,7 +295,7 @@ func (service *Service) GetDocuments(client *Client, variables *PayloadVariables
 	if err := client.Query(&q, *variables, WithName("ServiceDocumentsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Service.Documents.PageInfo.HasNextPage {
+	if q.Account.Service.Documents.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Service.Documents.PageInfo.End
 		resp, err := service.GetDocuments(client, variables)
 		if err != nil {
@@ -407,7 +407,7 @@ func (client *Client) ListServices(variables *PayloadVariables) (*ServiceConnect
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServices(variables)
 		if err != nil {
@@ -443,7 +443,7 @@ func (client *Client) ListServicesWithFilter(filterIdentifier string, variables 
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithFilter(filterIdentifier, variables)
 		if err != nil {
@@ -476,7 +476,7 @@ func (client *Client) ListServicesWithFramework(framework string, variables *Pay
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithFramework(framework, variables)
 		if err != nil {
@@ -509,7 +509,7 @@ func (client *Client) ListServicesWithLanguage(language string, variables *Paylo
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithLanguage(language, variables)
 		if err != nil {
@@ -542,7 +542,7 @@ func (client *Client) ListServicesWithLifecycle(lifecycle string, variables *Pay
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithLifecycle(lifecycle, variables)
 		if err != nil {
@@ -575,7 +575,7 @@ func (client *Client) ListServicesWithOwner(owner string, variables *PayloadVari
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithOwner(owner, variables)
 		if err != nil {
@@ -608,7 +608,7 @@ func (client *Client) ListServicesWithProduct(product string, variables *Payload
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithProduct(product, variables)
 		if err != nil {
@@ -658,7 +658,7 @@ func (client *Client) ListServicesWithTag(tag TagArgs, variables *PayloadVariabl
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithTag(tag, variables)
 		if err != nil {
@@ -691,7 +691,7 @@ func (client *Client) ListServicesWithTier(tier string, variables *PayloadVariab
 		return nil, err
 	}
 
-	for q.Account.Services.PageInfo.HasNextPage {
+	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
 		resp, err := client.ListServicesWithTier(tier, variables)
 		if err != nil {

--- a/system.go
+++ b/system.go
@@ -31,7 +31,7 @@ func (systemId *SystemId) GetTags(client *Client, variables *PayloadVariables) (
 	if err := client.Query(&q, *variables, WithName("SystemTagsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.System.Tags.PageInfo.HasNextPage {
+	if q.Account.System.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.System.Tags.PageInfo.End
 		resp, err := systemId.GetTags(client, variables)
 		if err != nil {
@@ -113,7 +113,7 @@ func (systemId *SystemId) ChildServices(client *Client, variables *PayloadVariab
 	if err := client.Query(&q, *variables, WithName("SystemChildServicesList")); err != nil {
 		return nil, err
 	}
-	for q.Account.System.ChildServices.PageInfo.HasNextPage {
+	if q.Account.System.ChildServices.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.System.ChildServices.PageInfo.End
 		resp, err := systemId.ChildServices(client, variables)
 		if err != nil {
@@ -174,7 +174,7 @@ func (client *Client) ListSystems(variables *PayloadVariables) (*SystemConnectio
 	if err := client.Query(&q, *variables, WithName("SystemsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.Systems.PageInfo.HasNextPage {
+	if q.Account.Systems.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Systems.PageInfo.End
 		resp, err := client.ListSystems(variables)
 		if err != nil {

--- a/team.go
+++ b/team.go
@@ -142,7 +142,7 @@ func (team *Team) GetMemberships(client *Client, variables *PayloadVariables) (*
 	team.Memberships.Nodes = append(team.Memberships.Nodes, q.Account.Team.Memberships.Nodes...)
 	team.Memberships.PageInfo = q.Account.Team.Memberships.PageInfo
 	team.Memberships.TotalCount += q.Account.Team.Memberships.TotalCount
-	for team.Memberships.PageInfo.HasNextPage {
+	if team.Memberships.PageInfo.HasNextPage {
 		(*variables)["after"] = team.Memberships.PageInfo.End
 		_, err := team.GetMemberships(client, variables)
 		if err != nil {
@@ -181,7 +181,7 @@ func (team *Team) GetTags(client *Client, variables *PayloadVariables) (*TagConn
 	}
 	team.Tags.PageInfo = q.Account.Team.Tags.PageInfo
 	team.Tags.TotalCount += q.Account.Team.Tags.TotalCount
-	for team.Tags.PageInfo.HasNextPage {
+	if team.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = team.Tags.PageInfo.End
 		_, err := team.GetTags(client, variables)
 		if err != nil {
@@ -357,7 +357,7 @@ func (client *Client) ListTeams(variables *PayloadVariables) (*TeamConnection, e
 		return nil, err
 	}
 
-	for q.Account.Teams.PageInfo.HasNextPage {
+	if q.Account.Teams.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Teams.PageInfo.End
 		resp, err := client.ListTeams(variables)
 		if err != nil {
@@ -390,7 +390,7 @@ func (client *Client) ListTeamsWithManager(email string, variables *PayloadVaria
 		return nil, err
 	}
 
-	for q.Account.Teams.PageInfo.HasNextPage {
+	if q.Account.Teams.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Teams.PageInfo.End
 		resp, err := client.ListTeamsWithManager(email, variables)
 		if err != nil {

--- a/user.go
+++ b/user.go
@@ -48,7 +48,7 @@ func (userId *UserId) GetTags(client *Client, variables *PayloadVariables) (*Tag
 	if err := client.Query(&q, *variables, WithName("UserTagsList")); err != nil {
 		return nil, err
 	}
-	for q.Account.User.Tags.PageInfo.HasNextPage {
+	if q.Account.User.Tags.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.User.Tags.PageInfo.End
 		resp, err := userId.GetTags(client, variables)
 		if err != nil {
@@ -85,7 +85,7 @@ func (user *User) Teams(client *Client, variables *PayloadVariables) (*TeamIdCon
 	if err := client.Query(&q, *variables, WithName("UserTeamsList")); err != nil { // what goes in "" here and how is it derived?
 		return nil, err
 	}
-	for q.Account.User.Teams.PageInfo.HasNextPage {
+	if q.Account.User.Teams.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.User.Teams.PageInfo.End
 		conn, err := user.Teams(client, variables)
 		if err != nil {
@@ -142,7 +142,7 @@ func (client *Client) ListUsers(variables *PayloadVariables) (*UserConnection, e
 		return nil, err
 	}
 
-	for q.Account.Users.PageInfo.HasNextPage {
+	if q.Account.Users.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Users.PageInfo.End
 		resp, err := client.ListUsers(variables)
 		if err != nil {


### PR DESCRIPTION
From https://github.com/OpsLevel/opslevel-go/pull/534#discussion_r2056619141

> We need to use recursion because you cannot feed the q var into client.Query multiple times. So it was originally written with iteration and then fixed to use recursion without undoing the former then copy pasted.

Just find/replace all the `for`s with `if`s to make this a bit clear. There might be more thorough cleanup possible but this is the high-value/low-effort version.