### PR TITLE
Run changie via go tool in changie-gen workflow

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -32,14 +32,18 @@ jobs:
           echo "No changelog exists for this PR, creating a new one"
         fi
 
+    - name: Set up Go
+      if: steps.changelog_check.outputs.exists == 'false'
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version-file: 'go.mod'
+
     - name: Create changie log
       if: steps.changelog_check.outputs.exists == 'false'
-      uses: miniscruff/changie-action@6dcc2533cac0495148ed4046c438487e4dceaa23 # v2
+      shell: bash
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
-      with:
-        version: latest
-        args: new --kind Dependency --body "$PR_TITLE"
+      run: go tool changie new --kind Dependency --body "$PR_TITLE"
 
     - name: Commit & Push changes
       if: steps.changelog_check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

- The previous fix in #617 moved the PR title into an env var but kept `miniscruff/changie-action`, which runs the command via `@actions/exec` without a shell. `argStringToArray` in the toolkit only parses quoting/escapes — it does no env-var expansion — so changie would have received the literal string `$PR_TITLE` as the changelog body.
- Switch to a `run:` step that invokes `go tool changie` (already declared in `go.mod`'s `tool` block). The shell expands `"$PR_TITLE"` correctly, and the title still flows through an env var rather than being interpolated into a command-line string by GitHub's templating, so the script-injection fix is preserved.
- Drops a third-party action; uses the changie version pinned in `go.mod`. `actions/setup-go` is the same SHA already pinned in `tests.yml` and `release.yml`.

## Test plan

- [ ] Wait for the next dependabot PR with the `dependencies` label to fire the workflow, then verify the generated `.changes/unreleased/*.yaml` body contains the actual PR title (not `$PR_TITLE`).
- [ ] Confirm a malicious title like `` `; echo pwned `` does not execute — the value should appear verbatim in the changelog body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)