### PR TITLE
Add Kubernetes integration create/update with ETL definitions

### DIFF
--- a/.changes/unreleased/Feature-20260717-100000.yaml
+++ b/.changes/unreleased/Feature-20260717-100000.yaml
@@ -1,0 +1,6 @@
+kind: Feature
+body: Add CreateIntegrationKubernetes and UpdateIntegrationKubernetes client methods
+  along with KubernetesIntegrationInput and a KubernetesIntegration fragment exposing
+  ExtractDefinition and TransformDefinition, so a Kubernetes integration's ETL config
+  can be managed via the API.
+time: 2026-07-17T10:00:00.000000Z

--- a/integration.go
+++ b/integration.go
@@ -57,9 +57,9 @@ type AWSIntegrationInput struct {
 }
 
 type KubernetesIntegrationInput struct {
-	ExtractDefinition   *Nullable[string] `json:"extractDefinition,omitempty"`
+	ExtractDefinition   *Nullable[YAML]   `json:"extractDefinition,omitempty"`
 	Name                *Nullable[string] `json:"name,omitempty"`
-	TransformDefinition *Nullable[string] `json:"transformDefinition,omitempty"`
+	TransformDefinition *Nullable[YAML]   `json:"transformDefinition,omitempty"`
 }
 
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }

--- a/integration.go
+++ b/integration.go
@@ -37,6 +37,11 @@ type GoogleCloudIntegrationFragment struct {
 	TagsOverrideOwnership bool                 `graphql:"tagsOverrideOwnership"`
 }
 
+type KubernetesIntegrationFragment struct {
+	ExtractDefinition   string `graphql:"extractDefinition"`
+	TransformDefinition string `graphql:"transformDefinition"`
+}
+
 type NewRelicIntegrationFragment struct {
 	BaseUrl    string `graphql:"baseUrl"`
 	AccountKey string `graphql:"accountKey"`
@@ -51,7 +56,17 @@ type AWSIntegrationInput struct {
 	RegionOverride       *[]string         `json:"regionOverride,omitempty"`
 }
 
+type KubernetesIntegrationInput struct {
+	ExtractDefinition   *Nullable[string] `json:"extractDefinition,omitempty"`
+	Name                *Nullable[string] `json:"name,omitempty"`
+	TransformDefinition *Nullable[string] `json:"transformDefinition,omitempty"`
+}
+
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
+func (kubernetesIntegrationInput KubernetesIntegrationInput) GetGraphQLType() string {
+	return "KubernetesIntegrationInput"
+}
+
 func (newRelicIntegrationInput NewRelicIntegrationInput) GetGraphQLType() string {
 	return "NewRelicIntegrationInput"
 }
@@ -231,6 +246,29 @@ func (client *Client) UpdateIntegrationGCP(identifier string, input GoogleCloudI
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("GoogleCloudIntegrationUpdate"))
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) CreateIntegrationKubernetes(input KubernetesIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload IntegrationCreatePayload `graphql:"kubernetesIntegrationCreate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("KubernetesIntegrationCreate"))
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) UpdateIntegrationKubernetes(identifier string, input KubernetesIntegrationInput) (*Integration, error) {
+	var m struct {
+		Payload IntegrationUpdatePayload `graphql:"kubernetesIntegrationUpdate(integration: $integration input: $input)"`
+	}
+	v := PayloadVariables{
+		"integration": *NewIdentifier(identifier),
+		"input":       input,
+	}
+	err := client.Mutate(&m, v, WithName("KubernetesIntegrationUpdate"))
 	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 

--- a/integration.go
+++ b/integration.go
@@ -57,9 +57,9 @@ type AWSIntegrationInput struct {
 }
 
 type KubernetesIntegrationInput struct {
-	ExtractDefinition   *Nullable[YAML]   `json:"extractDefinition,omitempty"`
+	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
 	Name                *Nullable[string] `json:"name,omitempty"`
-	TransformDefinition *Nullable[YAML]   `json:"transformDefinition,omitempty"`
+	TransformDefinition *YAML             `json:"transformDefinition,omitempty"`
 }
 
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }

--- a/integration_test.go
+++ b/integration_test.go
@@ -179,11 +179,13 @@ func TestCreateKubernetesIntegration(t *testing.T) {
       }}}`,
 	)
 	client := BestTestClient(t, "integration/create_kubernetes", testRequest)
+	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Deployment\n")
+	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Deployment\n")
 	// Act
 	result, err := client.CreateIntegrationKubernetes(opslevel.KubernetesIntegrationInput{
 		Name:                opslevel.RefOf("Kubernetes"),
-		ExtractDefinition:   opslevel.RefOf(opslevel.YAML("extractors:\n- external_kind: Deployment\n")),
-		TransformDefinition: opslevel.RefOf(opslevel.YAML("transforms:\n- infrastructure_resource: Deployment\n")),
+		ExtractDefinition:   &extractDefinition,
+		TransformDefinition: &transformDefinition,
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)
@@ -422,11 +424,13 @@ func TestUpdateKubernetesIntegration(t *testing.T) {
       }}}`,
 	)
 	client := BestTestClient(t, "integration/update_kubernetes", testRequest)
+	extractDefinition := opslevel.YAML("extractors:\n- external_kind: StatefulSet\n")
+	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: StatefulSet\n")
 	// Act
 	result, err := client.UpdateIntegrationKubernetes(string(id1), opslevel.KubernetesIntegrationInput{
 		Name:                opslevel.RefOf("Kubernetes Updated"),
-		ExtractDefinition:   opslevel.RefOf(opslevel.YAML("extractors:\n- external_kind: StatefulSet\n")),
-		TransformDefinition: opslevel.RefOf(opslevel.YAML("transforms:\n- infrastructure_resource: StatefulSet\n")),
+		ExtractDefinition:   &extractDefinition,
+		TransformDefinition: &transformDefinition,
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -182,8 +182,8 @@ func TestCreateKubernetesIntegration(t *testing.T) {
 	// Act
 	result, err := client.CreateIntegrationKubernetes(opslevel.KubernetesIntegrationInput{
 		Name:                opslevel.RefOf("Kubernetes"),
-		ExtractDefinition:   opslevel.RefOf("extractors:\n- external_kind: Deployment\n"),
-		TransformDefinition: opslevel.RefOf("transforms:\n- infrastructure_resource: Deployment\n"),
+		ExtractDefinition:   opslevel.RefOf(opslevel.YAML("extractors:\n- external_kind: Deployment\n")),
+		TransformDefinition: opslevel.RefOf(opslevel.YAML("transforms:\n- infrastructure_resource: Deployment\n")),
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)
@@ -425,8 +425,8 @@ func TestUpdateKubernetesIntegration(t *testing.T) {
 	// Act
 	result, err := client.UpdateIntegrationKubernetes(string(id1), opslevel.KubernetesIntegrationInput{
 		Name:                opslevel.RefOf("Kubernetes Updated"),
-		ExtractDefinition:   opslevel.RefOf("extractors:\n- external_kind: StatefulSet\n"),
-		TransformDefinition: opslevel.RefOf("transforms:\n- infrastructure_resource: StatefulSet\n"),
+		ExtractDefinition:   opslevel.RefOf(opslevel.YAML("extractors:\n- external_kind: StatefulSet\n")),
+		TransformDefinition: opslevel.RefOf(opslevel.YAML("transforms:\n- infrastructure_resource: StatefulSet\n")),
 	})
 	// Assert
 	autopilot.Equals(t, nil, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -159,6 +159,40 @@ func TestCreateGoogleCloudIntegration(t *testing.T) {
 	}, result.Projects)
 }
 
+func TestCreateKubernetesIntegration(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation KubernetesIntegrationCreate($input:KubernetesIntegrationInput!){kubernetesIntegrationCreate(input: $input){integration{{ template "integration_request" }},errors{message,path}}}`,
+		`{"input": { "name": "Kubernetes", "extractDefinition": "extractors:\n- external_kind: Deployment\n", "transformDefinition": "transforms:\n- infrastructure_resource: Deployment\n" }}`,
+		`{"data": {
+      "kubernetesIntegrationCreate": {
+        "integration": {
+          {{ template "id1" }},
+          "name": "Kubernetes",
+          "type": "kubernetes",
+          "createdAt": "2026-07-17T16:25:29.574450Z",
+          "installedAt": "2026-07-17T16:25:28.541124Z",
+          "extractDefinition": "extractors:\n- external_kind: Deployment\n",
+          "transformDefinition": "transforms:\n- infrastructure_resource: Deployment\n"
+        },
+        "errors": []
+      }}}`,
+	)
+	client := BestTestClient(t, "integration/create_kubernetes", testRequest)
+	// Act
+	result, err := client.CreateIntegrationKubernetes(opslevel.KubernetesIntegrationInput{
+		Name:                opslevel.RefOf("Kubernetes"),
+		ExtractDefinition:   opslevel.RefOf("extractors:\n- external_kind: Deployment\n"),
+		TransformDefinition: opslevel.RefOf("transforms:\n- infrastructure_resource: Deployment\n"),
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, "Kubernetes", result.Name)
+	autopilot.Equals(t, "extractors:\n- external_kind: Deployment\n", result.ExtractDefinition)
+	autopilot.Equals(t, "transforms:\n- infrastructure_resource: Deployment\n", result.TransformDefinition)
+}
+
 func TestCreateNewRelicIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
@@ -366,6 +400,40 @@ func TestUpdateGoogleCloudIntegration(t *testing.T) {
 	autopilot.Equals(t, []opslevel.GoogleCloudProject{
 		{Id: "123", Name: "my-project-1", Url: "XXX_URL_XXX"},
 	}, result.Projects)
+}
+
+func TestUpdateKubernetesIntegration(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation KubernetesIntegrationUpdate($input:KubernetesIntegrationInput!$integration:IdentifierInput!){kubernetesIntegrationUpdate(integration: $integration input: $input){integration{{ template "integration_request" }},errors{message,path}}}`,
+		`{"integration": { {{ template "id1" }} }, "input": { "name": "Kubernetes Updated", "extractDefinition": "extractors:\n- external_kind: StatefulSet\n", "transformDefinition": "transforms:\n- infrastructure_resource: StatefulSet\n" }}`,
+		`{"data": {
+      "kubernetesIntegrationUpdate": {
+        "integration": {
+          {{ template "id1" }},
+          "name": "Kubernetes Updated",
+          "type": "kubernetes",
+          "createdAt": "2026-07-17T16:25:29.574450Z",
+          "installedAt": "2026-07-17T16:25:28.541124Z",
+          "extractDefinition": "extractors:\n- external_kind: StatefulSet\n",
+          "transformDefinition": "transforms:\n- infrastructure_resource: StatefulSet\n"
+        },
+        "errors": []
+      }}}`,
+	)
+	client := BestTestClient(t, "integration/update_kubernetes", testRequest)
+	// Act
+	result, err := client.UpdateIntegrationKubernetes(string(id1), opslevel.KubernetesIntegrationInput{
+		Name:                opslevel.RefOf("Kubernetes Updated"),
+		ExtractDefinition:   opslevel.RefOf("extractors:\n- external_kind: StatefulSet\n"),
+		TransformDefinition: opslevel.RefOf("transforms:\n- infrastructure_resource: StatefulSet\n"),
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, "Kubernetes Updated", result.Name)
+	autopilot.Equals(t, "extractors:\n- external_kind: StatefulSet\n", result.ExtractDefinition)
+	autopilot.Equals(t, "transforms:\n- infrastructure_resource: StatefulSet\n", result.TransformDefinition)
 }
 
 func TestUpdateNewRelicIntegration(t *testing.T) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -68,6 +68,7 @@ type Integration struct {
 	AWSIntegrationFragment            `graphql:"... on AwsIntegration"`
 	AzureResourcesIntegrationFragment `graphql:"... on AzureResourcesIntegration"`
 	GoogleCloudIntegrationFragment    `graphql:"... on GoogleCloudIntegration"`
+	KubernetesIntegrationFragment     `graphql:"... on KubernetesIntegration"`
 	NewRelicIntegrationFragment       `graphql:"... on NewRelicIntegration"`
 }
 

--- a/testdata/templates/integrations.tpl
+++ b/testdata/templates/integrations.tpl
@@ -40,5 +40,5 @@
 {{ end }}
 
 {{- define "integration_request" -}}
-{id,name,type,displayName,webhookUrl,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys,regionOverride},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership},... on NewRelicIntegration{baseUrl,accountKey}}
+{id,name,type,displayName,webhookUrl,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys,regionOverride},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership},... on KubernetesIntegration{extractDefinition,transformDefinition},... on NewRelicIntegration{baseUrl,accountKey}}
 {{- end }}

--- a/yaml.go
+++ b/yaml.go
@@ -1,0 +1,6 @@
+package opslevel
+
+// YAML represents a YAML document serialized as a string for use with the OpsLevel API.
+type YAML string
+
+func (y YAML) GetGraphQLType() string { return "YAML" }


### PR DESCRIPTION
## Summary

Adds Go client support for managing a Kubernetes infra integration's ETL config
(extract/transform definitions) via the public GraphQL API. Customer ask from
GitLab issue #14148 (Truelayer wants to manage their Kubernetes integration ETL
as code). The schema side is already merged in the monolith (MR !19177); this is
the client counterpart.

## Changes

- `KubernetesIntegrationInput` (`name`, `extractDefinition`, `transformDefinition`
  as `*Nullable[string]`) — hand-written alongside `AWSIntegrationInput` since
  `input.go` is generated.
- `CreateIntegrationKubernetes(input)` → `kubernetesIntegrationCreate`
- `UpdateIntegrationKubernetes(identifier, input)` → `kubernetesIntegrationUpdate`
- Read path: `KubernetesIntegrationFragment` (`ExtractDefinition`,
  `TransformDefinition`) added to the `Integration` struct as
  `... on KubernetesIntegration`, with the shared `integration_request` test
  template updated in the matching position so existing recorded queries still match.
- Tests: `TestCreateKubernetesIntegration` / `TestUpdateKubernetesIntegration`
  assert the ETL definitions round-trip through the mutations.
- Changie entry under `.changes/unreleased/`.

Mutation/input/field names verified against the monolith's committed public
schema dump (`public/schemas/schema.graphql`).

## Testing

- `go build ./...`
- `go test -race ./...` — full suite passes (existing integration tests double as
  a regression check for the shared query-template change)
- `task lint` (gofumpt + golangci-lint) — 0 issues
