### PR TITLE
Add support for custom actions triggering

### DIFF
--- a/.changes/unreleased/Feature-20250514-145109.yaml
+++ b/.changes/unreleased/Feature-20250514-145109.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add `client.InvokeAction` to support triggering actions via the API
+time: 2025-05-14T14:51:09.396768-05:00

--- a/actions.go
+++ b/actions.go
@@ -216,3 +216,14 @@ func (client *Client) DeleteTriggerDefinition(input string) error {
 	err := client.Mutate(&m, v, WithName("TriggerDefinitionDelete"))
 	return HandleErrors(err, m.Payload.Errors)
 }
+
+func (client *Client) InvokeAction(input CustomActionsTriggerInvokeInput) error {
+	var m struct {
+		Payload BasePayload `graphql:"customActionsTriggerInvoke(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("CustomActionsTriggerInvoke"))
+	return HandleErrors(err, m.Payload.Errors)
+}

--- a/input.go
+++ b/input.go
@@ -758,6 +758,13 @@ type CustomActionsTriggerDefinitionUpdateInput struct {
 	ResponseTemplate       *Nullable[string]                                `json:"responseTemplate,omitempty" yaml:"responseTemplate,omitempty" example:"example_value"`             // The liquid template used to parse the response from the External Action (Optional)
 }
 
+// CustomActionsTriggerInvokeInput Inputs that specify the trigger definition to invoke, the user that invoked it, and what object it is invoked on
+type CustomActionsTriggerInvokeInput struct {
+	ManualInputs      JSON             `json:"manualInputs,omitempty" yaml:"manualInputs,omitempty" example:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"` // Additional details provided for a specific invocation of this Custom Action (Optional Default: "{}")
+	TargetObject      *IdentifierInput `json:"targetObject,omitempty" yaml:"targetObject,omitempty"`                                                                                                                     // The identifier of the object to perform the custom action on (Optional)
+	TriggerDefinition IdentifierInput  `json:"triggerDefinition" yaml:"triggerDefinition"`                                                                                                                               // The trigger definition to invoke (Required)
+}
+
 // CustomActionsWebhookActionCreateInput Specifies the input fields used in the `customActionsWebhookActionCreate` mutation
 type CustomActionsWebhookActionCreateInput struct {
 	Async          *bool                       `json:"async,omitempty" yaml:"async,omitempty" example:"false"`                                                                                                         // Whether the action expects an additional, asynchronous response upon completion (Required Default: false)


### PR DESCRIPTION
Resolves #

### Problem

We've added an API for invoking actions but opslevel-go cannot do it

### Solution

Codegen the structs and implement the client functions for this

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
