### PR TITLE
Add component filtering via input filter

### DIFF
--- a/.changes/unreleased/Feature-20250717-082310.yaml
+++ b/.changes/unreleased/Feature-20250717-082310.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add `ListServicesWithInputFilter` method for constructing service queries with
+  ad hoc filters.
+time: 2025-07-17T08:23:10.305942-07:00

--- a/enum.go
+++ b/enum.go
@@ -2857,44 +2857,56 @@ var AllPayloadSortEnum = []string{
 type PredicateKeyEnum string
 
 var (
-	PredicateKeyEnumAliases         PredicateKeyEnum = "aliases"           // Filter by Alias attached to this service, if any
-	PredicateKeyEnumComponentTypeID PredicateKeyEnum = "component_type_id" // Filter by the `component_type` field
-	PredicateKeyEnumCreationSource  PredicateKeyEnum = "creation_source"   // Filter by the creation source
-	PredicateKeyEnumDomainID        PredicateKeyEnum = "domain_id"         // Filter by Domain that includes the System this service is assigned to, if any
-	PredicateKeyEnumFilterID        PredicateKeyEnum = "filter_id"         // Filter by another filter
-	PredicateKeyEnumFramework       PredicateKeyEnum = "framework"         // Filter by `framework` field
-	PredicateKeyEnumGroupIDs        PredicateKeyEnum = "group_ids"         // Filter by group hierarchy. Will return resources who's owner is in the group ancestry chain
-	PredicateKeyEnumLanguage        PredicateKeyEnum = "language"          // Filter by `language` field
-	PredicateKeyEnumLifecycleIndex  PredicateKeyEnum = "lifecycle_index"   // Filter by `lifecycle` field
-	PredicateKeyEnumName            PredicateKeyEnum = "name"              // Filter by `name` field
-	PredicateKeyEnumOwnerID         PredicateKeyEnum = "owner_id"          // Filter by `owner` field
-	PredicateKeyEnumOwnerIDs        PredicateKeyEnum = "owner_ids"         // Filter by `owner` hierarchy. Will return resources who's owner is in the team ancestry chain
-	PredicateKeyEnumProduct         PredicateKeyEnum = "product"           // Filter by `product` field
-	PredicateKeyEnumProperties      PredicateKeyEnum = "properties"        // Filter by custom-defined properties
-	PredicateKeyEnumRepositoryIDs   PredicateKeyEnum = "repository_ids"    // Filter by Repository that this service is attached to, if any
-	PredicateKeyEnumSystemID        PredicateKeyEnum = "system_id"         // Filter by System that this service is assigned to, if any
-	PredicateKeyEnumTags            PredicateKeyEnum = "tags"              // Filter by `tags` field
-	PredicateKeyEnumTierIndex       PredicateKeyEnum = "tier_index"        // Filter by `tier` field
+	PredicateKeyEnumAliases           PredicateKeyEnum = "aliases"            // Filter by Alias attached to this service, if any
+	PredicateKeyEnumAlertStatus       PredicateKeyEnum = "alert_status"       // Filter by alert status field
+	PredicateKeyEnumComponentTypeID   PredicateKeyEnum = "component_type_id"  // Filter by the `component_type` field
+	PredicateKeyEnumCreationSource    PredicateKeyEnum = "creation_source"    // Filter by the creation source
+	PredicateKeyEnumDeployEnvironment PredicateKeyEnum = "deploy_environment" // Filter by the existence of a deploy to an environment
+	PredicateKeyEnumDomainID          PredicateKeyEnum = "domain_id"          // Filter by Domain that includes the System this service is assigned to, if any
+	PredicateKeyEnumFilterID          PredicateKeyEnum = "filter_id"          // Filter by another filter
+	PredicateKeyEnumFramework         PredicateKeyEnum = "framework"          // Filter by `framework` field
+	PredicateKeyEnumGroupIDs          PredicateKeyEnum = "group_ids"          // Filter by group hierarchy. Will return resources who's owner is in the group ancestry chain
+	PredicateKeyEnumLanguage          PredicateKeyEnum = "language"           // Filter by `language` field
+	PredicateKeyEnumLevelIndex        PredicateKeyEnum = "level_index"        // Filter by level field
+	PredicateKeyEnumLifecycleIndex    PredicateKeyEnum = "lifecycle_index"    // Filter by `lifecycle` field
+	PredicateKeyEnumName              PredicateKeyEnum = "name"               // Filter by `name` field
+	PredicateKeyEnumOwnerID           PredicateKeyEnum = "owner_id"           // Filter by `owner` field
+	PredicateKeyEnumOwnerIDs          PredicateKeyEnum = "owner_ids"          // Filter by `owner` hierarchy. Will return resources who's owner is in the team ancestry chain
+	PredicateKeyEnumProduct           PredicateKeyEnum = "product"            // Filter by `product` field
+	PredicateKeyEnumProperties        PredicateKeyEnum = "properties"         // Filter by custom-defined properties
+	PredicateKeyEnumProperty          PredicateKeyEnum = "property"           // Filter by a custom-defined property value
+	PredicateKeyEnumRelationship      PredicateKeyEnum = "relationship"       // Filter by the existence of a relationship to another catalog component
+	PredicateKeyEnumRepositoryIDs     PredicateKeyEnum = "repository_ids"     // Filter by Repository that this service is attached to, if any
+	PredicateKeyEnumSystemID          PredicateKeyEnum = "system_id"          // Filter by System that this service is assigned to, if any
+	PredicateKeyEnumTag               PredicateKeyEnum = "tag"                // Filter by tag field
+	PredicateKeyEnumTags              PredicateKeyEnum = "tags"               // Filter by `tags` field
+	PredicateKeyEnumTierIndex         PredicateKeyEnum = "tier_index"         // Filter by `tier` field
 )
 
 // All PredicateKeyEnum as []string
 var AllPredicateKeyEnum = []string{
 	string(PredicateKeyEnumAliases),
+	string(PredicateKeyEnumAlertStatus),
 	string(PredicateKeyEnumComponentTypeID),
 	string(PredicateKeyEnumCreationSource),
+	string(PredicateKeyEnumDeployEnvironment),
 	string(PredicateKeyEnumDomainID),
 	string(PredicateKeyEnumFilterID),
 	string(PredicateKeyEnumFramework),
 	string(PredicateKeyEnumGroupIDs),
 	string(PredicateKeyEnumLanguage),
+	string(PredicateKeyEnumLevelIndex),
 	string(PredicateKeyEnumLifecycleIndex),
 	string(PredicateKeyEnumName),
 	string(PredicateKeyEnumOwnerID),
 	string(PredicateKeyEnumOwnerIDs),
 	string(PredicateKeyEnumProduct),
 	string(PredicateKeyEnumProperties),
+	string(PredicateKeyEnumProperty),
+	string(PredicateKeyEnumRelationship),
 	string(PredicateKeyEnumRepositoryIDs),
 	string(PredicateKeyEnumSystemID),
+	string(PredicateKeyEnumTag),
 	string(PredicateKeyEnumTags),
 	string(PredicateKeyEnumTierIndex),
 }

--- a/service.go
+++ b/service.go
@@ -563,7 +563,7 @@ func (client *Client) ListServicesWithFramework(framework string, variables *Pay
 	return &q.Account.Services, nil
 }
 
-func (client *Client) ListServicesWithInputFilter(filters []ServiceFilterInput, variables *PayloadVariables) (*ServiceConnection, error) {
+func (client *Client) ListServicesWithInputFilter(filter ServiceFilterInput, variables *PayloadVariables) (*ServiceConnection, error) {
 	var q struct {
 		Account struct {
 			Services ServiceConnection `graphql:"services(filter: $filter, after: $after, first: $first)"`
@@ -572,7 +572,7 @@ func (client *Client) ListServicesWithInputFilter(filters []ServiceFilterInput, 
 	if variables == nil {
 		variables = client.InitialPageVariablesPointer()
 	}
-	(*variables)["filter"] = filters
+	(*variables)["filter"] = []ServiceFilterInput{filter} // GraphQL expects an array of filters
 
 	if err := client.Query(&q, *variables, WithName("ServiceListWithInputFilter")); err != nil {
 		return nil, err
@@ -580,7 +580,7 @@ func (client *Client) ListServicesWithInputFilter(filters []ServiceFilterInput, 
 
 	if q.Account.Services.PageInfo.HasNextPage {
 		(*variables)["after"] = q.Account.Services.PageInfo.End
-		resp, err := client.ListServicesWithInputFilter(filters, variables)
+		resp, err := client.ListServicesWithInputFilter(filter, variables)
 		if err != nil {
 			return nil, err
 		}

--- a/service_test.go
+++ b/service_test.go
@@ -476,7 +476,7 @@ func TestGetServiceWithAlias(t *testing.T) {
           "edges": [
             {
               "node": {
-                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
+                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
                 "defaultAlias": "github.com:rocktavious/autopilot"
               },
               "serviceRepositories": [
@@ -485,7 +485,7 @@ func TestGetServiceWithAlias(t *testing.T) {
                   "displayName": "rocktavious/autopilot",
                   "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZVJlcG9zaXRvcnkvNDIxNw",
                   "repository": {
-                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
                     "defaultAlias": "github.com:rocktavious/autopilot"
                   },
                   "service": {
@@ -653,7 +653,7 @@ func TestGetService(t *testing.T) {
           "edges": [
             {
               "node": {
-                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
+                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
                 "defaultAlias": "github.com:rocktavious/autopilot"
               },
               "serviceRepositories": [
@@ -662,7 +662,7 @@ func TestGetService(t *testing.T) {
                   "displayName": "rocktavious/autopilot",
                   "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZVJlcG9zaXRvcnkvNDIxNw",
                   "repository": {
-                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
                     "defaultAlias": "github.com:rocktavious/autopilot"
                   },
                   "service": {
@@ -1078,12 +1078,12 @@ func TestListServicesWithFilter(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query ServiceListWithFilter($after:String!$filter:IdentifierInput$first:Int!){account{services(filterIdentifier: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "filter": {"id": "{{ template "id1_string" }}"}, {{ template "first_page_variables" }} }`,
+		`{ {{ template "first_page_variables" }}, "filter": { {{ template "id1" }} } }`,
 		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query ServiceListWithFilter($after:String!$filter:IdentifierInput$first:Int!){account{services(filterIdentifier: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "filter": {"id": "{{ template "id1_string" }}"}, {{ template "second_page_variables" }} }`,
+		`{ {{ template "second_page_variables" }}, "filter": { {{ template "id1" }} } }`,
 		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_2" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}

--- a/service_test.go
+++ b/service_test.go
@@ -630,10 +630,10 @@ func TestGetService(t *testing.T) {
           "alias": "developers",
           "id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS84NDk"
         },
-		"parent": {
+        "parent": {
           "id": "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzExOTc",
           "aliases": ["just_updated_this_with_an_alias","taimoor_s_orange_system","update_2_lol"]
-    },
+        },
         "preferredApiDocument": {
           "id": "Z2lkOi8vb3BzbGV2ZWwvRG9jdW1lbnRzOjpBcGkvOTU0MQ",
           "htmlUrl": null,
@@ -1183,7 +1183,7 @@ func TestListServicesWithTag(t *testing.T) {
 	testRequestOne := autopilot.NewTestRequest(
 		`query ServiceListWithTag($after:String!$first:Int!$tag:TagArgs!){account{services(tag: $tag, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},{{ template "pagination_request" }}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},{{ template "pagination_request" }}},type{id,aliases}},{{ template "pagination_request" }}}}}`,
 		`{ {{ template "first_page_variables" }}, "tag": { "key": "app", "value": "worker" } }`,
-		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
+		`{"data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query ServiceListWithTag($after:String!$first:Int!$tag:TagArgs!){account{services(tag: $tag, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},{{ template "pagination_request" }}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},{{ template "pagination_request" }}},type{id,aliases}},{{ template "pagination_request" }}}}}`,

--- a/service_test.go
+++ b/service_test.go
@@ -476,7 +476,7 @@ func TestGetServiceWithAlias(t *testing.T) {
           "edges": [
             {
               "node": {
-                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
+                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
                 "defaultAlias": "github.com:rocktavious/autopilot"
               },
               "serviceRepositories": [
@@ -485,7 +485,7 @@ func TestGetServiceWithAlias(t *testing.T) {
                   "displayName": "rocktavious/autopilot",
                   "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZVJlcG9zaXRvcnkvNDIxNw",
                   "repository": {
-                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
                     "defaultAlias": "github.com:rocktavious/autopilot"
                   },
                   "service": {
@@ -653,7 +653,7 @@ func TestGetService(t *testing.T) {
           "edges": [
             {
               "node": {
-                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
+                "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
                 "defaultAlias": "github.com:rocktavious/autopilot"
               },
               "serviceRepositories": [
@@ -662,7 +662,7 @@ func TestGetService(t *testing.T) {
                   "displayName": "rocktavious/autopilot",
                   "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZVJlcG9zaXRvcnkvNDIxNw",
                   "repository": {
-                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjY1MTk",
+                    "id": "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodUIvMjY1MTk",
                     "defaultAlias": "github.com:rocktavious/autopilot"
                   },
                   "service": {
@@ -1078,12 +1078,12 @@ func TestListServicesWithFilter(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query ServiceListWithFilter($after:String!$filter:IdentifierInput$first:Int!){account{services(filterIdentifier: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ {{ template "first_page_variables" }}, "filter": { {{ template "id1" }} } }`,
+		`{ "filter": {"id": "{{ template "id1_string" }}"}, {{ template "first_page_variables" }} }`,
 		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query ServiceListWithFilter($after:String!$filter:IdentifierInput$first:Int!){account{services(filterIdentifier: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ {{ template "second_page_variables" }}, "filter": { {{ template "id1" }} } }`,
+		`{ "filter": {"id": "{{ template "id1_string" }}"}, {{ template "second_page_variables" }} }`,
 		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_2" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
@@ -1183,7 +1183,7 @@ func TestListServicesWithTag(t *testing.T) {
 	testRequestOne := autopilot.NewTestRequest(
 		`query ServiceListWithTag($after:String!$first:Int!$tag:TagArgs!){account{services(tag: $tag, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},{{ template "pagination_request" }}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},{{ template "pagination_request" }}},type{id,aliases}},{{ template "pagination_request" }}}}}`,
 		`{ {{ template "first_page_variables" }}, "tag": { "key": "app", "value": "worker" } }`,
-		`{"data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query ServiceListWithTag($after:String!$first:Int!$tag:TagArgs!){account{services(tag: $tag, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},{{ template "pagination_request" }}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},{{ template "pagination_request" }}},type{id,aliases}},{{ template "pagination_request" }}}}}`,
@@ -1438,4 +1438,222 @@ func TestServiceReconcileAliases(t *testing.T) {
 	autopilot.Ok(t, err)
 	autopilot.Equals(t, service.Aliases, aliasesWanted)
 	autopilot.Equals(t, service.ManagedAliases, aliasesWanted)
+}
+
+func TestListServicesWithInputFilter(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "key": "name", "arg": "Foo", "type": "equals", "caseSensitive": false }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": "MQ", "endCursor": "MQ" } }}}}`,
+	)
+	client := BestTestClient(t, "service/list_with_input_filter", testRequest)
+	// Act
+	filters := []ol.ServiceFilterInput{{
+		Key:           ol.PredicateKeyEnumName,
+		Arg:           "Foo",
+		Type:          ol.PredicateTypeEnumEquals,
+		CaseSensitive: false,
+	}}
+	response, err := client.ListServicesWithInputFilter(filters, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 1, response.TotalCount)
+	if len(response.Nodes) > 0 {
+		autopilot.Equals(t, "Foo", response.Nodes[0].Name)
+		autopilot.Equals(t, "Z2lkOi8vMTIzNDU2Nzg5OTg3NjU0MzIx", string(response.Nodes[0].Id))
+	}
+}
+
+func TestListServicesWithInputFilterAnd(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "connective": "and", "caseSensitive": false, "predicates": [{ "key": "language", "arg": "Ruby", "type": "contains", "caseSensitive": false }, { "key": "tier_index", "arg": "1", "type": "equals", "caseSensitive": false }] }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": "MQ", "endCursor": "MQ" } }}}}`,
+	)
+	client := BestTestClient(t, "service/list_with_input_filter_and", testRequest)
+
+	// Act - Complex filter: language is Ruby AND tier index is 1
+	predicates := []ol.ServiceFilterInput{
+		{
+			Key:  ol.PredicateKeyEnumLanguage,
+			Arg:  "Ruby",
+			Type: ol.PredicateTypeEnumContains,
+		},
+		{
+			Key:  ol.PredicateKeyEnumTierIndex,
+			Arg:  "1",
+			Type: ol.PredicateTypeEnumEquals,
+		},
+	}
+
+	complexFilter := ol.ServiceFilterInput{
+		Connective: &ol.ConnectiveEnumAnd,
+		Predicates: &predicates,
+	}
+
+	response, err := client.ListServicesWithInputFilter([]ol.ServiceFilterInput{complexFilter}, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 1, response.TotalCount)
+}
+
+func TestListServicesWithInputFilterOr(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "connective": "or", "caseSensitive": false, "predicates": [{ "key": "language", "arg": "Ruby", "type": "contains", "caseSensitive": false }, { "key": "language", "arg": "Go", "type": "contains", "caseSensitive": false }] }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }}, {{ template "service_2" }} ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": "MQ", "endCursor": "Mg" } }}}}`,
+	)
+	client := BestTestClient(t, "service/list_with_input_filter_or", testRequest)
+
+	// Act - OR filter: language is Ruby OR Go
+	orPredicates := []ol.ServiceFilterInput{
+		{
+			Key:  ol.PredicateKeyEnumLanguage,
+			Arg:  "Ruby",
+			Type: ol.PredicateTypeEnumContains,
+		},
+		{
+			Key:  ol.PredicateKeyEnumLanguage,
+			Arg:  "Go",
+			Type: ol.PredicateTypeEnumContains,
+		},
+	}
+
+	orFilter := ol.ServiceFilterInput{
+		Connective: &ol.ConnectiveEnumOr,
+		Predicates: &orPredicates,
+	}
+
+	response, err := client.ListServicesWithInputFilter([]ol.ServiceFilterInput{orFilter}, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 2, response.TotalCount)
+}
+
+func TestListServicesWithInputFilterNested(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "connective": "and", "caseSensitive": false, "predicates": [{ "connective": "or", "caseSensitive": false, "predicates": [{ "key": "language", "arg": "Ruby", "type": "contains", "caseSensitive": false }, { "key": "language", "arg": "Go", "type": "contains", "caseSensitive": false }] }, { "key": "tier_index", "arg": "1", "type": "equals", "caseSensitive": false }] }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": "MQ", "endCursor": "MQ" } }}}}`,
+	)
+	client := BestTestClient(t, "service/list_with_input_filter_nested", testRequest)
+
+	// Act - Nested filter: (language is Ruby OR Go) AND tier index is 1
+	orPredicates := []ol.ServiceFilterInput{
+		{
+			Key:  ol.PredicateKeyEnumLanguage,
+			Arg:  "Ruby",
+			Type: ol.PredicateTypeEnumContains,
+		},
+		{
+			Key:  ol.PredicateKeyEnumLanguage,
+			Arg:  "Go",
+			Type: ol.PredicateTypeEnumContains,
+		},
+	}
+
+	orFilter := ol.ServiceFilterInput{
+		Connective: &ol.ConnectiveEnumOr,
+		Predicates: &orPredicates,
+	}
+
+	nestedFilter := ol.ServiceFilterInput{
+		Connective: &ol.ConnectiveEnumAnd,
+		Predicates: &[]ol.ServiceFilterInput{
+			orFilter,
+			{
+				Key:  ol.PredicateKeyEnumTierIndex,
+				Arg:  "1",
+				Type: ol.PredicateTypeEnumEquals,
+			},
+		},
+	}
+
+	response, err := client.ListServicesWithInputFilter([]ol.ServiceFilterInput{nestedFilter}, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 1, response.TotalCount)
+}
+
+func TestListServicesWithInputFilterMultiplePredicateTypes(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "key": "name", "arg": "api", "type": "contains", "caseSensitive": true }, { "key": "product", "arg": "test", "type": "does_not_contain", "caseSensitive": false }, { "key": "tier_index", "arg": "3", "type": "greater_than_or_equal_to", "caseSensitive": false }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": "MQ", "endCursor": "MQ" } }}}}`,
+	)
+	client := BestTestClient(t, "service/list_with_input_filter_multiple_types", testRequest)
+
+	// Act - Multiple filters with different predicate types
+	filters := []ol.ServiceFilterInput{
+		{
+			Key:           ol.PredicateKeyEnumName,
+			Arg:           "api",
+			Type:          ol.PredicateTypeEnumContains,
+			CaseSensitive: true,
+		},
+		{
+			Key:  ol.PredicateKeyEnumProduct,
+			Arg:  "test",
+			Type: ol.PredicateTypeEnumDoesNotContain,
+		},
+		{
+			Key:  ol.PredicateKeyEnumTierIndex,
+			Arg:  "3",
+			Type: ol.PredicateTypeEnumGreaterThanOrEqualTo,
+		},
+	}
+
+	response, err := client.ListServicesWithInputFilter(filters, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 1, response.TotalCount)
+}
+
+func TestListServicesWithInputFilterCaseSensitivity(t *testing.T) {
+	// Test case sensitive match
+	testRequestMatch := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "key": "name", "arg": "Foo", "type": "equals", "caseSensitive": true }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [ {{ template "service_1" }} ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": "MQ", "endCursor": "MQ" } }}}}`,
+	)
+
+	// Test case sensitive non-match (different case)
+	testRequestNoMatch := autopilot.NewTestRequest(
+		`query ServiceListWithInputFilter($after:String!$filter:[ServiceFilterInput!]!$first:Int!){account{services(filter: $filter, after: $after, first: $first){nodes{apiDocumentPath,description,framework,htmlUrl,id,aliases,language,lifecycle{alias,description,id,index,name},locked,managedAliases,maturityReport{overallLevel{alias,checks{id,name},description,id,index,name}},name,note,owner{alias,id},parent{id,aliases},preferredApiDocument{id,htmlUrl,source{... on ApiDocIntegration{id,name,type},... on ServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},timestamps{createdAt,updatedAt}},preferredApiDocumentSource,product,repos{edges{node{id,defaultAlias},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},defaultServiceRepository{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}},tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},tier{alias,description,id,index,name},timestamps{createdAt,updatedAt},tools{nodes{category,categoryAlias,displayName,environment,id,service{id,aliases},url},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},type{id,aliases}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
+		`{ "filter": [{ "key": "name", "arg": "foo", "type": "equals", "caseSensitive": true }], {{ template "first_page_variables" }} }`,
+		`{ "data": { "account": { "services": { "nodes": [], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": null, "endCursor": null } }}}}`,
+	)
+
+	requests := []autopilot.TestRequest{testRequestMatch, testRequestNoMatch}
+	client := BestTestClient(t, "service/list_with_input_filter_case_sensitivity", requests...)
+
+	// Act & Assert - Test case sensitive match (should find service "Foo")
+	filterMatch := []ol.ServiceFilterInput{{
+		Key:           ol.PredicateKeyEnumName,
+		Arg:           "Foo",
+		Type:          ol.PredicateTypeEnumEquals,
+		CaseSensitive: true,
+	}}
+	response, err := client.ListServicesWithInputFilter(filterMatch, nil)
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 1, response.TotalCount)
+	if len(response.Nodes) > 0 {
+		autopilot.Equals(t, "Foo", response.Nodes[0].Name)
+	}
+
+	// Act & Assert - Test case sensitive non-match (should NOT find service with "foo" when name is "Foo")
+	filterNoMatch := []ol.ServiceFilterInput{{
+		Key:           ol.PredicateKeyEnumName,
+		Arg:           "foo", // lowercase - should not match "Foo" when case sensitive
+		Type:          ol.PredicateTypeEnumEquals,
+		CaseSensitive: true,
+	}}
+	response, err = client.ListServicesWithInputFilter(filterNoMatch, nil)
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 0, response.TotalCount)
 }


### PR DESCRIPTION
Resolves #

### Problem

Today, services can only be filtered using a pre-existing filter's ID. So, to make complex service queries a user must first create a real persistent Filter object on their OpsLevel account, which is undesirable for retrieving information ad hoc.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Add a new `ListServicesWithInputFilter` method that allows querying services with dynamic filter predicates.

This uses OpsLevel's existing internal filter predicate format. It's not super user friendly or intuitive, but it has a lot of flexibility & power and is worth pushing out since no service filter rewrite is on the roadmap.

### Examples
Here's an example file with a regular filter, a conjunctive filter, and a nested filter. This resembles the scenarios in the test file.

```go
// Manual test for ListServicesWithInputFilter
// Usage: go run testan/search_services_with_input_filter.go
// Edit the filter and variables as needed for your OpsLevel instance.
package main

import (
	"encoding/json"
	"fmt"
	"log"
	"os"

	opslevel "github.com/opslevel/opslevel-go/v2025"
)

func main() {
	apiToken := os.Getenv("OPSLEVEL_API_TOKEN")
	if apiToken == "" {
		log.Fatal("OPSLEVEL_API_TOKEN environment variable is not set")
	}

	client := opslevel.NewGQLClient(
		opslevel.SetAPIToken(apiToken),
	)

	// Example filter: filter by name containing "api"
	simpleFilter := opslevel.ServiceFilterInput{
		Key:  opslevel.PredicateKeyEnumName,
		Arg:  "monolith",
		Type: opslevel.PredicateTypeEnumContains,
	}

	// Print the outgoing filter JSON
	if filterJSON, err := json.Marshal(simpleFilter); err == nil {
		log.Printf("Outgoing simpleFilter JSON: %s", filterJSON)
	} else {
		log.Printf("Failed to marshal simpleFilter: %v", err)
	}

	services, err := client.ListServicesWithInputFilter(simpleFilter, nil)
	if err != nil {
		log.Fatalf("Failed to search services: %v", err)
	}

	fmt.Printf("Found %d service(s) matching simple filter:\n", services.TotalCount)
	for _, svc := range services.Nodes {
		fmt.Printf("- Name: %s\n  ID: %s\n  Owner: %s\n  Language: %s\n", svc.Name, svc.Id, svc.Owner.Alias, svc.Language)
	}

	// Complex filter: language is Ruby and tier index is 1
	predicates := []opslevel.ServiceFilterInput{
		{
			Key:  opslevel.PredicateKeyEnumLanguage,
			Arg:  "Ruby",
			Type: opslevel.PredicateTypeEnumContains,
		},
		{
			Key:  opslevel.PredicateKeyEnumTierIndex,
			Arg:  "1",
			Type: opslevel.PredicateTypeEnumEquals,
		},
	}

	complexFilter := opslevel.ServiceFilterInput{
		Connective: &opslevel.ConnectiveEnumAnd,
		Predicates: &predicates,
	}

	// Print the outgoing complex filter JSON
	if filterJSON, err := json.Marshal(complexFilter); err == nil {
		log.Printf("Outgoing complexFilter JSON: %s", filterJSON)
	} else {
		log.Printf("Failed to marshal complexFilter: %v", err)
	}

	services, err = client.ListServicesWithInputFilter(complexFilter, nil)
	if err != nil {
		log.Fatalf("Failed to search services with complex filter: %v", err)
	}

	fmt.Printf("Found %d service(s) matching complex filter (Ruby, tier 1):\n", services.TotalCount)
	for _, svc := range services.Nodes {
		fmt.Printf("- Name: %s\n  ID: %s\n  Owner: %s\n  Language: %s\n  Tier Index: %d\n", svc.Name, svc.Id, svc.Owner.Alias, svc.Language, svc.Tier.Index)
	}

	// Giga filter: language is Ruby or Go and tier index is 1
	orPredicates := []opslevel.ServiceFilterInput{
		{
			Key:  opslevel.PredicateKeyEnumLanguage,
			Arg:  "Ruby",
			Type: opslevel.PredicateTypeEnumContains,
		},
		{
			Key:  opslevel.PredicateKeyEnumLanguage,
			Arg:  "Go",
			Type: opslevel.PredicateTypeEnumContains,
		},
	}

	orFilter := opslevel.ServiceFilterInput{
		Connective: &opslevel.ConnectiveEnumOr,
		Predicates: &orPredicates,
	}

	gigaPredicates := []opslevel.ServiceFilterInput{
		orFilter,
		{
			Key:  opslevel.PredicateKeyEnumTierIndex,
			Arg:  "1",
			Type: opslevel.PredicateTypeEnumEquals,
		},
	}

	gigaFilter := opslevel.ServiceFilterInput{
		Connective: &opslevel.ConnectiveEnumAnd,
		Predicates: &gigaPredicates,
	}

	// Print the outgoing complex filter JSON
	if filterJSON, err := json.Marshal(gigaFilter); err == nil {
		log.Printf("Outgoing gigaFilter JSON: %s", filterJSON)
	} else {
		log.Printf("Failed to marshal gigaFilter: %v", err)
	}

	services, err = client.ListServicesWithInputFilter(gigaFilter, nil)
	if err != nil {
		log.Fatalf("Failed to search services with complex filter: %v", err)
	}

	fmt.Printf("Found %d service(s) matching giga filter (Ruby or Go, tier 1):\n", services.TotalCount)
	for _, svc := range services.Nodes {
		fmt.Printf("- Name: %s\n  ID: %s\n  Owner: %s\n  Language: %s\n  Tier Index: %d\n", svc.Name, svc.Id, svc.Owner.Alias, svc.Language, svc.Tier.Index)
	}
}
```

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [ ] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
