### PR TITLE
Add ability to “query” for a given relationship

### DIFF
--- a/relationship.go
+++ b/relationship.go
@@ -1,5 +1,7 @@
 package opslevel
 
+import "fmt"
+
 type RelationshipDefinitionPayload struct {
 	Definition RelationshipDefinitionType // The relationship that was defined.
 	BasePayload
@@ -40,6 +42,22 @@ func (client *Client) GetRelationshipDefinition(identifier string) (*Relationshi
 		"input": *NewIdentifier(identifier),
 	}
 	err := client.Query(&q, v, WithName("RelationshipDefinitionGet"))
+	return &q.Account.Resource, HandleErrors(err, nil)
+}
+
+func (client *Client) GetRelationship(identifier string) (*RelationshipType, error) {
+	if !IsID(identifier) {
+		return nil, fmt.Errorf("identifier '%s' is not a valid ID", identifier)
+	}
+	var q struct {
+		Account struct {
+			Resource RelationshipType `graphql:"relationship(id: $input)"`
+		}
+	}
+	v := PayloadVariables{
+		"input": *NewID(identifier),
+	}
+	err := client.Query(&q, v, WithName("RelationshipGet"))
 	return &q.Account.Resource, HandleErrors(err, nil)
 }
 

--- a/relationship_test.go
+++ b/relationship_test.go
@@ -143,3 +143,33 @@ func TestRelationshipDefinitionDelete(t *testing.T) {
 	// Assert
 	autopilot.Ok(t, err)
 }
+
+func TestGetRelationship(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query RelationshipGet($input:ID!){account{relationship(id: $input){id,source{... on Domain{id,aliases},... on InfrastructureResource{id,aliases,name},... on Service{id,aliases},... on System{id,aliases},... on Team{alias,id}},target{... on Domain{id,aliases},... on InfrastructureResource{id,aliases,name},... on Service{id,aliases},... on System{id,aliases},... on Team{alias,id}},type}}}`,
+		`{"input": "{{ template "id1_string" }}" }`,
+		`{"data": {"account": {"relationship": {
+			"id": "{{ template "id1_string" }}",
+			"source": {
+				"id": "{{ template "id2_string" }}",
+				"aliases": ["source-alias"]
+			},
+			"target": {
+				"id": "{{ template "id3_string" }}",
+				"aliases": ["target-alias"]
+			},
+			"type": "belongs_to"
+		}}}}`,
+	)
+
+	client := BestTestClient(t, "relationship/get", testRequest)
+	// Act
+	result, err := client.GetRelationship(string(id1))
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, id2, result.Source.Domain.Id)
+	autopilot.Equals(t, id3, result.Target.Domain.Id)
+	autopilot.Equals(t, ol.RelationshipTypeEnumBelongsTo, result.Type)
+}


### PR DESCRIPTION
Resolves #

### Problem

Terraform needs the ability to query for a relationship by ID so that it can detect drift.  This is not currently possible

### Solution

Make this possible.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
