### PR TITLE
Add SystemRelationship support on ComponentType and ComponentTypeInput

### DIFF
--- a/.changes/unreleased/Feature-20260409-144550.yaml
+++ b/.changes/unreleased/Feature-20260409-144550.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add SystemRelationship support on ComponentType and ComponentTypeInput
+time: 2026-04-09T14:45:50.438117+05:30

--- a/input.go
+++ b/input.go
@@ -700,12 +700,13 @@ type ComponentTypeIconInput struct {
 
 // ComponentTypeInput Specifies the input fields used to create a component type
 type ComponentTypeInput struct {
-	Alias             *Nullable[string]                       `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_value"`             // The unique alias of the component type (Optional)
-	Description       *Nullable[string]                       `json:"description,omitempty" yaml:"description,omitempty" example:"example_value"` // The description of the component type (Optional)
-	Icon              *ComponentTypeIconInput                 `json:"icon,omitempty" yaml:"icon,omitempty"`                                       // The icon associated with the component type (Optional)
-	Name              *Nullable[string]                       `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`               // The unique name of the component type (Optional)
-	OwnerRelationship *OwnerRelationshipInput                 `json:"ownerRelationship,omitempty" yaml:"ownerRelationship,omitempty"`             // The owner relationship for the component type (Optional)
-	Properties        *[]ComponentTypePropertyDefinitionInput `json:"properties,omitempty" yaml:"properties,omitempty" example:"[]"`              // A list of property definitions for the component type (Optional)
+	Alias              *Nullable[string]                       `json:"alias,omitempty" yaml:"alias,omitempty" example:"example_value"`             // The unique alias of the component type (Optional)
+	Description        *Nullable[string]                       `json:"description,omitempty" yaml:"description,omitempty" example:"example_value"` // The description of the component type (Optional)
+	Icon               *ComponentTypeIconInput                 `json:"icon,omitempty" yaml:"icon,omitempty"`                                       // The icon associated with the component type (Optional)
+	Name               *Nullable[string]                       `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`               // The unique name of the component type (Optional)
+	OwnerRelationship  *OwnerRelationshipInput                 `json:"ownerRelationship,omitempty" yaml:"ownerRelationship,omitempty"`             // The owner relationship for the component type (Optional)
+	SystemRelationship *SystemRelationshipInput                `json:"systemRelationship,omitempty" yaml:"systemRelationship,omitempty"`           // The system relationship for the component type (Optional)
+	Properties         *[]ComponentTypePropertyDefinitionInput `json:"properties,omitempty" yaml:"properties,omitempty" example:"[]"`              // A list of property definitions for the component type (Optional)
 }
 
 // ComponentTypePropertyDefinitionInput The input for defining a property
@@ -995,6 +996,11 @@ type OctopusDeployIntegrationInput struct {
 
 // OwnerRelationshipInput The input for defining the owner relationship for a component type
 type OwnerRelationshipInput struct {
+	ManagementRules *[]ManagementRuleInput `json:"managementRules,omitempty" yaml:"managementRules,omitempty"` // The management rules for the relationship (Optional)
+}
+
+// SystemRelationshipInput The input for defining the system relationship for a component type
+type SystemRelationshipInput struct {
 	ManagementRules *[]ManagementRuleInput `json:"managementRules,omitempty" yaml:"managementRules,omitempty"` // The management rules for the relationship (Optional)
 }
 

--- a/object.go
+++ b/object.go
@@ -145,14 +145,15 @@ type ComponentTypeId struct {
 // ComponentType Information about a particular component type
 type ComponentType struct {
 	ComponentTypeId
-	Description       string                        // The description of the component type (Optional)
-	Href              string                        // The relative path to link to the component type (Required)
-	Icon              ComponentTypeIcon             // The icon associated with the component type (Required)
-	IsDefault         bool                          // Whether or not the component type is the default (Required)
-	Name              string                        // The name of the component type (Required)
-	OwnerRelationship OwnerRelationshipType         // The owner relationship for this component type (Required)
-	Timestamps        Timestamps                    // When the component type was created and updated (Required)
-	Properties        *PropertyDefinitionConnection `graphql:"-"`
+	Description        string                        // The description of the component type (Optional)
+	Href               string                        // The relative path to link to the component type (Required)
+	Icon               ComponentTypeIcon             // The icon associated with the component type (Required)
+	IsDefault          bool                          // Whether or not the component type is the default (Required)
+	Name               string                        // The name of the component type (Required)
+	OwnerRelationship  OwnerRelationshipType         // The owner relationship for this component type (Required)
+	SystemRelationship SystemRelationshipType        // The system relationship for this component type (Required)
+	Timestamps         Timestamps                    // When the component type was created and updated (Required)
+	Properties         *PropertyDefinitionConnection `graphql:"-"`
 }
 
 // ComponentTypeIcon The icon for a component type
@@ -395,6 +396,11 @@ type ManualCheckFrequency struct {
 // OwnerRelationshipType The owner relationship for a component type
 type OwnerRelationshipType struct {
 	ManagementRules []RelationshipDefinitionManagementRule // The management rules for the owner relationship (Required)
+}
+
+// SystemRelationshipType The system relationship for a component type
+type SystemRelationshipType struct {
+	ManagementRules []RelationshipDefinitionManagementRule // The management rules for the system relationship (Required)
 }
 
 // Predicate A condition used to select services

--- a/testdata/templates/component_type.tpl
+++ b/testdata/templates/component_type.tpl
@@ -1,5 +1,5 @@
 {{- define "component_type_graphql" }}
-{id,aliases,description,href,icon{color,name},isDefault,name,ownerRelationship{managementRules{operator,sourceProperty,sourcePropertyBuiltin,targetCategory,targetProperty,targetPropertyBuiltin,targetType}},timestamps{createdAt,updatedAt}}
+{id,aliases,description,href,icon{color,name},isDefault,name,ownerRelationship{managementRules{operator,sourceProperty,sourcePropertyBuiltin,targetCategory,targetProperty,targetPropertyBuiltin,targetType}},systemRelationship{managementRules{operator,sourceProperty,sourcePropertyBuiltin,targetCategory,targetProperty,targetPropertyBuiltin,targetType}},timestamps{createdAt,updatedAt}}
 {{end}}
 {{- define "component_type_1_response" }}
 {
@@ -24,6 +24,19 @@
           "targetProperty": "name",
           "targetPropertyBuiltin": true,
           "targetType": "team"
+        }
+      ]
+    },
+    "systemRelationship": {
+      "managementRules": [
+        {
+          "operator": "EQUALS",
+          "sourceProperty": "tag_key_eq:system",
+          "sourcePropertyBuiltin": true,
+          "targetCategory": null,
+          "targetProperty": "name",
+          "targetPropertyBuiltin": true,
+          "targetType": "system"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Mirrors the existing `OwnerRelationship` implementation 1:1 to expose the
public GraphQL `systemRelationship` field on `ComponentType` and the
corresponding argument on `ComponentTypeInput`.

The server-side GraphQL surface has been live for a while (monorepo MRs
!17865 / !17910), but the Go client hasn't exposed it yet. This unblocks
the Terraform provider work for OpsLevel/terraform-provider-opslevel#14687
(customer: Springer Nature).

## Changes

- `object.go`: new `SystemRelationshipType` struct + `SystemRelationship` field on `ComponentType`
- `input.go`: new `SystemRelationshipInput` struct + `SystemRelationship` field on `ComponentTypeInput`
- `testdata/templates/component_type.tpl`: updated GraphQL query selection + mock response to include `systemRelationship`
- `.changes/unreleased/Feature-*.yaml`: changie entry

Structurally identical to `OwnerRelationship` — confirmed against Ruby
source definitions in the monorepo. No logic changes, no refactoring,
no new dependencies.

## Test plan

- [x] `task test` — full suite passes (76.9% coverage), all 5 ComponentType tests green
- [x] `task lint` — clean (gofumpt + golangci-lint)
- [x] `go build ./...` in `terraform-provider-opslevel` compiles against this branch via local `replace` directive

## Follow-ups

- After this merges and a release is cut, bump the dependency in
  `terraform-provider-opslevel` and wire up the `system_relationship`
  attribute on the `opslevel_component_type` resource.
- `componentTypePropagateSystemRelationship` mutation is intentionally
  out of scope — it's an imperative bulk operation that doesn't map
  cleanly to declarative Terraform, and there's no precedent for it
  with `owner_relationship`. Can be added later if needed.
