### PR TITLE
Add relationship create and delete

### DIFF
--- a/.changes/unreleased/Feature-20250522-103636.yaml
+++ b/.changes/unreleased/Feature-20250522-103636.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to create and delete relationships
+time: 2025-05-22T10:36:36.854903-05:00

--- a/object.go
+++ b/object.go
@@ -362,6 +362,14 @@ type RelationshipNode struct {
 	Source      RelationshipResource // The catalog item that a relationship stems from (Required)
 }
 
+// RelationshipType The type specifying a relationship between two resources
+type RelationshipType struct {
+	Id     ID                   // The ID of the relationship (Required)
+	Source RelationshipResource // The resource that is the source of the relationship (Required)
+	Target RelationshipResource // The resource that is the target of the relationship (Required)
+	Type   RelationshipTypeEnum // The type of the relationship between source and target (Required)
+}
+
 // RepositoryPath The repository path used for this service
 type RepositoryPath struct {
 	Href string // The deep link to the repository path where the linked service's code exists (Required)

--- a/relationship.go
+++ b/relationship.go
@@ -16,6 +16,20 @@ func (client *Client) CreateRelationshipDefinition(input RelationshipDefinitionI
 	return &m.Payload.Definition, HandleErrors(err, m.Payload.Errors)
 }
 
+func (client *Client) CreateRelationship(input RelationshipDefinition) (*RelationshipType, error) {
+	var m struct {
+		Payload struct {
+			Relationship RelationshipType
+			Errors       []Error
+		} `graphql:"relationshipDefinitionCreate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("RelationshipCreate"))
+	return &m.Payload.Relationship, HandleErrors(err, m.Payload.Errors)
+}
+
 func (client *Client) GetRelationshipDefinition(identifier string) (*RelationshipDefinitionType, error) {
 	var q struct {
 		Account struct {
@@ -84,5 +98,20 @@ func (client *Client) DeleteRelationshipDefinition(identifier string) (*ID, erro
 		"input": input,
 	}
 	err := client.Mutate(&m, v, WithName("RelationshipDefinitionDelete"))
+	return &m.Payload.DeletedId, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) DeleteRelationship(identifier string) (*ID, error) {
+	var m struct {
+		Payload struct {
+			DeletedId ID      `graphql:"deletedId"`
+			Errors    []Error `graphql:"errors"`
+		} `graphql:"relationshipDelete(resource: $input)"`
+	}
+	input := *NewIdentifier(identifier)
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("RelationshipDelete"))
 	return &m.Payload.DeletedId, HandleErrors(err, m.Payload.Errors)
 }

--- a/union.go
+++ b/union.go
@@ -41,6 +41,7 @@ type RelationshipResource struct {
 	InfrastructureResource InfrastructureResource `graphql:"... on InfrastructureResource"`
 	Service                Service                `graphql:"... on Service"`
 	System                 SystemId               `graphql:"... on System"`
+	Team                   TeamId                 `graphql:"... on Team"`
 }
 
 // ServiceDocumentSource represents the source of a document.


### PR DESCRIPTION
Resolves #

### Problem

There is currently no way to create or delete actual relationships with components.

### Solution

Add the create and delete mutations for it.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
