### PR TITLE
Add ability to get last deploy of a service

### DIFF
--- a/.changes/unreleased/Feature-20250514-150622.yaml
+++ b/.changes/unreleased/Feature-20250514-150622.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add utility function to service struct to `GetLastDeploy` event
+time: 2025-05-14T15:06:22.701659-05:00

--- a/service.go
+++ b/service.go
@@ -239,10 +239,10 @@ func (service *Service) GetLastDeploy(client *Client, variables *PayloadVariable
 	if service.Id == "" {
 		return nil, fmt.Errorf("unable to get LastDeploy, invalid service id: '%s'", service.Id)
 	}
-	(*variables)["service"] = service.Id
 	if variables == nil {
 		variables = client.InitialPageVariablesPointer()
 	}
+	(*variables)["service"] = service.Id
 	if err := client.Query(&q, *variables, WithName("ServiceLastDeploy")); err != nil {
 		return nil, err
 	}

--- a/service.go
+++ b/service.go
@@ -40,6 +40,7 @@ type Service struct {
 	Dependencies *ServiceDependenciesConnection `graphql:"-"`
 	Dependents   *ServiceDependentsConnection   `graphql:"-"`
 
+	LastDeploy *Deploy                      `graphql:"-"`
 	Properties *ServicePropertiesConnection `graphql:"-"`
 }
 
@@ -225,6 +226,27 @@ func (service *Service) GetTags(client *Client, variables *PayloadVariables) (*T
 		}
 	}
 	return service.Tags, nil
+}
+
+func (service *Service) GetLastDeploy(client *Client, variables *PayloadVariables) (*Deploy, error) {
+	var q struct {
+		Account struct {
+			Service struct {
+				LastDeploy Deploy
+			} `graphql:"service(id: $service)"`
+		}
+	}
+	if service.Id == "" {
+		return nil, fmt.Errorf("unable to get LastDeploy, invalid service id: '%s'", service.Id)
+	}
+	(*variables)["service"] = service.Id
+	if variables == nil {
+		variables = client.InitialPageVariablesPointer()
+	}
+	if err := client.Query(&q, *variables, WithName("ServiceLastDeploy")); err != nil {
+		return nil, err
+	}
+	return &q.Account.Service.LastDeploy, nil
 }
 
 func (service *Service) GetAliases() []string {


### PR DESCRIPTION
Resolves #

### Problem

Given a service there is no way to get the last deploy for it.

### Solution

Add a utility function to the service struct to get the last deploy field.  It was done as a add on function so we don't bloat the ListServices call further.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
