### PR TITLE
Bump default page size from 100 to 500

### DIFF
--- a/.changes/unreleased/Feature-20250730-094006.yaml
+++ b/.changes/unreleased/Feature-20250730-094006.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Increase default pagesize from 100 to 500
+time: 2025-07-30T09:40:06.51662-04:00

--- a/cache_test.go
+++ b/cache_test.go
@@ -21,42 +21,42 @@ func TestCache(t *testing.T) {
 	)
 	testRequestThree := autopilot.NewTestRequest(
 		`query SystemsList($after:String!$first:Int!){account{systems(after: $after, first: $first){nodes{id,aliases,description,htmlUrl,managedAliases,name,note,owner{... on Team{teamAlias:alias,id}},parent{id,aliases,description,htmlUrl,managedAliases,name,note,owner{... on Team{teamAlias:alias,id}}}},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{ "systems":{ "nodes":[{{ template "system1_response" }}] } }}}`,
 	)
 	testRequestFour := autopilot.NewTestRequest(
 		`query TeamList($after:String!$first:Int!){account{teams(after: $after, first: $first){nodes{alias,id,aliases,managedAliases,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,manager{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},memberships{nodes{role,team{alias,id},user{id,email,name}},{{ template "pagination_request" }}},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},{{ template "pagination_request" }}}},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{ "teams":{ "nodes":[{{ template "team_1" }}] } }}}`,
 	)
 	testRequestFive := autopilot.NewTestRequest(
 		`query CategoryList($after:String!$first:Int!){account{rubric{categories(after: $after, first: $first){nodes{description,id,name},{{ template "pagination_request" }}}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{"rubric":{ "categories":{ "nodes":[{{ template "category_1" }}] } }}}}`,
 	)
 	testRequestSix := autopilot.NewTestRequest(
 		`query LevelsList($after:String!$first:Int!){account{rubric{levels(after: $after, first: $first){nodes{alias,checks{id,name},description,id,index,name},{{ template "pagination_request" }}}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{"rubric":{ "levels":{ "nodes":[{{ template "level_1" }}] } }}}}`,
 	)
 	testRequestSeven := autopilot.NewTestRequest(
 		`query FilterList($after:String!$first:Int!){account{filters(after: $after, first: $first){nodes{id,name,connective,htmlUrl,predicates{caseSensitive,key,keyData,type,value}},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{ "filters":{ "nodes":[{{ template "filter_1" }}] } }}}`,
 	)
 	testRequestEight := autopilot.NewTestRequest(
 		`query IntegrationList($after:String!$first:Int!){account{integrations(after: $after, first: $first){nodes{{ template "integration_request" }},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{ "integrations":{ "nodes":[{{ template "integration_1" }}] } }}}`,
 	)
 	testRequestNine := autopilot.NewTestRequest(
 		`query RepositoryList($after:String!$first:Int!$visible:Boolean!){account{repositories(after: $after, first: $first, visible: $visible){hiddenCount,nodes{archivedAt,createdOn,defaultAlias,defaultBranch,description,forked,htmlUrl,id,languages{name,usage},lastOwnerChangedAt,locked,name,organization,owner{alias,id},private,repoKey,sbomGenerationConfiguration{disabledReason,enabled,nextGenerationAt,state},services{edges{atRoot,node{id,aliases},paths{href,path},serviceRepositories{baseDirectory,displayName,id,repository{id,defaultAlias},service{id,aliases}}},{{ template "pagination_request" }}},tags{nodes{id,key,value},{{ template "pagination_request" }}},tier{alias,description,id,index,name},type,url,visible},organizationCount,ownedCount,{{ template "pagination_request" }},visibleCount}}}`,
-		`{ "after": "", "first": 100, "visible": true }`,
+		`{ "after": "", "first": 500, "visible": true }`,
 		`{"data":{"account":{ "repositories":{ "hiddenCount": 0, "nodes":[{{ template "repository_1" }}] } }}}`,
 	)
 	testRequestTen := autopilot.NewTestRequest(
 		`query InfrastructureResourceSchemaList($after:String!$first:Int!){account{infrastructureResourceSchemas(after: $after, first: $first){nodes{type,schema},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "first": 100 }`,
+		`{ "after": "", "first": 500 }`,
 		`{"data":{"account":{ "infrastructureResourceSchemas":{ "nodes":[ {{ template "infra_schema_1" }} ] }}}}`,
 	)
 	testRequestEleven := autopilot.TestRequest{}

--- a/campaign_test.go
+++ b/campaign_test.go
@@ -11,12 +11,12 @@ func TestListCampaigns(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query CampaignsList($after:String!$first:Int!$sortBy:CampaignSortEnum!$status:String!){account{campaigns(first: $first, after: $after, sortBy: $sortBy, filter: [{key: status, arg: $status}]){nodes{checkStats{total,totalSuccessful},endedDate,filter{id,name},htmlUrl,id,name,owner{alias,id},projectBrief,rawProjectBrief,reminder{channels,daysOfWeek,defaultSlackChannel,frequency,frequencyUnit,message,nextOccurrence,timeOfDay,timezone},serviceStats{total,totalSuccessful},startDate,status,targetDate},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "after": "", "first": 100, "sortBy": "start_date_DESC", "status": "in_progress" }`,
+		`{ "after": "", "first": 500, "sortBy": "start_date_DESC", "status": "in_progress" }`,
 		`{ "data": { "account": { "campaigns": { "nodes": [ {{ template "campaign1_response" }}, {{ template "campaign2_response" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query CampaignsList($after:String!$first:Int!$sortBy:CampaignSortEnum!$status:String!){account{campaigns(first: $first, after: $after, sortBy: $sortBy, filter: [{key: status, arg: $status}]){nodes{checkStats{total,totalSuccessful},endedDate,filter{id,name},htmlUrl,id,name,owner{alias,id},projectBrief,rawProjectBrief,reminder{channels,daysOfWeek,defaultSlackChannel,frequency,frequencyUnit,message,nextOccurrence,timeOfDay,timezone},serviceStats{total,totalSuccessful},startDate,status,targetDate},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "after": "OA", "first": 100, "sortBy": "start_date_DESC", "status": "in_progress" }`,
+		`{ "after": "OA", "first": 500, "sortBy": "start_date_DESC", "status": "in_progress" }`,
 		`{ "data": { "account": { "campaigns": { "nodes": [ {{ template "campaign3_response" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
@@ -90,7 +90,7 @@ func TestListCampaignsEmpty(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`query CampaignsList($after:String!$first:Int!$sortBy:CampaignSortEnum!$status:String!){account{campaigns(first: $first, after: $after, sortBy: $sortBy, filter: [{key: status, arg: $status}]){nodes{checkStats{total,totalSuccessful},endedDate,filter{id,name},htmlUrl,id,name,owner{alias,id},projectBrief,rawProjectBrief,reminder{channels,daysOfWeek,defaultSlackChannel,frequency,frequencyUnit,message,nextOccurrence,timeOfDay,timezone},serviceStats{total,totalSuccessful},startDate,status,targetDate},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "after": "", "first": 100, "sortBy": "start_date_DESC", "status": "in_progress" }`,
+		`{ "after": "", "first": 500, "sortBy": "start_date_DESC", "status": "in_progress" }`,
 		`{ "data": { "account": { "campaigns": { "nodes": [], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": null, "endCursor": null } }}}}`,
 	)
 

--- a/client.go
+++ b/client.go
@@ -27,7 +27,7 @@ func newClientSettings(options ...Option) *ClientSettings {
 		token:     os.Getenv("OPSLEVEL_API_TOKEN"),
 		timeout:   time.Second * 10,
 		retries:   10,
-		pageSize:  100,
+		pageSize:  500,
 		transport: http.DefaultTransport,
 		headers: map[string]string{
 			"User-Agent":         buildUserAgent(""),

--- a/infra_test.go
+++ b/infra_test.go
@@ -102,12 +102,12 @@ func TestListInfra(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "all": true, "first": 100 }`,
+		`{ "after": "", "all": true, "first": 500 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_1" }}, {{ template "infra_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query InfrastructureResourceList($after:String!$all:Boolean!$first:Int!){account{infrastructureResources(after: $after, first: $first){nodes{id,aliases,name,type @include(if: $all),providerResourceType @include(if: $all),providerData @include(if: $all){accountName,externalUrl,providerName},owner @include(if: $all){... on Team{teamAlias:alias,id}},ownerLocked @include(if: $all),data @include(if: $all),rawData @include(if: $all)},{{ template "pagination_request" }}}}}`,
-		`{ "after": "OA", "all": true, "first": 100 }`,
+		`{ "after": "OA", "all": true, "first": 500 }`,
 		`{ "data": { "account": { "infrastructureResources": { "nodes": [ {{ template "infra_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}

--- a/level_test.go
+++ b/level_test.go
@@ -70,7 +70,7 @@ func TestListRubricLevels(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`query LevelsList($after:String!$first:Int!){account{rubric{levels(after: $after, first: $first){nodes{alias,checks{id,name},description,id,index,name},{{ template "pagination_request" }}}}}}`,
-		`{"after":"","first":100}`,
+		`{"after":"","first":500}`,
 		`{
     "data": {
       "account": {

--- a/maturity_test.go
+++ b/maturity_test.go
@@ -134,7 +134,7 @@ func TestListServicesMaturity(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`query ServiceMaturityList($after:String!$first:Int!){account{services(after: $after, first: $first){nodes{name,maturityReport{categoryBreakdown{category{description,id,name},level{alias,checks{id,name},description,id,index,name}},overallLevel{alias,checks{id,name},description,id,index,name}}},{{ template "pagination_request" }}}}}`,
-		`{"after":"", "first":100}`,
+		`{"after":"", "first":500}`,
 		`{
   "data": {
     "account": {

--- a/team_test.go
+++ b/team_test.go
@@ -431,7 +431,7 @@ func TestListTeamsWithManager(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query TeamList($after:String!$email:String!$first:Int!){account{teams(managerEmail: $email, after: $after, first: $first){nodes{alias,id,aliases,managedAliases,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,manager{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},memberships{nodes{role,team{alias,id},user{id,email,name}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "after": "", "first": 100, "email": "kyle@opslevel.com" }`,
+		`{ "after": "", "first": 500, "email": "kyle@opslevel.com" }`,
 		`{ "data": {
       "account": {
         "teams": {
@@ -502,7 +502,7 @@ func TestListTeamsWithManager(t *testing.T) {
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query TeamList($after:String!$email:String!$first:Int!){account{teams(managerEmail: $email, after: $after, first: $first){nodes{alias,id,aliases,managedAliases,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,manager{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},memberships{nodes{role,team{alias,id},user{id,email,name}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{ "after": "OA", "first": 100, "email": "kyle@opslevel.com" }`,
+		`{ "after": "OA", "first": 500, "email": "kyle@opslevel.com" }`,
 		`{ "data": {
       "account": {
         "teams": {
@@ -936,7 +936,7 @@ func TestSearchTeams(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
 		`query TeamSearch($after:String!$first:Int!$searchTerm:String!){account{teams(searchTerm: $searchTerm, after: $after, first: $first){nodes{alias,id,aliases,managedAliases,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,manager{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},memberships{nodes{role,team{alias,id},user{id,email,name}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}},pageInfo{hasNextPage,hasPreviousPage,startCursor,endCursor}}}}`,
-		`{"searchTerm": "DevOps", "after": "", "first": 100}`,
+		`{"searchTerm": "DevOps", "after": "", "first": 500}`,
 		`{ "data": { "account": { "teams": { "nodes": [ { "alias": "devops", "id": "id1", "aliases": ["devops"], "managedAliases": ["devops"], "contacts": [], "htmlUrl": "https://app.opslevel.com/teams/devops", "manager": { "id": "user1", "email": "manager@opslevel.com", "name": "Manager" }, "memberships": { "nodes": [], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": null, "endCursor": null } }, "name": "DevOps", "parentTeam": null, "responsibilities": "Own Infra & Tools.", "tags": { "nodes": [], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": null, "endCursor": null } } } ], "pageInfo": { "hasNextPage": false, "hasPreviousPage": false, "startCursor": null, "endCursor": null } } } } }`,
 	)
 

--- a/testdata/templates/common.tpl
+++ b/testdata/templates/common.tpl
@@ -46,22 +46,22 @@
 }{{ end }}
 {{- define "first_page_variables" }}
 "after": "",
-"first": 100
+"first": 500
 {{ end }}
 {{- define "second_page_variables" }}
 "after": "OA",
-"first": 100
+"first": 500
 {{ end }}
 {{- define "pagination_initial_query_variables" }}
 {
     "after": "",
-    "first": 100
+    "first": 500
 }
 {{ end }}
 {{- define "pagination_second_query_variables" }}
 {
 	"after": "OA",
-	"first": 100
+	"first": 500
 }
 {{ end }}
 {{- define "next_page_false" }}

--- a/user_test.go
+++ b/user_test.go
@@ -105,12 +105,12 @@ func TestListUser(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query UserList($after:String!$filter:[UsersFilterInput!]$first:Int!){account{users(after: $after, first: $first, filter: $filter){nodes{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "filter": null, "first": 100 }`,
+		`{ "after": "", "filter": null, "first": 500 }`,
 		`{ "data": { "account": { "users": { "nodes": [ {{ template "user_1" }}, {{ template "user_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query UserList($after:String!$filter:[UsersFilterInput!]$first:Int!){account{users(after: $after, first: $first, filter: $filter){nodes{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},{{ template "pagination_request" }}}}}`,
-		`{ "after": "OA", "filter": null, "first": 100 }`,
+		`{ "after": "OA", "filter": null, "first": 500 }`,
 		`{ "data": { "account": { "users": { "nodes": [ {{ template "user_3" }} ], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
@@ -133,12 +133,12 @@ func TestListUserOmitDeactivated(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(
 		`query UserList($after:String!$filter:[UsersFilterInput!]$first:Int!){account{users(after: $after, first: $first, filter: $filter){nodes{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},{{ template "pagination_request" }}}}}`,
-		`{ "after": "", "filter": [ {"key": "deactivated_at", "type": "equals"} ], "first": 100 }`,
+		`{ "after": "", "filter": [ {"key": "deactivated_at", "type": "equals"} ], "first": 500 }`,
 		`{ "data": { "account": { "users": { "nodes": [ {{ template "user_1" }}, {{ template "user_2" }} ], {{ template "pagination_initial_pageInfo_response" }} }}}}`,
 	)
 	testRequestTwo := autopilot.NewTestRequest(
 		`query UserList($after:String!$filter:[UsersFilterInput!]$first:Int!){account{users(after: $after, first: $first, filter: $filter){nodes{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role},{{ template "pagination_request" }}}}}`,
-		`{ "after": "OA", "filter": [ {"key": "deactivated_at", "type": "equals"} ], "first": 100 }`,
+		`{ "after": "OA", "filter": [ {"key": "deactivated_at", "type": "equals"} ], "first": 500 }`,
 		`{ "data": { "account": { "users": { "nodes": [], {{ template "pagination_second_pageInfo_response" }} }}}}`,
 	)
 	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}


### PR DESCRIPTION
Resolves #

### Problem

In March 2025 the Monoliths default page size increased to 500

### Solution

Sync opslevel-go with that

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Does this change require a Terraform schema change?
  - If so what is the ticket or PR #
- [x] Make a [changie](https://github.com/OpsLevel/opslevel-go/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
