### PR TITLE
Allow client transport to be overridden

### DIFF
--- a/.changes/unreleased/Feature-20250629-123543.yaml
+++ b/.changes/unreleased/Feature-20250629-123543.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Allow the HTTP transport of GraphQL and REST clients to be overridden
+time: 2025-06-29T12:35:43.236187+01:00

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
@@ -9,24 +10,25 @@ import (
 )
 
 type ClientSettings struct {
-	url      string
-	token    string
-	timeout  time.Duration
-	retries  int
-	headers  map[string]string
-	pageSize int // Only Used by GQL
+	url       string
+	token     string
+	timeout   time.Duration
+	retries   int
+	headers   map[string]string
+	pageSize  int // Only Used by GQL
+	transport http.RoundTripper
 }
 
 type Option func(*ClientSettings)
 
 func newClientSettings(options ...Option) *ClientSettings {
 	settings := &ClientSettings{
-		url:     "https://app.opslevel.com",
-		token:   os.Getenv("OPSLEVEL_API_TOKEN"),
-		timeout: time.Second * 10,
-		retries: 10,
-
-		pageSize: 100,
+		url:       "https://app.opslevel.com",
+		token:     os.Getenv("OPSLEVEL_API_TOKEN"),
+		timeout:   time.Second * 10,
+		retries:   10,
+		pageSize:  100,
+		transport: http.DefaultTransport,
 		headers: map[string]string{
 			"User-Agent":         buildUserAgent(""),
 			"GraphQL-Visibility": "public",
@@ -87,6 +89,12 @@ func SetAPIVisibility(visibility string) Option {
 func SetPageSize(size int) Option {
 	return func(c *ClientSettings) {
 		c.pageSize = size
+	}
+}
+
+func SetTransport(transport http.RoundTripper) Option {
+	return func(c *ClientSettings) {
+		c.transport = transport
 	}
 }
 

--- a/clientGQL.go
+++ b/clientGQL.go
@@ -23,6 +23,8 @@ func NewGQLClient(options ...Option) *Client {
 	retryClient.Logger = nil
 
 	standardClient := retryClient.StandardClient()
+	standardClient.Transport = settings.transport
+
 	var url string
 	if strings.Contains(settings.url, "/LOCAL_TESTING/") {
 		url = settings.url

--- a/clientRest.go
+++ b/clientRest.go
@@ -18,5 +18,6 @@ func NewRestClient(options ...Option) *resty.Client {
 		client.SetHeader(key, value)
 	}
 	client.SetTimeout(settings.timeout)
+	client.SetTransport(settings.transport)
 	return client
 }


### PR DESCRIPTION
This change fixes #197, and is based on #263.

### Problem

In our codebase, we use `*httpmock.MockTransport` to mock third parties. However, this requires being able to override the transport used by the OpsLevel client, which is currently not possible.

### Solution

Introduces `SetTransport` as a client option, and ensures this is applied to both the GraphQL and REST clients. In #263, it was mentioned that support should be added for both.

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change? **No, it doesn't**
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
