### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Security
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/OpsLevel/opslevel-go/security/code-scanning/7](https://github.com/OpsLevel/opslevel-go/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best practice is to set this at the workflow root (top-level), so it applies to all jobs unless overridden. If the workflow only needs to read repository contents (which is typical for security scanning jobs), set `contents: read`. If more permissions are needed, they can be added as required. The change should be made at the top level of `.github/workflows/security.yml`, immediately after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
