### PR TITLE
Add alert source APIs

### DIFF
--- a/.changes/unreleased/Feature-20250514-144247.yaml
+++ b/.changes/unreleased/Feature-20250514-144247.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add `client.CreateOrUpdateAlertSource` and `client.UpdateAlertSourceStatus` to interface with the new generic alert source APIs
+time: 2025-05-14T14:42:47.635522-05:00

--- a/alert_source.go
+++ b/alert_source.go
@@ -12,6 +12,20 @@ func NewAlertSource(kind AlertSourceTypeEnum, id string) *AlertSourceExternalIde
 	return &output
 }
 
+func (client *Client) CreateOrUpdateAlertSource(input AlertSourceInput) (*AlertSource, error) {
+	var m struct {
+		Payload struct {
+			AlertSource AlertSource
+			Errors      []Error
+		} `graphql:"alertSourceUpsert(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("AlertSourceUpsert"))
+	return &m.Payload.AlertSource, HandleErrors(err, m.Payload.Errors)
+}
+
 func (client *Client) CreateAlertSourceService(input AlertSourceServiceCreateInput) (*AlertSourceService, error) {
 	var m struct {
 		Payload AlertSourceServiceCreatePayload `graphql:"alertSourceServiceCreate(input: $input)"`
@@ -49,6 +63,20 @@ func (client *Client) GetAlertSource(id ID) (*AlertSource, error) {
 	}
 	err := client.Query(&q, v, WithName("AlertSourceGet"))
 	return &q.Account.AlertSource, HandleErrors(err, nil)
+}
+
+func (client *Client) UpdateAlertSourceStatus(input AlertSourceStatusUpdateInput) (*AlertSource, error) {
+	var m struct {
+		Payload struct {
+			AlertSource AlertSource
+			Errors      []Error
+		} `graphql:"alertSourceStatusUpdate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("AlertSourceStatusUpdate"))
+	return &m.Payload.AlertSource, HandleErrors(err, m.Payload.Errors)
 }
 
 func (client *Client) DeleteAlertSourceService(id ID) error {

--- a/input.go
+++ b/input.go
@@ -6,7 +6,15 @@ import "github.com/relvacode/iso8601"
 // AlertSourceExternalIdentifier Specifies the input needed to find an alert source with external information
 type AlertSourceExternalIdentifier struct {
 	ExternalId string              `json:"externalId" yaml:"externalId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The external id of the alert (Required)
-	Type       AlertSourceTypeEnum `json:"type" yaml:"type" example:"datadog"`                                     // The type of the alert (Required)
+	Type       AlertSourceTypeEnum `json:"type" yaml:"type" example:"custom"`                                      // The type of the alert (Required)
+}
+
+// AlertSourceInput Input fields for the mutations to manage Alert Sources
+type AlertSourceInput struct {
+	Description *Nullable[string]               `json:"description,omitempty" yaml:"description,omitempty" example:"example_value"` // The description of the alert source (Optional)
+	Identifier  ExternalResourceIdentifierInput `json:"identifier" yaml:"identifier"`                                               // The alert source identifier (Required)
+	Name        *Nullable[string]               `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`               // The name of the alert source (Optional)
+	Url         *Nullable[string]               `json:"url,omitempty" yaml:"url,omitempty" example:"example_value"`                 // The url of the alert source (Optional)
 }
 
 // AlertSourceServiceCreateInput Specifies the input used for attaching an alert source to a service
@@ -19,6 +27,12 @@ type AlertSourceServiceCreateInput struct {
 // AlertSourceServiceDeleteInput Specifies the input fields used in the `alertSourceServiceDelete` mutation
 type AlertSourceServiceDeleteInput struct {
 	Id ID `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the alert source service to be deleted (Required)
+}
+
+// AlertSourceStatusUpdateInput Specifies the input fields used in the `alertSourceStatusUpdate` mutation
+type AlertSourceStatusUpdateInput struct {
+	AlertSource ExternalResourceIdentifierInput `json:"alertSource" yaml:"alertSource"`       // The alert source to be updated (Required)
+	Status      AlertSourceStatusTypeEnum       `json:"status" yaml:"status" example:"alert"` // The new status of the alert source (Required)
 }
 
 // AliasCreateInput The input for the `aliasCreate` mutation
@@ -790,6 +804,12 @@ type EventIntegrationInput struct {
 type EventIntegrationUpdateInput struct {
 	Id   ID     `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The ID of the event integration to update (Required)
 	Name string `json:"name" yaml:"name" example:"example_value"`               // The name of the event integration (Required)
+}
+
+// ExternalResourceIdentifierInput Specifies the input fields to locate resouce created via API in OpsLevel
+type ExternalResourceIdentifierInput struct {
+	ExternalId  string          `json:"externalId" yaml:"externalId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the resource in your system (Required)
+	Integration IdentifierInput `json:"integration" yaml:"integration"`                                         // The integration identifier (Required)
 }
 
 // ExternalUuidMutationInput Specifies the input used for modifying a resource's external UUID


### PR DESCRIPTION
Resolves #

### Problem

We have new APIs for working with alert sources more generically but not way to do this via opslevel-go

### Solution

Codegen the structs and add the necessary client functions for this

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
