### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,5 +1,8 @@
 name: "Reports"
 
+permissions:
+  contents: read
+
 # Every Monday at 1PM UTC (9AM EST)
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
Potential fix for [https://github.com/OpsLevel/opslevel-go/security/code-scanning/6](https://github.com/OpsLevel/opslevel-go/security/code-scanning/6)

To fix the problem, we should add a `permissions` block to the workflow file, specifying the least privilege required for the jobs. Since both jobs only need to read repository contents (for checkout and Snyk analysis) and do not need to write to the repository, the minimal permissions should be set to `contents: read`. This can be added at the workflow level (top-level, after the `name` and before `jobs`), which will apply to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
