### PR TITLE
Add RunnerJob.InitCommands/InitImage and RunnerJobVariable.Scope

### DIFF
--- a/.changes/unreleased/Feature-20260629-093256.yaml
+++ b/.changes/unreleased/Feature-20260629-093256.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Add Scope field on RunnerJobVariable so variables can be restricted to the startup init container or the main job container
+body: Add Scope field on RunnerJobVariable so variables can be restricted to the init container or the main job container
 time: 2026-06-29T09:32:56.728664-07:00

--- a/.changes/unreleased/Feature-20260629-093256.yaml
+++ b/.changes/unreleased/Feature-20260629-093256.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add Scope field on RunnerJobVariable so variables can be restricted to the startup init container or the main job container
+time: 2026-06-29T09:32:56.728664-07:00

--- a/.changes/unreleased/Feature-20260629-093307.yaml
+++ b/.changes/unreleased/Feature-20260629-093307.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Add StartupCommands and StartupImage fields on RunnerJob to support running an init container before the main job container
+body: Add InitCommands and InitImage fields on RunnerJob to support running an init container before the main job container
 time: 2026-06-29T09:33:07.696442-07:00

--- a/.changes/unreleased/Feature-20260629-093307.yaml
+++ b/.changes/unreleased/Feature-20260629-093307.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add StartupCommands and StartupImage fields on RunnerJob to support running an init container before the main job container
+time: 2026-06-29T09:33:07.696442-07:00

--- a/job.go
+++ b/job.go
@@ -72,13 +72,13 @@ type Runner struct {
 }
 
 // RunnerJobVariableScope controls which container(s) on the job pod receive a
-// variable. An empty value means the variable is available in both the startup
-// init container and the main job container (the default).
+// variable. An empty value means the variable is available in both the init
+// container and the main job container (the default).
 type RunnerJobVariableScope string
 
 const (
-	RunnerJobVariableScopeStartup RunnerJobVariableScope = "startup"
-	RunnerJobVariableScopeMain    RunnerJobVariableScope = "main"
+	RunnerJobVariableScopeInit RunnerJobVariableScope = "init"
+	RunnerJobVariableScopeMain RunnerJobVariableScope = "main"
 )
 
 type RunnerJobVariable struct {
@@ -94,15 +94,15 @@ type RunnerJobFile struct {
 }
 
 type RunnerJob struct {
-	Commands        []string             `json:"commands"`
-	Id              ID                   `json:"id"`
-	Image           string               `json:"image"`
-	Outcome         RunnerJobOutcomeEnum `json:"outcome"`
-	Status          RunnerJobStatusEnum  `json:"status"`
-	Variables       []RunnerJobVariable  `json:"variables"`
-	Files           []RunnerJobFile      `json:"files"`
-	StartupCommands []string             `json:"startupCommands"`
-	StartupImage    string               `json:"startupImage"`
+	Commands     []string             `json:"commands"`
+	Id           ID                   `json:"id"`
+	Image        string               `json:"image"`
+	Outcome      RunnerJobOutcomeEnum `json:"outcome"`
+	Status       RunnerJobStatusEnum  `json:"status"`
+	Variables    []RunnerJobVariable  `json:"variables"`
+	Files        []RunnerJobFile      `json:"files"`
+	InitCommands []string             `json:"initCommands"`
+	InitImage    string               `json:"initImage"`
 }
 
 func (runnerJob *RunnerJob) Number() string {

--- a/job.go
+++ b/job.go
@@ -71,10 +71,21 @@ type Runner struct {
 	Status RunnerStatusTypeEnum `json:"status"`
 }
 
+// RunnerJobVariableScope controls which container(s) on the job pod receive a
+// variable. An empty value means the variable is available in both the startup
+// init container and the main job container (the default).
+type RunnerJobVariableScope string
+
+const (
+	RunnerJobVariableScopeStartup RunnerJobVariableScope = "startup"
+	RunnerJobVariableScopeMain    RunnerJobVariableScope = "main"
+)
+
 type RunnerJobVariable struct {
-	Key       string `json:"key"`
-	Sensitive bool   `json:"sensitive"`
-	Value     string `json:"value"`
+	Key       string                 `json:"key"`
+	Sensitive bool                   `json:"sensitive"`
+	Value     string                 `json:"value"`
+	Scope     RunnerJobVariableScope `json:"scope"`
 }
 
 type RunnerJobFile struct {
@@ -83,13 +94,15 @@ type RunnerJobFile struct {
 }
 
 type RunnerJob struct {
-	Commands  []string             `json:"commands"`
-	Id        ID                   `json:"id"`
-	Image     string               `json:"image"`
-	Outcome   RunnerJobOutcomeEnum `json:"outcome"`
-	Status    RunnerJobStatusEnum  `json:"status"`
-	Variables []RunnerJobVariable  `json:"variables"`
-	Files     []RunnerJobFile      `json:"files"`
+	Commands        []string             `json:"commands"`
+	Id              ID                   `json:"id"`
+	Image           string               `json:"image"`
+	Outcome         RunnerJobOutcomeEnum `json:"outcome"`
+	Status          RunnerJobStatusEnum  `json:"status"`
+	Variables       []RunnerJobVariable  `json:"variables"`
+	Files           []RunnerJobFile      `json:"files"`
+	StartupCommands []string             `json:"startupCommands"`
+	StartupImage    string               `json:"startupImage"`
 }
 
 func (runnerJob *RunnerJob) Number() string {

--- a/job_test.go
+++ b/job_test.go
@@ -58,7 +58,7 @@ func TestRunnerGetScale(t *testing.T) {
 func TestRunnerGetPendingJobs(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation RunnerGetPendingJob($id:ID!$token:ID){runnerGetPendingJob(runnerId: $id lastUpdateToken: $token){runnerJob{commands,id,image,outcome,status,variables{key,sensitive,value},files{name,contents}},lastUpdateToken,errors{message,path}}}`,
+		`mutation RunnerGetPendingJob($id:ID!$token:ID){runnerGetPendingJob(runnerId: $id lastUpdateToken: $token){runnerJob{commands,id,image,outcome,status,variables{key,sensitive,value,scope},files{name,contents},startupCommands,startupImage},lastUpdateToken,errors{message,path}}}`,
 		`{"id":"1234567890", "token":  "1234"}`,
 		`{"data": {
       "runnerGetPendingJob": {
@@ -75,9 +75,20 @@ func TestRunnerGetPendingJobs(t *testing.T) {
           "variables": [
             {
               "key": "AWS_ACCESS_KEY",
-              "value": "XXXXXXX"
+              "value": "XXXXXXX",
+              "scope": "main"
+            },
+            {
+              "key": "REPO_CLONE_URL",
+              "value": "https://token@example.com/repo.git",
+              "sensitive": true,
+              "scope": "startup"
             }
-          ]
+          ],
+          "startupCommands": [
+            "/opslevel/clone-repo ."
+          ],
+          "startupImage": "public.ecr.aws/opslevel/cli:v2022.02.25"
         },
         "lastUpdateToken": "12344321",
         "errors": []
@@ -92,6 +103,10 @@ func TestRunnerGetPendingJobs(t *testing.T) {
 	autopilot.Equals(t, "public.ecr.aws/opslevel/cli:v2022.02.25", result.Image)
 	autopilot.Equals(t, "ls -al", result.Commands[1])
 	autopilot.Equals(t, ol.ID("12344321"), token)
+	autopilot.Equals(t, []string{"/opslevel/clone-repo ."}, result.StartupCommands)
+	autopilot.Equals(t, "public.ecr.aws/opslevel/cli:v2022.02.25", result.StartupImage)
+	autopilot.Equals(t, ol.RunnerJobVariableScopeMain, result.Variables[0].Scope)
+	autopilot.Equals(t, ol.RunnerJobVariableScopeStartup, result.Variables[1].Scope)
 }
 
 func TestRunnerAppendJobLog(t *testing.T) {

--- a/job_test.go
+++ b/job_test.go
@@ -58,7 +58,7 @@ func TestRunnerGetScale(t *testing.T) {
 func TestRunnerGetPendingJobs(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
-		`mutation RunnerGetPendingJob($id:ID!$token:ID){runnerGetPendingJob(runnerId: $id lastUpdateToken: $token){runnerJob{commands,id,image,outcome,status,variables{key,sensitive,value,scope},files{name,contents},startupCommands,startupImage},lastUpdateToken,errors{message,path}}}`,
+		`mutation RunnerGetPendingJob($id:ID!$token:ID){runnerGetPendingJob(runnerId: $id lastUpdateToken: $token){runnerJob{commands,id,image,outcome,status,variables{key,sensitive,value,scope},files{name,contents},initCommands,initImage},lastUpdateToken,errors{message,path}}}`,
 		`{"id":"1234567890", "token":  "1234"}`,
 		`{"data": {
       "runnerGetPendingJob": {
@@ -82,13 +82,13 @@ func TestRunnerGetPendingJobs(t *testing.T) {
               "key": "REPO_CLONE_URL",
               "value": "https://token@example.com/repo.git",
               "sensitive": true,
-              "scope": "startup"
+              "scope": "init"
             }
           ],
-          "startupCommands": [
+          "initCommands": [
             "/opslevel/clone-repo ."
           ],
-          "startupImage": "public.ecr.aws/opslevel/cli:v2022.02.25"
+          "initImage": "public.ecr.aws/opslevel/cli:v2022.02.25"
         },
         "lastUpdateToken": "12344321",
         "errors": []
@@ -103,10 +103,10 @@ func TestRunnerGetPendingJobs(t *testing.T) {
 	autopilot.Equals(t, "public.ecr.aws/opslevel/cli:v2022.02.25", result.Image)
 	autopilot.Equals(t, "ls -al", result.Commands[1])
 	autopilot.Equals(t, ol.ID("12344321"), token)
-	autopilot.Equals(t, []string{"/opslevel/clone-repo ."}, result.StartupCommands)
-	autopilot.Equals(t, "public.ecr.aws/opslevel/cli:v2022.02.25", result.StartupImage)
+	autopilot.Equals(t, []string{"/opslevel/clone-repo ."}, result.InitCommands)
+	autopilot.Equals(t, "public.ecr.aws/opslevel/cli:v2022.02.25", result.InitImage)
 	autopilot.Equals(t, ol.RunnerJobVariableScopeMain, result.Variables[0].Scope)
-	autopilot.Equals(t, ol.RunnerJobVariableScopeStartup, result.Variables[1].Scope)
+	autopilot.Equals(t, ol.RunnerJobVariableScopeInit, result.Variables[1].Scope)
 }
 
 func TestRunnerAppendJobLog(t *testing.T) {


### PR DESCRIPTION
Adds two new fields for configuring the `initContainer` of a RunnerJob: `RunnerJob.InitCommands/InitImage`

Also adds a new `scope` field to `RunnerJobVariable` with possible values of `""`, `"init"`, or `"main"`, allowing the partitioning of variables to the init or main container. `""`, the default value, will just include variables in both containers.

`opslevel-runner` changes supporting these additions to follow

Pre-requisite for: https://github.com/OpsLevel/opslevel-runner/pull/304