### PR TITLE
Reject CaseSensitive on predicate types that don't support it

### DIFF
--- a/.changes/unreleased/Bugfix-20260713-180016.yaml
+++ b/.changes/unreleased/Bugfix-20260713-180016.yaml
@@ -1,0 +1,5 @@
+kind: Bugfix
+body: FilterPredicate.Validate now rejects any CaseSensitive value (true or false) on
+  predicate types that do not support case sensitivity (e.g. exists, matches), since
+  the API ignores the value and returns null for it.
+time: 2026-07-13T18:00:16.000000Z

--- a/filters.go
+++ b/filters.go
@@ -50,7 +50,10 @@ func (filterPredicate *FilterPredicate) validateCaseSensitivity() error {
 		PredicateTypeEnumDoesNotMatch,
 		PredicateTypeEnumSatisfiesJqExpression,
 	}
-	if slices.Contains(knownNotCaseSensitiveTypes, filterPredicate.Type) && *filterPredicate.CaseSensitive {
+	// The API ignores CaseSensitive for these predicate types and returns null for it
+	// in responses, so any value set here (true or false) would silently disagree with
+	// the API response for clients that round-trip it. Reject any non-nil value.
+	if slices.Contains(knownNotCaseSensitiveTypes, filterPredicate.Type) {
 		return fmt.Errorf("FilterPredicate type '%s' cannot have CaseSensitive value set", filterPredicate.Type)
 	}
 	return nil

--- a/filters_test.go
+++ b/filters_test.go
@@ -301,3 +301,66 @@ func TestDeleteFilter(t *testing.T) {
 	// Assert
 	autopilot.Equals(t, nil, err)
 }
+
+func TestFilterPredicateValidateCaseSensitivity(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	testCases := map[string]struct {
+		predicate ol.FilterPredicate
+		wantErr   bool
+	}{
+		"nil on not-case-sensitive type is valid": {
+			predicate: ol.FilterPredicate{
+				Key:           ol.PredicateKeyEnumRepositoryIDs,
+				Type:          ol.PredicateTypeEnumExists,
+				CaseSensitive: nil,
+			},
+			wantErr: false,
+		},
+		"true on not-case-sensitive type is an error": {
+			predicate: ol.FilterPredicate{
+				Key:           ol.PredicateKeyEnumRepositoryIDs,
+				Type:          ol.PredicateTypeEnumExists,
+				CaseSensitive: boolPtr(true),
+			},
+			wantErr: true,
+		},
+		"false on not-case-sensitive type is an error": {
+			predicate: ol.FilterPredicate{
+				Key:           ol.PredicateKeyEnumRepositoryIDs,
+				Type:          ol.PredicateTypeEnumExists,
+				CaseSensitive: boolPtr(false),
+			},
+			wantErr: true,
+		},
+		"true on case-sensitive type is valid": {
+			predicate: ol.FilterPredicate{
+				Key:           ol.PredicateKeyEnumLanguage,
+				Type:          ol.PredicateTypeEnumEquals,
+				Value:         "Go",
+				CaseSensitive: boolPtr(true),
+			},
+			wantErr: false,
+		},
+		"false on case-sensitive type is valid": {
+			predicate: ol.FilterPredicate{
+				Key:           ol.PredicateKeyEnumLanguage,
+				Type:          ol.PredicateTypeEnumEquals,
+				Value:         "Go",
+				CaseSensitive: boolPtr(false),
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.predicate.Validate()
+			if tc.wantErr {
+				autopilot.Assert(t, err != nil, "expected an error but got nil")
+			} else {
+				autopilot.Equals(t, nil, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`FilterPredicate.validateCaseSensitivity()` only rejected a `CaseSensitive` value when it was `true`. A `false` value on a predicate type that doesn't support case sensitivity (e.g. `exists`, `matches`) passed validation and was sent to the API, which ignores it and returns `null`. Any client that round-trips the response — like [terraform-provider-opslevel](https://github.com/OpsLevel/terraform-provider-opslevel/pull/659) — then sees the value it set silently disagree with the API, surfacing in Terraform as "Provider produced inconsistent result after apply".

This drops the `&& *filterPredicate.CaseSensitive` clause so `Validate()` rejects **any** non-nil `CaseSensitive` (true or false) for these types. `nil` remains valid (handled by the existing early return).

## Changes

- **filters.go** — `validateCaseSensitivity` now rejects any non-nil `CaseSensitive` on `knownNotCaseSensitiveTypes`, with a comment explaining the API ignores/nulls the value. Error message unchanged.
- **filters_test.go** — new table-driven `TestFilterPredicateValidateCaseSensitivity` exercising `Validate()` end to end: nil/true/false on a not-case-sensitive type (`repository_ids` + `exists`) and true/false on a case-sensitive type (`language` + `equals`).
- **.changes/unreleased/** — changie `Bugfix` entry.

## Verification

- New `false`-value test case **fails before** the code change and **passes after**.
- `go test -race ./...` → `ok`
- `gofumpt -d -e .` → clean; `golangci-lint run` → `0 issues`

## Refs

- OpsLevel support ticket #15041
- terraform-provider-opslevel PR #659 (reviewer request to update `validateCaseSensitivity` to catch nil-returning cases)
