### PR TITLE
Add custom yaml marshalling for Nullable[T]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/relvacode/iso8601 v1.6.0
 	github.com/rocktavious/autopilot/v2023 v2023.12.7
 	github.com/rs/zerolog v1.34.0
+	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -24,6 +26,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/coder/websocket v1.8.13 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -36,6 +39,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
 golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scalar.go
+++ b/scalar.go
@@ -138,14 +138,15 @@ func (nullable *Nullable[T]) UnmarshalYAML(value *yaml.Node) error {
 			key := value.Content[i]
 			val := value.Content[i+1]
 
-			if key.Value == "value" {
+			switch key.Value {
+			case "value":
 				var v T
 				if err := val.Decode(&v); err != nil {
 					return err
 				}
 				nullable.Value = v
 				nullable.SetNull = false
-			} else if key.Value == "setNull" {
+			case "setNull":
 				var setNull bool
 				if err := val.Decode(&setNull); err != nil {
 					return err

--- a/scalar.go
+++ b/scalar.go
@@ -137,7 +137,7 @@ func (nullable *Nullable[T]) UnmarshalYAML(value *yaml.Node) error {
 		for i := 0; i < len(value.Content); i += 2 {
 			key := value.Content[i]
 			val := value.Content[i+1]
-			
+
 			if key.Value == "value" {
 				var v T
 				if err := val.Decode(&v); err != nil {


### PR DESCRIPTION
Resolves #

### Problem

The CLI expects yaml like

```
description: "hello world"
```

but with the `Nullable[T]` change it now expects

```
description:
  value: "hello world"
```

### Solution

Add custom yaml marshalling to support reading nullable's as they old way to keep compatiblity.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
