### PR TITLE
Fix Nullable yaml marshalling for example commands

### DIFF
--- a/scalar.go
+++ b/scalar.go
@@ -109,6 +109,13 @@ func (nullable *Nullable[T]) UnmarshalJSON(data []byte) error {
 	return stuff
 }
 
+func (nullable *Nullable[T]) MarshalYAML() (interface{}, error) {
+	if nullable == nil || nullable.SetNull {
+		return nil, nil
+	}
+	return nullable.Value, nil
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface
 func (nullable *Nullable[T]) UnmarshalYAML(value *yaml.Node) error {
 	// Handle null values


### PR DESCRIPTION
Resolves #

### Problem

When Nullable[T] is yaml marshalled (for the CLI) the output was like this

```
key:
  value: null
  setNull: true
```

and it needed to be like this

```
key: null
```

### Solution

Fix this issue for the CLI's yaml example marshalling

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
