### PR TITLE
fix service LastDeploy field to not use pagination variables

### DIFF
--- a/service.go
+++ b/service.go
@@ -229,8 +229,9 @@ func (service *Service) GetLastDeploy(client *Client, variables *PayloadVariable
 	if service.Id == "" {
 		return nil, fmt.Errorf("unable to get LastDeploy, invalid service id: '%s'", service.Id)
 	}
+
 	if variables == nil {
-		variables = client.InitialPageVariablesPointer()
+		variables = &PayloadVariables{}
 	}
 	(*variables)["service"] = service.Id
 	if err := client.Query(&q, *variables, WithName("ServiceLastDeploy")); err != nil {


### PR DESCRIPTION
Resolves #

### Problem

Fixes that we were defaulting `GetLastDeploy` params to pagination params, when those aren't accepted for this (singular) field.

### Solution

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
