### PR TITLE
Add SBOM gen flag to repository struture

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -13,28 +13,29 @@ type RepositoryId struct {
 }
 
 type Repository struct {
-	ArchivedAt         iso8601.Time
-	CreatedOn          iso8601.Time
-	DefaultAlias       string
-	DefaultBranch      string
-	Description        string
-	Forked             bool
-	HtmlUrl            string
-	Id                 ID
-	Languages          []Language
-	LastOwnerChangedAt iso8601.Time
-	Locked             bool
-	Name               string
-	Organization       string
-	Owner              TeamId
-	Private            bool
-	RepoKey            string
-	Services           *RepositoryServiceConnection
-	Tags               *TagConnection
-	Tier               Tier
-	Type               string
-	Url                string
-	Visible            bool
+	ArchivedAt                  iso8601.Time
+	CreatedOn                   iso8601.Time
+	DefaultAlias                string
+	DefaultBranch               string
+	Description                 string
+	Forked                      bool
+	HtmlUrl                     string
+	Id                          ID
+	Languages                   []Language
+	LastOwnerChangedAt          iso8601.Time
+	Locked                      bool
+	Name                        string
+	Organization                string
+	Owner                       TeamId
+	Private                     bool
+	RepoKey                     string
+	SBOMGenerationConfiguration SBOMGenerationConfiguration
+	Services                    *RepositoryServiceConnection
+	Tags                        *TagConnection
+	Tier                        Tier
+	Type                        string
+	Url                         string
+	Visible                     bool
 }
 
 // RepositoryConnection The connection type for Repository


### PR DESCRIPTION
Resolves #

### Problem

SBOM generation can be configured on repository update but the response type doesn't tell you the details

### Solution

The response type for Repository is not code gen'd yet so we have to manually added this

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
