### PR TITLE
Unpin internal grype action to pick up fixes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   call-grype:
-    uses: opslevel/actions/.github/workflows/grype.yml@d66c9d7c93ff6df99a929e012366433e564d58fa # main
+    uses: opslevel/actions/.github/workflows/grype.yml@main
     with:
       alias: opslevel-go
     secrets: inherit


### PR DESCRIPTION
This one is internally managed and got picked up accidentally in the hardening sweep - it doesn't need to be pinned, and we want to pick up some recent changes here anyway.