### PR TITLE
Kr/repo update SBOM

### DIFF
--- a/.changes/unreleased/Feature-20250522-105617.yaml
+++ b/.changes/unreleased/Feature-20250522-105617.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to configure sbom generation on Repository Update
+time: 2025-05-22T10:56:17.629557-05:00

--- a/enum.go
+++ b/enum.go
@@ -3075,6 +3075,36 @@ var AllRelationshipTypeEnum = []string{
 	string(RelationshipTypeEnumRelatedTo),
 }
 
+// RepositorySBOMGenerationConfigEnum The enumerated list of configuration values for SBOM generation at the repository level
+type RepositorySBOMGenerationConfigEnum string
+
+var (
+	RepositorySBOMGenerationConfigEnumOptIn  RepositorySBOMGenerationConfigEnum = "opt_in"  // Indicates that the repository will opt in to automated SBOM generation if it would be otherwise enabled at an integration or account level
+	RepositorySBOMGenerationConfigEnumOptOut RepositorySBOMGenerationConfigEnum = "opt_out" // Indicates that the repository will opt out of automated SBOM generation if it would be otherwise enabled at an integration or account level
+)
+
+// All RepositorySBOMGenerationConfigEnum as []string
+var AllRepositorySBOMGenerationConfigEnum = []string{
+	string(RepositorySBOMGenerationConfigEnumOptIn),
+	string(RepositorySBOMGenerationConfigEnumOptOut),
+}
+
+// RepositorySBOMGenerationDisabledReasonEnum The set of values that explain why SBOM autogeneration is disabled
+type RepositorySBOMGenerationDisabledReasonEnum string
+
+var (
+	RepositorySBOMGenerationDisabledReasonEnumAccount     RepositorySBOMGenerationDisabledReasonEnum = "account"     // SBOM autogeneration is disabled at the account level
+	RepositorySBOMGenerationDisabledReasonEnumIntegration RepositorySBOMGenerationDisabledReasonEnum = "integration" // SBOM autogeneration is disabled at the integration level
+	RepositorySBOMGenerationDisabledReasonEnumRepository  RepositorySBOMGenerationDisabledReasonEnum = "repository"  // SBOM autogeneration is disabled at the repository level
+)
+
+// All RepositorySBOMGenerationDisabledReasonEnum as []string
+var AllRepositorySBOMGenerationDisabledReasonEnum = []string{
+	string(RepositorySBOMGenerationDisabledReasonEnumAccount),
+	string(RepositorySBOMGenerationDisabledReasonEnumIntegration),
+	string(RepositorySBOMGenerationDisabledReasonEnumRepository),
+}
+
 // RepositoryVisibilityEnum Possible visibility levels for repositories
 type RepositoryVisibilityEnum string
 

--- a/input.go
+++ b/input.go
@@ -1011,9 +1011,10 @@ type RelationshipDefinitionMetadataInput struct {
 
 // RepositoryUpdateInput Specifies the input fields used to update a repository
 type RepositoryUpdateInput struct {
-	Id      ID              `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                               // The id of the repository to be updated (Required)
-	OwnerId *Nullable[ID]   `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The team that owns the repository (Optional)
-	Visible *Nullable[bool] `json:"visible,omitempty" yaml:"visible,omitempty" example:"false"`                           // Indicates if the repository is visible (Optional)
+	Id             ID                                  `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                               // The id of the repository to be updated (Required)
+	OwnerId        *Nullable[ID]                       `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The team that owns the repository (Optional)
+	SbomGeneration *RepositorySBOMGenerationConfigEnum `json:"sbomGeneration,omitempty" yaml:"sbomGeneration,omitempty" example:"opt_in"`            // The desired configuration state at the repository level for SBOM generation (Optional)
+	Visible        *Nullable[bool]                     `json:"visible,omitempty" yaml:"visible,omitempty" example:"false"`                           // Indicates if the repository is visible (Optional)
 }
 
 // ScorecardInput Input used to create scorecards

--- a/object.go
+++ b/object.go
@@ -376,6 +376,14 @@ type RepositoryPath struct {
 	Path string // The path where the linked service's code exists, relative to the root of the repository (Required)
 }
 
+// SBOMGenerationConfiguration The configuration details that explain whether SBOM generation is allowed for the repository
+type SBOMGenerationConfiguration struct {
+	DisabledReason   RepositorySBOMGenerationDisabledReasonEnum // A brief explanation of why SBOM autogeneration is disabled (Optional)
+	Enabled          bool                                       // Whether SBOM autogeneration is enabled through all associated configuration objects (Required)
+	NextGenerationAt iso8601.Time                               // The approximate time at which a new software bill of material will be generated for this repository (Optional)
+	State            RepositorySBOMGenerationConfigEnum         // The configuration option set by the current object (Optional)
+}
+
 // ScorecardId A scorecard
 type ScorecardId struct {
 	Id      ID       // A reference to the scorecard.


### PR DESCRIPTION
Resolves #

### Problem

A new field was exposed to configure sbom gen rules on repository update but opslevel-go cannot do it.

### Solution

Run codegen to pick this up.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
