### PR TITLE
Add OnCall types and Service.GetOnCalls for incident routing

### DIFF
--- a/on_call.go
+++ b/on_call.go
@@ -1,0 +1,23 @@
+package opslevel
+
+// OnCall A user that is currently on call for a service.
+type OnCall struct {
+	ExternalEmail string  `graphql:"externalEmail"`
+	Id            ID      `graphql:"id"`
+	Name          string  `graphql:"name"`
+	User          *UserId `graphql:"user"`
+}
+
+// OnCallConnection The connection type for OnCall.
+type OnCallConnection struct {
+	Edges      []OnCallEdge `graphql:"edges"`
+	Nodes      []OnCall     `graphql:"nodes"`
+	PageInfo   PageInfo     `graphql:"pageInfo"`
+	TotalCount int          `graphql:"totalCount"`
+}
+
+// OnCallEdge An edge in an on-call connection.
+type OnCallEdge struct {
+	Cursor string  `graphql:"cursor"`
+	Node   *OnCall `graphql:"node"`
+}

--- a/service.go
+++ b/service.go
@@ -44,6 +44,7 @@ type Service struct {
 	Dependents   *ServiceDependentsConnection   `graphql:"-"`
 
 	LastDeploy *Deploy               `graphql:"-"`
+	OnCalls    *OnCallConnection     `graphql:"-"`
 	Properties *PropertiesConnection `graphql:"-"`
 }
 
@@ -245,6 +246,41 @@ func (service *Service) GetLastDeploy(client *Client, variables *PayloadVariable
 		return nil, err
 	}
 	return &q.Account.Service.LastDeploy, nil
+}
+
+func (service *Service) GetOnCalls(client *Client, variables *PayloadVariables) (*OnCallConnection, error) {
+	var q struct {
+		Account struct {
+			Service struct {
+				OnCalls OnCallConnection `graphql:"onCalls(after: $after, first: $first)"`
+			} `graphql:"service(id: $service)"`
+		}
+	}
+	if service.Id == "" {
+		return nil, fmt.Errorf("unable to get OnCalls, invalid service id: '%s'", service.Id)
+	}
+	if variables == nil {
+		variables = client.InitialPageVariablesPointer()
+	}
+	(*variables)["service"] = service.Id
+	if err := client.Query(&q, *variables, WithName("ServiceOnCallsList")); err != nil {
+		return nil, err
+	}
+	if service.OnCalls == nil {
+		service.OnCalls = &OnCallConnection{}
+	}
+	service.OnCalls.Nodes = append(service.OnCalls.Nodes, q.Account.Service.OnCalls.Nodes...)
+	service.OnCalls.Edges = append(service.OnCalls.Edges, q.Account.Service.OnCalls.Edges...)
+	service.OnCalls.PageInfo = q.Account.Service.OnCalls.PageInfo
+	if service.OnCalls.PageInfo.HasNextPage {
+		(*variables)["after"] = service.OnCalls.PageInfo.End
+		_, err := service.GetOnCalls(client, variables)
+		if err != nil {
+			return nil, err
+		}
+	}
+	service.OnCalls.TotalCount = len(service.OnCalls.Nodes)
+	return service.OnCalls, nil
 }
 
 func (service *Service) GetAliases() []string {

--- a/service_test.go
+++ b/service_test.go
@@ -1048,6 +1048,47 @@ func TestGetServiceStatsInvalidServiceId(t *testing.T) {
 	autopilot.Equals(t, "unable to get 'ServiceStats', invalid service id: ''", err.Error())
 }
 
+func TestGetServiceOnCalls(t *testing.T) {
+	testRequestOne := autopilot.NewTestRequest(
+		`query ServiceOnCallsList($after:String!$first:Int!$service:ID!){account{service(id: $service){onCalls(after: $after, first: $first){edges{cursor,node{externalEmail,id,name,user{id,email,name}}},nodes{externalEmail,id,name,user{id,email,name}},{{ template "pagination_request" }},totalCount}}}}`,
+		`{ {{ template "first_page_variables" }}, "service": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85NjQ4" }`,
+		`{ "data": { "account": { "service": { "onCalls": { "edges": [ { "cursor": "MQ", "node": { "externalEmail": "alice@example.com", "id": "Z2lkOi8vb3BzbGV2ZWwvT25DYWxsLzE", "name": "Alice", "user": { "id": "Z2lkOi8vb3BzbGV2ZWwvVXNlci8x", "email": "alice@example.com", "name": "Alice" } } } ], "nodes": [ { "externalEmail": "alice@example.com", "id": "Z2lkOi8vb3BzbGV2ZWwvT25DYWxsLzE", "name": "Alice", "user": { "id": "Z2lkOi8vb3BzbGV2ZWwvVXNlci8x", "email": "alice@example.com", "name": "Alice" } } ], {{ template "pagination_initial_pageInfo_response" }}, "totalCount": 1 } } } } }`,
+	)
+	testRequestTwo := autopilot.NewTestRequest(
+		`query ServiceOnCallsList($after:String!$first:Int!$service:ID!){account{service(id: $service){onCalls(after: $after, first: $first){edges{cursor,node{externalEmail,id,name,user{id,email,name}}},nodes{externalEmail,id,name,user{id,email,name}},{{ template "pagination_request" }},totalCount}}}}`,
+		`{ {{ template "second_page_variables" }}, "service": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85NjQ4" }`,
+		`{ "data": { "account": { "service": { "onCalls": { "edges": [ { "cursor": "Mg", "node": { "externalEmail": "bob@example.com", "id": "Z2lkOi8vb3BzbGV2ZWwvT25DYWxsLzI", "name": "Bob", "user": null } } ], "nodes": [ { "externalEmail": "bob@example.com", "id": "Z2lkOi8vb3BzbGV2ZWwvT25DYWxsLzI", "name": "Bob", "user": null } ], {{ template "pagination_second_pageInfo_response" }}, "totalCount": 1 } } } } }`,
+	)
+	requests := []autopilot.TestRequest{testRequestOne, testRequestTwo}
+
+	client := BestTestClient(t, "service/get_on_calls", requests...)
+	service := ol.Service{
+		ServiceId: ol.ServiceId{
+			Id: "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85NjQ4",
+		},
+	}
+	// Act
+	resp, err := service.GetOnCalls(client, nil)
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 2, resp.TotalCount)
+	autopilot.Equals(t, "Alice", resp.Nodes[0].Name)
+	autopilot.Equals(t, "bob@example.com", resp.Nodes[1].ExternalEmail)
+}
+
+func TestGetServiceOnCallsInvalidServiceId(t *testing.T) {
+	client := BestTestClient(t, "service/get_on_calls_invalid_service")
+	service := ol.Service{
+		ServiceId: ol.ServiceId{
+			Id: "",
+		},
+	}
+	// Act
+	_, err := service.GetOnCalls(client, nil)
+	// Assert
+	autopilot.Equals(t, "unable to get OnCalls, invalid service id: ''", err.Error())
+}
+
 func TestListServices(t *testing.T) {
 	// Arrange
 	testRequestOne := autopilot.NewTestRequest(


### PR DESCRIPTION
## Summary

Surfaces the currently on-call person(s) for a service via the Go SDK. Required so the OpsLevel MCP server can answer incident-response questions like "who's on-call for the payments service right now?". Pairs with the backend PR that exposed `Service.onCalls` publicly on the GraphQL schema (linked below).

Part 2 of OpsLevel GitLab issue 14711 (gap 1 — users tool tags/teams — was [#614](https://github.com/OpsLevel/opslevel-go/pull/614)).

## Changes

### `on_call.go` (new)
- `OnCall` — `{ExternalEmail, Id, Name, User *UserId}`. Matches the deployed GraphQL `OnCall` type.
- `OnCallConnection` — standard connection with `Edges`, `Nodes`, `PageInfo`, `TotalCount`.
- `OnCallEdge` — `{Cursor, Node *OnCall}`.

### `service.go`
- New field on `Service`: `OnCalls *OnCallConnection` with **`graphql:"-"`** — intentionally excluded from auto-fetch in `ListServices` to avoid N+1 (the backend has an open follow-up on the `user` resolver inside `OnCallType`, flagged during the schema PR review).
- New method `Service.GetOnCalls(client, variables) (*OnCallConnection, error)`. Standard per-service fetcher with pagination follow-through, mirroring `Service.GetTags` style.

### `service_test.go`
- `TestGetServiceOnCalls` — mock query + response with two on-call nodes (one mapping to an OpsLevel user, one with only `externalEmail`), asserts field population and `nil`-handling for `User`.
- `TestGetServiceOnCallsInvalidServiceId` — asserts the empty-id guard error.

## Design decisions
