### PR TITLE
Add function to get the system of the service

### DIFF
--- a/.changes/unreleased/Feature-20250502-085309.yaml
+++ b/.changes/unreleased/Feature-20250502-085309.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add a function on the Service object to get the system of that service
+time: 2025-05-02T08:53:09.984285-05:00

--- a/service.go
+++ b/service.go
@@ -167,6 +167,27 @@ func (service *Service) Hydrate(client *Client) error {
 	return nil
 }
 
+func (service *Service) GetSystem(client *Client, variables *PayloadVariables) (*System, error) {
+	var q struct {
+		Account struct {
+			Service struct {
+				System System `graphql:"system"`
+			} `graphql:"service(id: $service)"`
+		}
+	}
+	if service.Id == "" {
+		return nil, fmt.Errorf("unable to get system, invalid Service id: '%s'", service.Id)
+	}
+	if variables == nil {
+		variables = client.InitialPageVariablesPointer()
+	}
+	(*variables)["service"] = service.Id
+	if err := client.Query(&q, *variables, WithName("ServiceSystemGet")); err != nil {
+		return nil, err
+	}
+	return &q.Account.Service.System, nil
+}
+
 func (service *Service) GetTags(client *Client, variables *PayloadVariables) (*TagConnection, error) {
 	var q struct {
 		Account struct {

--- a/service_test.go
+++ b/service_test.go
@@ -40,6 +40,26 @@ func TestServiceTags(t *testing.T) {
 	autopilot.Equals(t, "true", result[1].Value)
 }
 
+func TestServiceSystem(t *testing.T) {
+	// Arrange
+	request := autopilot.NewTestRequest(
+		`query ServiceSystemGet($after:String!$first:Int!$service:ID!){account{service(id: $service){system{id,aliases,description,htmlUrl,managedAliases,name,note,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,description,htmlUrl,managedAliases,name,note,owner{... on Team{teamAlias:alias,id}}}}}}}`,
+		`{ {{ template "first_page_variables" }}, "service": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85NjQ4" }`,
+		`{ "data": { "account": { "service": { "system": {{ template "system1_response" }} } } } }`,
+	)
+	client := BestTestClient(t, "service/system", request)
+	// Act
+	service := ol.Service{
+		ServiceId: ol.ServiceId{
+			Id: "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85NjQ4",
+		},
+	}
+	resp, err := service.GetSystem(client, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(resp.Id))
+}
+
 func TestServiceTools(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(


### PR DESCRIPTION
Resolves https://github.com/OpsLevel/terraform-provider-opslevel/issues/567

### Problem

There is no way to get the system of a service

### Solution

Part 1 for https://github.com/OpsLevel/terraform-provider-opslevel/issues/567

Add a context method on the service resource, similar to that of `GetProperties` and `GetTags`

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
