### PR TITLE
Regenerate types with client-gen (14-08-2026)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -28,6 +28,9 @@ type AlertSourceServiceV2Connection ConnectionBase[AlertSourceService]
 // CampaignConnection The connection type for Campaign
 type CampaignConnection ConnectionBase[Campaign]
 
+// CampaignTeamConnection The connection type for CampaignTeam
+type CampaignTeamConnection ConnectionBase[CampaignTeam]
+
 // CategoryConnection The connection type for Category
 type CategoryConnection ConnectionBase[Category]
 

--- a/connection.go
+++ b/connection.go
@@ -73,6 +73,9 @@ type IntegrationConnection ConnectionBase[Integration]
 // LevelConnection The connection type for Level
 type LevelConnection ConnectionBase[Level]
 
+// PackageConnection The connection type for Package
+type PackageConnection ConnectionBase[Package]
+
 // PropertyConnection The connection type for Property
 type PropertyConnection ConnectionBase[Property]
 

--- a/enum.go
+++ b/enum.go
@@ -111,7 +111,7 @@ var AllBasicTypeEnum = []string{
 	string(BasicTypeEnumEquals),
 }
 
-// CampaignFilterEnum Fields that can be used as part of filter for campaigns
+// CampaignFilterEnum Fields that can be used as part of a filter for campaigns
 type CampaignFilterEnum string
 
 var (
@@ -159,13 +159,13 @@ var AllCampaignReminderFrequencyUnitEnum = []string{
 	string(CampaignReminderFrequencyUnitEnumWeek),
 }
 
-// CampaignReminderTypeEnum Type/Format of the notification
+// CampaignReminderTypeEnum Type/format of the notification
 type CampaignReminderTypeEnum string
 
 var (
 	CampaignReminderTypeEnumEmail          CampaignReminderTypeEnum = "email"           // Notification will be sent via email
-	CampaignReminderTypeEnumMicrosoftTeams CampaignReminderTypeEnum = "microsoft_teams" // Notification will be sent by microsoft teams
-	CampaignReminderTypeEnumSlack          CampaignReminderTypeEnum = "slack"           // Notification will be sent by slack
+	CampaignReminderTypeEnumMicrosoftTeams CampaignReminderTypeEnum = "microsoft_teams" // Notification will be sent via Microsoft Teams
+	CampaignReminderTypeEnumSlack          CampaignReminderTypeEnum = "slack"           // Notification will be sent via Slack
 )
 
 // All CampaignReminderTypeEnum as []string

--- a/enum.go
+++ b/enum.go
@@ -27,7 +27,7 @@ type AlertSourceTypeEnum string
 var (
 	AlertSourceTypeEnumCustom      AlertSourceTypeEnum = "custom"       // A custom alert source (aka service)
 	AlertSourceTypeEnumDatadog     AlertSourceTypeEnum = "datadog"      // A Datadog alert source (aka monitor)
-	AlertSourceTypeEnumFireHydrant AlertSourceTypeEnum = "fire_hydrant" // An FireHydrant alert source (aka service)
+	AlertSourceTypeEnumFireHydrant AlertSourceTypeEnum = "fire_hydrant" // A FireHydrant alert source (aka service)
 	AlertSourceTypeEnumIncidentIo  AlertSourceTypeEnum = "incident_io"  // An incident.io alert source (aka service)
 	AlertSourceTypeEnumNewRelic    AlertSourceTypeEnum = "new_relic"    // A New Relic alert source (aka service)
 	AlertSourceTypeEnumOpsgenie    AlertSourceTypeEnum = "opsgenie"     // An Opsgenie alert source (aka service)
@@ -276,7 +276,7 @@ type CheckResultStatusEnum string
 
 var (
 	CheckResultStatusEnumFailed CheckResultStatusEnum = "failed" // Indicates that the check has failed for the associated service
-	CheckResultStatusEnumPassed CheckResultStatusEnum = "passed" // Indicates that the check has passed for the associated service.
+	CheckResultStatusEnumPassed CheckResultStatusEnum = "passed" // Indicates that the check has passed for the associated service
 )
 
 // All CheckResultStatusEnum as []string
@@ -291,7 +291,7 @@ type CheckStatus string
 var (
 	CheckStatusFailed  CheckStatus = "failed"  // The check evaluated to a falsy value based on some conditions
 	CheckStatusPassed  CheckStatus = "passed"  // The check evaluated to a truthy value based on some conditions
-	CheckStatusPending CheckStatus = "pending" // The check has not been evaluated yet.
+	CheckStatusPending CheckStatus = "pending" // The check has not been evaluated yet
 )
 
 // All CheckStatus as []string
@@ -306,22 +306,22 @@ type CheckType string
 
 var (
 	CheckTypeAlertSourceUsage    CheckType = "alert_source_usage"    // Verifies that the service has an alert source of a particular type or name
-	CheckTypeCodeIssue           CheckType = "code_issue"            // Verifies that the severity and quantity of code issues does not exceed defined thresholds
+	CheckTypeCodeIssue           CheckType = "code_issue"            // Verifies that the severity and quantity of code issues do not exceed defined thresholds
 	CheckTypeCustom              CheckType = "custom"                // Allows for the creation of programmatic checks that use an API to mark the status as passing or failing
-	CheckTypeGeneric             CheckType = "generic"               // Requires a generic integration api call to complete a series of checks for multiple services
+	CheckTypeGeneric             CheckType = "generic"               // Requires a generic integration API call to complete a series of checks for multiple services
 	CheckTypeGitBranchProtection CheckType = "git_branch_protection" // Verifies that all the repositories on the service have branch protection enabled
 	CheckTypeHasDocumentation    CheckType = "has_documentation"     // Verifies that the service has visible documentation of a particular type and subtype
 	CheckTypeHasOwner            CheckType = "has_owner"             // Verifies that the service has an owner defined
-	CheckTypeHasRecentDeploy     CheckType = "has_recent_deploy"     // Verifies that the services has received a deploy within a specified number of days
+	CheckTypeHasRecentDeploy     CheckType = "has_recent_deploy"     // Verifies that the service has received a deploy within a specified number of days
 	CheckTypeHasRepository       CheckType = "has_repository"        // Verifies that the service has a repository integrated
-	CheckTypeHasServiceConfig    CheckType = "has_service_config"    // Verifies that the service is maintained though the use of an opslevel.yml service config
+	CheckTypeHasServiceConfig    CheckType = "has_service_config"    // Verifies that the service is maintained through the use of an opslevel.yml service config
 	CheckTypeManual              CheckType = "manual"                // Requires a service owner to manually complete a check for the service
 	CheckTypePackageVersion      CheckType = "package_version"       // Verifies certain aspects of a service using or not using software packages
-	CheckTypePayload             CheckType = "payload"               // Requires a payload integration api call to complete a check for the service
+	CheckTypePayload             CheckType = "payload"               // Requires a payload integration API call to complete a check for the service
 	CheckTypeRelationship        CheckType = "relationship"          // Verifies that the component has a specific number of relationship items defined for a specific relationship definition, with support for minimum, maximum, or exact count requirements
-	CheckTypeRepoFile            CheckType = "repo_file"             // Quickly scan the service’s repository for the existence or contents of a specific file
+	CheckTypeRepoFile            CheckType = "repo_file"             // Quickly scan the service's repository for the existence or contents of a specific file
 	CheckTypeRepoGrep            CheckType = "repo_grep"             // Run a comprehensive search across the service's repository using advanced search parameters
-	CheckTypeRepoSearch          CheckType = "repo_search"           // Quickly search the service’s repository for specific contents in any file
+	CheckTypeRepoSearch          CheckType = "repo_search"           // Quickly search the service's repository for specific contents in any file
 	CheckTypeServiceDependency   CheckType = "service_dependency"    // Verifies that the service has either a dependent or dependency
 	CheckTypeServiceProperty     CheckType = "service_property"      // Verifies that a service property is set or matches a specified format
 	CheckTypeTagDefined          CheckType = "tag_defined"           // Verifies that the service has the specified tag defined
@@ -2581,7 +2581,7 @@ var AllCustomActionsTriggerEventStatusEnum = []string{
 type DayOfWeekEnum string
 
 var (
-	DayOfWeekEnumFriday    DayOfWeekEnum = "friday"    // Yesterday was Thursday. Tomorrow is Saturday. We so excited
+	DayOfWeekEnumFriday    DayOfWeekEnum = "friday"    // Yesterday was Thursday. Tomorrow is Saturday. We are so excited
 	DayOfWeekEnumMonday    DayOfWeekEnum = "monday"    // Monday is the day of the week that takes place between Sunday and Tuesday
 	DayOfWeekEnumSaturday  DayOfWeekEnum = "saturday"  // The day of the week before Sunday and following Friday, and (together with Sunday) forming part of the weekend
 	DayOfWeekEnumSunday    DayOfWeekEnum = "sunday"    // The day of the week before Monday and following Saturday, (together with Saturday) forming part of the weekend
@@ -2855,7 +2855,7 @@ var AllPayloadSortEnum = []string{
 	string(PayloadSortEnumProcessedAtDesc),
 }
 
-// PredicateKeyEnum Fields that can be used as part of filter for services
+// PredicateKeyEnum Fields that can be used as part of a filter for services
 type PredicateKeyEnum string
 
 var (
@@ -3109,13 +3109,13 @@ var AllRepositorySBOMGenerationConfigEnum = []string{
 	string(RepositorySBOMGenerationConfigEnumOptOut),
 }
 
-// RepositorySBOMGenerationDisabledReasonEnum The set of values that explain why SBOM autogeneration is disabled
+// RepositorySBOMGenerationDisabledReasonEnum The set of values that explain why SBOM auto-generation is disabled
 type RepositorySBOMGenerationDisabledReasonEnum string
 
 var (
-	RepositorySBOMGenerationDisabledReasonEnumAccount     RepositorySBOMGenerationDisabledReasonEnum = "account"     // SBOM autogeneration is disabled at the account level
-	RepositorySBOMGenerationDisabledReasonEnumIntegration RepositorySBOMGenerationDisabledReasonEnum = "integration" // SBOM autogeneration is disabled at the integration level
-	RepositorySBOMGenerationDisabledReasonEnumRepository  RepositorySBOMGenerationDisabledReasonEnum = "repository"  // SBOM autogeneration is disabled at the repository level
+	RepositorySBOMGenerationDisabledReasonEnumAccount     RepositorySBOMGenerationDisabledReasonEnum = "account"     // SBOM auto-generation is disabled at the account level
+	RepositorySBOMGenerationDisabledReasonEnumIntegration RepositorySBOMGenerationDisabledReasonEnum = "integration" // SBOM auto-generation is disabled at the integration level
+	RepositorySBOMGenerationDisabledReasonEnumRepository  RepositorySBOMGenerationDisabledReasonEnum = "repository"  // SBOM auto-generation is disabled at the repository level
 )
 
 // All RepositorySBOMGenerationDisabledReasonEnum as []string
@@ -3129,7 +3129,7 @@ var AllRepositorySBOMGenerationDisabledReasonEnum = []string{
 type RepositoryVisibilityEnum string
 
 var (
-	RepositoryVisibilityEnumInternal     RepositoryVisibilityEnum = "INTERNAL"     // Repositories that are only accessible to organization users (Github, Gitlab)
+	RepositoryVisibilityEnumInternal     RepositoryVisibilityEnum = "INTERNAL"     // Repositories that are only accessible to organization users (GitHub, GitLab)
 	RepositoryVisibilityEnumOrganization RepositoryVisibilityEnum = "ORGANIZATION" // Repositories that are only accessible to organization users (ADO)
 	RepositoryVisibilityEnumPrivate      RepositoryVisibilityEnum = "PRIVATE"      // Repositories that are private to the user
 	RepositoryVisibilityEnumPublic       RepositoryVisibilityEnum = "PUBLIC"       // Repositories that are publicly accessible
@@ -3205,13 +3205,13 @@ var (
 	ServiceFilterEnumDomainID          ServiceFilterEnum = "domain_id"          // Filter by Domain that includes the System this service is assigned to, if any
 	ServiceFilterEnumFilterID          ServiceFilterEnum = "filter_id"          // Filter by another filter
 	ServiceFilterEnumFramework         ServiceFilterEnum = "framework"          // Filter by `framework` field
-	ServiceFilterEnumGroupIDs          ServiceFilterEnum = "group_ids"          // Filter by group hierarchy. Will return resources who's owner is in the group ancestry chain
+	ServiceFilterEnumGroupIDs          ServiceFilterEnum = "group_ids"          // Filter by group hierarchy. Will return resources whose owner is in the group ancestry chain
 	ServiceFilterEnumLanguage          ServiceFilterEnum = "language"           // Filter by `language` field
 	ServiceFilterEnumLevelIndex        ServiceFilterEnum = "level_index"        // Filter by `level` field
 	ServiceFilterEnumLifecycleIndex    ServiceFilterEnum = "lifecycle_index"    // Filter by `lifecycle` field
 	ServiceFilterEnumName              ServiceFilterEnum = "name"               // Filter by `name` field
 	ServiceFilterEnumOwnerID           ServiceFilterEnum = "owner_id"           // Filter by `owner` field
-	ServiceFilterEnumOwnerIDs          ServiceFilterEnum = "owner_ids"          // Filter by `owner` hierarchy. Will return resources who's owner is in the team ancestry chain
+	ServiceFilterEnumOwnerIDs          ServiceFilterEnum = "owner_ids"          // Filter by `owner` hierarchy. Will return resources whose owner is in the team ancestry chain
 	ServiceFilterEnumProduct           ServiceFilterEnum = "product"            // Filter by `product` field
 	ServiceFilterEnumProperty          ServiceFilterEnum = "property"           // Filter by a custom-defined property value
 	ServiceFilterEnumRelationship      ServiceFilterEnum = "relationship"       // Filter by the existence of a relationship to another catalog component
@@ -3489,7 +3489,7 @@ var AllUserRole = []string{
 	string(UserRoleUser),
 }
 
-// UsersFilterEnum Fields that can be used as part of filter for users
+// UsersFilterEnum Fields that can be used as part of a filter for users
 type UsersFilterEnum string
 
 var (
@@ -3497,7 +3497,7 @@ var (
 	UsersFilterEnumEmail         UsersFilterEnum = "email"           // Filter by `email` field
 	UsersFilterEnumLastSignInAt  UsersFilterEnum = "last_sign_in_at" // Filter by the `last_sign_in_at` field
 	UsersFilterEnumName          UsersFilterEnum = "name"            // Filter by `name` field
-	UsersFilterEnumRole          UsersFilterEnum = "role"            // Filter by `role` field. (user or admin)
+	UsersFilterEnumRole          UsersFilterEnum = "role"            // Filter by `role` field. The value is the role's `slug` (e.g. `user` or `admin`)
 	UsersFilterEnumTag           UsersFilterEnum = "tag"             // Filter by `tags` belonging to user
 )
 

--- a/input.go
+++ b/input.go
@@ -5,7 +5,7 @@ import "github.com/relvacode/iso8601"
 
 // AlertSourceExternalIdentifier Specifies the input needed to find an alert source with external information
 type AlertSourceExternalIdentifier struct {
-	ExternalId string              `json:"externalId" yaml:"externalId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The external id of the alert (Required)
+	ExternalId string              `json:"externalId" yaml:"externalId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The external ID of the alert (Required)
 	Type       AlertSourceTypeEnum `json:"type" yaml:"type" example:"custom"`                                      // The type of the alert (Required)
 }
 
@@ -14,7 +14,7 @@ type AlertSourceInput struct {
 	Description *Nullable[string]               `json:"description,omitempty" yaml:"description,omitempty" example:"example_value"` // The description of the alert source (Optional)
 	Identifier  ExternalResourceIdentifierInput `json:"identifier" yaml:"identifier"`                                               // The alert source identifier (Required)
 	Name        *Nullable[string]               `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`               // The name of the alert source (Optional)
-	Url         *Nullable[string]               `json:"url,omitempty" yaml:"url,omitempty" example:"example_value"`                 // The url of the alert source (Optional)
+	Url         *Nullable[string]               `json:"url,omitempty" yaml:"url,omitempty" example:"example_value"`                 // The URL of the alert source (Optional)
 }
 
 // AlertSourceServiceCreateInput Specifies the input used for attaching an alert source to a service
@@ -198,38 +198,38 @@ type CheckAlertSourceUsageUpdateInput struct {
 // CheckCodeIssueCreateInput Specifies the input fields used to create a code issue check
 type CheckCodeIssueCreateInput struct {
 	CategoryId     ID                            `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                 // The id of the category the check belongs to (Required)
-	Constraint     CheckCodeIssueConstraintEnum  `json:"constraint" yaml:"constraint" example:"any"`                                             // The type of constraint used in evaluation the code issues check (Required)
+	Constraint     CheckCodeIssueConstraintEnum  `json:"constraint" yaml:"constraint" example:"any"`                                             // The type of constraint used in evaluating the code issues check (Required)
 	EnableOn       *Nullable[iso8601.Time]       `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2025-01-05T01:00:00.000Z"`        // The date when the check will be automatically enabled (Optional)
 	Enabled        *Nullable[bool]               `json:"enabled,omitempty" yaml:"enabled,omitempty" example:"false"`                             // Whether the check is enabled or not (Optional Default: false)
 	FilterId       *Nullable[ID]                 `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter of the check (Optional)
 	IssueName      *Nullable[string]             `json:"issueName,omitempty" yaml:"issueName,omitempty" example:"example_value"`                 // The issue name used for code issue lookup (Optional)
-	IssueType      *Nullable[[]string]           `json:"issueType,omitempty" yaml:"issueType,omitempty" example:"['bug', 'error']"`              // The type of code issue to consider (Optional)
+	IssueType      *Nullable[[]string]           `json:"issueType,omitempty" yaml:"issueType,omitempty" example:"['bug', 'error']"`              // The type of code issue to consider, generally in the format of 'source:type'. Possible values depend on the installed integrations (Optional)
 	LevelId        ID                            `json:"levelId" yaml:"levelId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The id of the level the check belongs to (Required)
 	MaxAllowed     *int                          `json:"maxAllowed,omitempty" yaml:"maxAllowed,omitempty" example:"3"`                           // The threshold count of code issues beyond which the check starts failing (Optional)
 	Name           string                        `json:"name" yaml:"name" example:"example_value"`                                               // The display name of the check (Required)
 	Notes          *string                       `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_value"`                         // Additional information about the check (Optional)
 	OwnerId        *Nullable[ID]                 `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check (Optional)
 	ResolutionTime *CodeIssueResolutionTimeInput `json:"resolutionTime,omitempty" yaml:"resolutionTime,omitempty"`                               // The resolution time recommended by the reporting source of the code issue (Optional)
-	Severity       *Nullable[[]string]           `json:"severity,omitempty" yaml:"severity,omitempty" example:"['sev1', 'sev2']"`                // The severity levels of the issue (Optional)
+	Severity       *Nullable[[]string]           `json:"severity,omitempty" yaml:"severity,omitempty" example:"['sev1', 'sev2']"`                // The severity levels of the issue, generally in the form of 'source:severity'. Possible values depend on the installed integrations (Optional)
 }
 
-// CheckCodeIssueUpdateInput Specifies the input fields used to update an exasting code issue check
+// CheckCodeIssueUpdateInput Specifies the input fields used to update an existing code issue check
 type CheckCodeIssueUpdateInput struct {
 	CategoryId     *Nullable[ID]                 `json:"categoryId,omitempty" yaml:"categoryId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the category the check belongs to (Optional)
-	Constraint     CheckCodeIssueConstraintEnum  `json:"constraint" yaml:"constraint" example:"any"`                                                 // The type of constraint used in evaluation the code issues check (Required)
+	Constraint     CheckCodeIssueConstraintEnum  `json:"constraint" yaml:"constraint" example:"any"`                                                 // The type of constraint used in evaluating the code issues check (Required)
 	EnableOn       *Nullable[iso8601.Time]       `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2025-01-05T01:00:00.000Z"`            // The date when the check will be automatically enabled (Optional)
 	Enabled        *Nullable[bool]               `json:"enabled,omitempty" yaml:"enabled,omitempty" example:"false"`                                 // Whether the check is enabled or not (Optional)
 	FilterId       *Nullable[ID]                 `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`     // The id of the filter the check belongs to (Optional)
 	Id             ID                            `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                                     // The id of the check to be updated (Required)
 	IssueName      *Nullable[string]             `json:"issueName,omitempty" yaml:"issueName,omitempty" example:"example_value"`                     // The issue name used for code issue lookup (Optional)
-	IssueType      *Nullable[[]string]           `json:"issueType,omitempty" yaml:"issueType,omitempty" example:"['bug', 'error']"`                  // The type of code issue to consider (Optional)
+	IssueType      *Nullable[[]string]           `json:"issueType,omitempty" yaml:"issueType,omitempty" example:"['bug', 'error']"`                  // The type of code issue to consider, generally in the format of 'source:type'. Possible values depend on the installed integrations (Optional)
 	LevelId        *Nullable[ID]                 `json:"levelId,omitempty" yaml:"levelId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`       // The id of the level the check belongs to (Optional)
 	MaxAllowed     *int                          `json:"maxAllowed,omitempty" yaml:"maxAllowed,omitempty" example:"3"`                               // The threshold count of code issues beyond which the check starts failing (Optional)
 	Name           *Nullable[string]             `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                               // The display name of the check (Optional)
 	Notes          *string                       `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_value"`                             // Additional information about the check (Optional)
 	OwnerId        *Nullable[ID]                 `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`       // The id of the owner of the check (Optional)
 	ResolutionTime *CodeIssueResolutionTimeInput `json:"resolutionTime,omitempty" yaml:"resolutionTime,omitempty"`                                   // The resolution time recommended by the reporting source of the code issue (Optional)
-	Severity       *Nullable[[]string]           `json:"severity,omitempty" yaml:"severity,omitempty" example:"['sev1', 'sev2']"`                    // The severity levels of the issue (Optional)
+	Severity       *Nullable[[]string]           `json:"severity,omitempty" yaml:"severity,omitempty" example:"['sev1', 'sev2']"`                    // The severity levels of the issue, generally in the form of 'source:severity'. Possible values depend on the installed integrations (Optional)
 }
 
 // CheckCopyInput Information about the check(s) that are to be copied
@@ -253,8 +253,8 @@ type CheckCustomEventCreateInput struct {
 	OwnerId          *Nullable[ID]           `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check (Optional)
 	PassPending      *Nullable[bool]         `json:"passPending,omitempty" yaml:"passPending,omitempty" example:"false"`                     // True if this check should pass by default. Otherwise the default 'pending' state counts as a failure (Optional)
 	ResultMessage    *Nullable[string]       `json:"resultMessage,omitempty" yaml:"resultMessage,omitempty" example:"example_value"`         // The check result message template. It is compiled with Liquid and formatted in Markdown. [More info about liquid templates](https://docs.opslevel.com/docs/checks/payload-checks/#liquid-templating) (Optional)
-	ServiceSelector  string                  `json:"serviceSelector" yaml:"serviceSelector" example:"example_value"`                         // A jq expression that will be ran against your payload. This will parse out the service identifier. [More info about jq](https://jqplay.org/) (Required)
-	SuccessCondition string                  `json:"successCondition" yaml:"successCondition" example:"example_value"`                       // A jq expression that will be ran against your payload. A truthy value will result in the check passing. [More info about jq](https://jqplay.org/) (Required)
+	ServiceSelector  string                  `json:"serviceSelector" yaml:"serviceSelector" example:"example_value"`                         // A jq expression that will be run against your payload. This will parse out the service identifier. [More info about jq](https://jqplay.org/) (Required)
+	SuccessCondition string                  `json:"successCondition" yaml:"successCondition" example:"example_value"`                       // A jq expression that will be run against your payload. A truthy value will result in the check passing. [More info about jq](https://jqplay.org/) (Required)
 }
 
 // CheckCustomEventUpdateInput Specifies the input fields used to update a custom event check
@@ -271,8 +271,8 @@ type CheckCustomEventUpdateInput struct {
 	OwnerId          *Nullable[ID]           `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`             // The id of the owner of the check (Optional)
 	PassPending      *Nullable[bool]         `json:"passPending,omitempty" yaml:"passPending,omitempty" example:"false"`                               // True if this check should pass by default. Otherwise the default 'pending' state counts as a failure (Optional)
 	ResultMessage    *Nullable[string]       `json:"resultMessage,omitempty" yaml:"resultMessage,omitempty" example:"example_value"`                   // The check result message template. It is compiled with Liquid and formatted in Markdown. [More info about liquid templates](https://docs.opslevel.com/docs/checks/payload-checks/#liquid-templating) (Optional)
-	ServiceSelector  *Nullable[string]       `json:"serviceSelector,omitempty" yaml:"serviceSelector,omitempty" example:"example_value"`               // A jq expression that will be ran against your payload. This will parse out the service identifier. [More info about jq](https://jqplay.org/) (Optional)
-	SuccessCondition *Nullable[string]       `json:"successCondition,omitempty" yaml:"successCondition,omitempty" example:"example_value"`             // A jq expression that will be ran against your payload. A truthy value will result in the check passing. [More info about jq](https://jqplay.org/) (Optional)
+	ServiceSelector  *Nullable[string]       `json:"serviceSelector,omitempty" yaml:"serviceSelector,omitempty" example:"example_value"`               // A jq expression that will be run against your payload. This will parse out the service identifier. [More info about jq](https://jqplay.org/) (Optional)
+	SuccessCondition *Nullable[string]       `json:"successCondition,omitempty" yaml:"successCondition,omitempty" example:"example_value"`             // A jq expression that will be run against your payload. A truthy value will result in the check passing. [More info about jq](https://jqplay.org/) (Optional)
 }
 
 // CheckDeleteInput Specifies the input fields used to delete a check
@@ -334,7 +334,7 @@ type CheckHasDocumentationUpdateInput struct {
 	OwnerId         *Nullable[ID]                `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`       // The id of the owner of the check (Optional)
 }
 
-// CheckHasRecentDeployCreateInput Specifies the input fields used to create a recent deploys check
+// CheckHasRecentDeployCreateInput Specifies the input fields used to create a recent deploy check
 type CheckHasRecentDeployCreateInput struct {
 	CategoryId ID                      `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                 // The id of the category the check belongs to (Required)
 	Days       int                     `json:"days" yaml:"days" example:"3"`                                                           // The number of days to check since the last deploy (Required)
@@ -427,7 +427,7 @@ type CheckPackageVersionUpdateInput struct {
 	VersionConstraintPredicate *Nullable[PredicateUpdateInput]  `json:"versionConstraintPredicate,omitempty" yaml:"versionConstraintPredicate,omitempty"`           // The predicate that describes the version constraint the package must satisfy (Optional)
 }
 
-// CheckRelationshipCreateInput Specifies the input fields used to create a relationships check
+// CheckRelationshipCreateInput Specifies the input fields used to create a relationship check
 type CheckRelationshipCreateInput struct {
 	CategoryId                 ID                      `json:"categoryId" yaml:"categoryId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                             // The id of the category the check belongs to (Required)
 	EnableOn                   *Nullable[iso8601.Time] `json:"enableOn,omitempty" yaml:"enableOn,omitempty" example:"2025-01-05T01:00:00.000Z"`                    // The date when the check will be automatically enabled (Optional)
@@ -469,7 +469,7 @@ type CheckRepositoryFileCreateInput struct {
 	Name                  string                  `json:"name" yaml:"name" example:"example_value"`                                               // The display name of the check (Required)
 	Notes                 *string                 `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_value"`                         // Additional information about the check (Optional)
 	OwnerId               *Nullable[ID]           `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check (Optional)
-	UseAbsoluteRoot       *Nullable[bool]         `json:"useAbsoluteRoot,omitempty" yaml:"useAbsoluteRoot,omitempty" example:"false"`             // Whether the checks looks at the absolute root of a repo or the relative root (the directory specified when attached a repo to a service) (Optional Default: false)
+	UseAbsoluteRoot       *Nullable[bool]         `json:"useAbsoluteRoot,omitempty" yaml:"useAbsoluteRoot,omitempty" example:"false"`             // Whether the check looks at the absolute root of a repo or the relative root (the directory specified when a repo is attached to a service) (Optional Default: false)
 }
 
 // CheckRepositoryFileUpdateInput Specifies the input fields used to update a repo file check
@@ -486,7 +486,7 @@ type CheckRepositoryFileUpdateInput struct {
 	Name                  *Nullable[string]       `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                                  // The display name of the check (Optional)
 	Notes                 *string                 `json:"notes,omitempty" yaml:"notes,omitempty" example:"example_value"`                                // Additional information about the check (Optional)
 	OwnerId               *Nullable[ID]           `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`          // The id of the owner of the check (Optional)
-	UseAbsoluteRoot       *Nullable[bool]         `json:"useAbsoluteRoot,omitempty" yaml:"useAbsoluteRoot,omitempty" example:"false"`                    // Whether the checks looks at the absolute root of a repo or the relative root (the directory specified when attached a repo to a service) (Optional Default: false)
+	UseAbsoluteRoot       *Nullable[bool]         `json:"useAbsoluteRoot,omitempty" yaml:"useAbsoluteRoot,omitempty" example:"false"`                    // Whether the check looks at the absolute root of a repo or the relative root (the directory specified when a repo is attached to a service) (Optional Default: false)
 }
 
 // CheckRepositoryGrepCreateInput Specifies the input fields used to create a repo grep check
@@ -739,7 +739,7 @@ type CheckToolUsageCreateInput struct {
 	OwnerId              *Nullable[ID]           `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the check (Optional)
 	ToolCategory         ToolCategory            `json:"toolCategory" yaml:"toolCategory" example:"admin"`                                       // The category that the tool belongs to (Required)
 	ToolNamePredicate    *PredicateInput         `json:"toolNamePredicate,omitempty" yaml:"toolNamePredicate,omitempty"`                         // The condition that the tool name should satisfy to be evaluated (Optional)
-	ToolUrlPredicate     *PredicateInput         `json:"toolUrlPredicate,omitempty" yaml:"toolUrlPredicate,omitempty"`                           // The condition that the tool url should satisfy to be evaluated (Optional)
+	ToolUrlPredicate     *PredicateInput         `json:"toolUrlPredicate,omitempty" yaml:"toolUrlPredicate,omitempty"`                           // The condition that the tool URL should satisfy to be evaluated (Optional)
 }
 
 // CheckToolUsageUpdateInput Specifies the input fields used to update a tool usage check
@@ -873,23 +873,23 @@ type CustomActionsTriggerInvokeInput struct {
 type CustomActionsWebhookActionCreateInput struct {
 	Async          *bool                       `json:"async,omitempty" yaml:"async,omitempty" example:"false"`                                                                                                         // Whether the action expects an additional, asynchronous response upon completion (Required Default: false)
 	Description    *Nullable[string]           `json:"description,omitempty" yaml:"description,omitempty" example:"example_value"`                                                                                     // The description that gets assigned to the Webhook Action you're creating (Optional)
-	Headers        *JSON                       `json:"headers,omitempty" yaml:"headers,omitempty" example:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"` // HTTP headers be passed along with your Webhook when triggered (Optional)
-	HttpMethod     CustomActionsHttpMethodEnum `json:"httpMethod" yaml:"httpMethod" example:"DELETE"`                                                                                                                  // HTTP used when the Webhook is triggered. Either POST or PUT (Required)
-	LiquidTemplate *Nullable[string]           `json:"liquidTemplate,omitempty" yaml:"liquidTemplate,omitempty" example:"example_value"`                                                                               // Template that can be used to generate a Webhook payload (Optional)
+	Headers        *JSON                       `json:"headers,omitempty" yaml:"headers,omitempty" example:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"` // HTTP headers to be passed along with your webhook when triggered (Optional)
+	HttpMethod     CustomActionsHttpMethodEnum `json:"httpMethod" yaml:"httpMethod" example:"DELETE"`                                                                                                                  // HTTP method used when the webhook is triggered. Either POST or PUT (Required)
+	LiquidTemplate *Nullable[string]           `json:"liquidTemplate,omitempty" yaml:"liquidTemplate,omitempty" example:"example_value"`                                                                               // Template that can be used to generate a webhook payload (Optional)
 	Name           string                      `json:"name" yaml:"name" example:"example_value"`                                                                                                                       // The name that gets assigned to the Webhook Action you're creating (Required)
-	WebhookUrl     string                      `json:"webhookUrl" yaml:"webhookUrl" example:"example_value"`                                                                                                           // The URL that you wish to send the Webhook to when triggered (Required)
+	WebhookUrl     string                      `json:"webhookUrl" yaml:"webhookUrl" example:"example_value"`                                                                                                           // The URL that you wish to send the webhook to when triggered (Required)
 }
 
 // CustomActionsWebhookActionUpdateInput Inputs that specify the details of a Webhook Action you wish to update
 type CustomActionsWebhookActionUpdateInput struct {
 	Async          *bool                        `json:"async,omitempty" yaml:"async,omitempty" example:"false"`                                                                                                         // Whether the action expects an additional, asynchronous response upon completion (Optional)
 	Description    *Nullable[string]            `json:"description,omitempty" yaml:"description,omitempty" example:"example_value"`                                                                                     // The description that gets assigned to the Webhook Action you're creating (Optional)
-	Headers        *JSON                        `json:"headers,omitempty" yaml:"headers,omitempty" example:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"` // HTTP headers be passed along with your Webhook when triggered (Optional)
-	HttpMethod     *CustomActionsHttpMethodEnum `json:"httpMethod,omitempty" yaml:"httpMethod,omitempty" example:"DELETE"`                                                                                              // HTTP used when the Webhook is triggered. Either POST or PUT (Optional)
+	Headers        *JSON                        `json:"headers,omitempty" yaml:"headers,omitempty" example:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"` // HTTP headers to be passed along with your webhook when triggered (Optional)
+	HttpMethod     *CustomActionsHttpMethodEnum `json:"httpMethod,omitempty" yaml:"httpMethod,omitempty" example:"DELETE"`                                                                                              // HTTP method used when the webhook is triggered. Either POST or PUT (Optional)
 	Id             ID                           `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                                                                                                         // The ID of the Webhook Action you wish to update (Required)
-	LiquidTemplate *Nullable[string]            `json:"liquidTemplate,omitempty" yaml:"liquidTemplate,omitempty" example:"example_value"`                                                                               // Template that can be used to generate a Webhook payload (Optional)
+	LiquidTemplate *Nullable[string]            `json:"liquidTemplate,omitempty" yaml:"liquidTemplate,omitempty" example:"example_value"`                                                                               // Template that can be used to generate a webhook payload (Optional)
 	Name           *Nullable[string]            `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                                                                                                   // The name that gets assigned to the Webhook Action you're creating (Optional)
-	WebhookUrl     *Nullable[string]            `json:"webhookUrl,omitempty" yaml:"webhookUrl,omitempty" example:"example_value"`                                                                                       // The URL that you wish to send the Webhook too when triggered (Optional)
+	WebhookUrl     *Nullable[string]            `json:"webhookUrl,omitempty" yaml:"webhookUrl,omitempty" example:"example_value"`                                                                                       // The URL that you wish to send the webhook to when triggered (Optional)
 }
 
 // CustomIntegrationInput Input for upserting a custom integration
@@ -922,7 +922,7 @@ type EventIntegrationUpdateInput struct {
 	Name string `json:"name" yaml:"name" example:"example_value"`               // The name of the event integration (Required)
 }
 
-// ExternalResourceIdentifierInput Specifies the input fields to locate resouce created via API in OpsLevel
+// ExternalResourceIdentifierInput Specifies the input fields used to locate a resource created via API in OpsLevel
 type ExternalResourceIdentifierInput struct {
 	ExternalId  string          `json:"externalId" yaml:"externalId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the resource in your system (Required)
 	Integration IdentifierInput `json:"integration" yaml:"integration"`                                         // The integration identifier (Required)
@@ -942,7 +942,7 @@ type FilterCreateInput struct {
 
 // FilterPredicateInput A condition that should be satisfied
 type FilterPredicateInput struct {
-	CaseSensitive *Nullable[bool]   `json:"caseSensitive,omitempty" yaml:"caseSensitive,omitempty" example:"false"` //  (Optional)
+	CaseSensitive *Nullable[bool]   `json:"caseSensitive,omitempty" yaml:"caseSensitive,omitempty" example:"false"` // Option for determining whether to compare strings case-sensitively (Optional)
 	Key           PredicateKeyEnum  `json:"key" yaml:"key" example:"aliases"`                                       // The condition key used by the predicate (Required)
 	KeyData       *Nullable[string] `json:"keyData,omitempty" yaml:"keyData,omitempty" example:"example_value"`     // Additional data used by the predicate. This field is used by predicates with key = 'tags' to specify the tag key. For example, to create a predicate for services containing the tag 'db:mysql', set keyData = 'db' and value = 'mysql' (Optional)
 	Type          PredicateTypeEnum `json:"type" yaml:"type" example:"belongs_to"`                                  // The condition type used by the predicate (Required)
@@ -978,7 +978,7 @@ type IdentifierInput struct {
 	Id    *ID     `json:"id,omitempty" yaml:"id,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the resource (Optional)
 }
 
-// InfrastructureResourceInput Specifies the input fields for a infrastructure resource
+// InfrastructureResourceInput Specifies the input fields for an infrastructure resource
 type InfrastructureResourceInput struct {
 	Data                 *JSON                                    `json:"data,omitempty" yaml:"data,omitempty" example:"{\"name\":\"my-big-query\",\"engine\":\"BigQuery\",\"endpoint\":\"https://google.com\",\"replica\":false}"` // The data for the infrastructure_resource (Optional)
 	OwnerId              *Nullable[ID]                            `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                                                                     // The id of the owner for the infrastructure_resource (Optional)
@@ -1323,9 +1323,9 @@ type TagInput struct {
 
 // TagRelationshipKeysAssignInput The input for the `tagRelationshipKeysAssign` mutation
 type TagRelationshipKeysAssignInput struct {
-	BelongsTo    *Nullable[string]   `json:"belongsTo,omitempty" yaml:"belongsTo,omitempty" example:"example_value"` //  (Optional)
-	DependencyOf *Nullable[[]string] `json:"dependencyOf,omitempty" yaml:"dependencyOf,omitempty" example:"[]"`      //  (Optional)
-	DependsOn    *Nullable[[]string] `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" example:"[]"`            //  (Optional)
+	BelongsTo    *Nullable[string]   `json:"belongsTo,omitempty" yaml:"belongsTo,omitempty" example:"example_value"` // The tag key that will create `belongs_to` relationships (Optional)
+	DependencyOf *Nullable[[]string] `json:"dependencyOf,omitempty" yaml:"dependencyOf,omitempty" example:"[]"`      // The tag keys that will create `dependency_of` relationships (Optional)
+	DependsOn    *Nullable[[]string] `json:"dependsOn,omitempty" yaml:"dependsOn,omitempty" example:"[]"`            // The tag keys that will create `depends_on` relationships (Optional)
 }
 
 // TagUpdateInput Specifies the input fields used to update a tag

--- a/input.go
+++ b/input.go
@@ -95,10 +95,39 @@ type CategoryUpdateInput struct {
 
 // CampaignCreateInput Specifies the input fields used to create a campaign
 type CampaignCreateInput struct {
-	Name         string        `json:"name" yaml:"name" example:"example_value"`                                               // The name of the campaign (Required)
-	OwnerId      ID            `json:"ownerId" yaml:"ownerId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The id of the team that owns the campaign (Required)
-	FilterId     *Nullable[ID] `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter applied to the campaign (Optional)
-	ProjectBrief *string       `json:"projectBrief,omitempty" yaml:"projectBrief,omitempty" example:"example_value"`           // The project brief of the campaign in Markdown (Optional)
+	CheckIdsToCopy *[]ID                  `json:"checkIdsToCopy,omitempty" yaml:"checkIdsToCopy,omitempty" example:"[]"`                  // The IDs of the existing rubric checks to be copied (Optional)
+	FilterId       *Nullable[ID]          `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The ID of the filter applied to this campaign (Optional)
+	Name           string                 `json:"name" yaml:"name" example:"example_value"`                                               // The name of the campaign (Required)
+	OwnerId        ID                     `json:"ownerId" yaml:"ownerId" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                       // The ID of the team that owns this campaign (Required)
+	ProjectBrief   *string                `json:"projectBrief,omitempty" yaml:"projectBrief,omitempty" example:"example_value"`           // The project brief of the campaign (Optional)
+	Reminder       *CampaignReminderInput `json:"reminder,omitempty" yaml:"reminder,omitempty"`                                           // Configuration of an optional campaign reminder (Optional)
+}
+
+// CampaignEndInput Specifies the input fields used to end a campaign and promote checks to the rubric
+type CampaignEndInput struct {
+	ChecksToPromote *[]CheckToPromoteInput `json:"checksToPromote,omitempty" yaml:"checksToPromote,omitempty" example:"[]"` // The list of campaign checks to be promoted to the rubric (Optional)
+	Id              ID                     `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                  // The ID of the campaign to be ended (Required)
+}
+
+// CampaignFilterInput Input to be used to filter campaigns
+type CampaignFilterInput struct {
+	Arg        *Nullable[string]      `json:"arg,omitempty" yaml:"arg,omitempty" example:"example_value"`     // Value to be filtered (Optional)
+	Connective *ConnectiveEnum        `json:"connective,omitempty" yaml:"connective,omitempty" example:"and"` // The logical operator to be used in conjunction with multiple filters (requires predicates to be supplied) (Optional Default: or)
+	Key        *CampaignFilterEnum    `json:"key,omitempty" yaml:"key,omitempty" example:"id"`                // Field to be filtered (Optional)
+	Predicates *[]CampaignFilterInput `json:"predicates,omitempty" yaml:"predicates,omitempty" example:"[]"`  // A list of campaign filter inputs (Optional)
+	Type       *BasicTypeEnum         `json:"type,omitempty" yaml:"type,omitempty" example:"does_not_equal"`  // Type of operation to be applied to value on the field (Optional Default: equals)
+}
+
+// CampaignReminderInput Configuration of an optional campaign reminder
+type CampaignReminderInput struct {
+	Channels            *[]CampaignReminderChannelEnum    `json:"channels,omitempty" yaml:"channels,omitempty" example:"[]"`                                  // The communication channels through which the reminder will be delivered (Optional)
+	DaysOfWeek          *[]DayOfWeekEnum                  `json:"daysOfWeek,omitempty" yaml:"daysOfWeek,omitempty" example:"[]"`                              // A list of weekdays on which the reminders will be delivered. Only available with weekly frequency (Optional)
+	DefaultSlackChannel *Nullable[string]                 `json:"defaultSlackChannel,omitempty" yaml:"defaultSlackChannel,omitempty" example:"example_value"` // The name of the Slack channel that will be notified if a team doesn't have a default Slack contact (Optional)
+	Frequency           int                               `json:"frequency" yaml:"frequency" example:"3"`                                                     // The interval at which reminders will be delivered (Required)
+	FrequencyUnit       CampaignReminderFrequencyUnitEnum `json:"frequencyUnit" yaml:"frequencyUnit" example:"day"`                                           // The time unit of the value in the 'frequency' field (Required)
+	Message             *Nullable[string]                 `json:"message,omitempty" yaml:"message,omitempty" example:"example_value"`                         // The message that will be delivered as the reminder (Optional)
+	TimeOfDay           string                            `json:"timeOfDay" yaml:"timeOfDay" example:"example_value"`                                         // The time of day at which the reminder will be delivered. Format: "HH:MM" (Required)
+	Timezone            string                            `json:"timezone" yaml:"timezone" example:"example_value"`                                           // The timezone at which the timeOfDay field is evaluated (in IANA format (e.g. "America/Chicago")) (Required)
 }
 
 // ChecksCopyToCampaignInput Specifies the input fields for copying checks to a campaign
@@ -107,25 +136,34 @@ type ChecksCopyToCampaignInput struct {
 	CheckIds   []ID `json:"checkIds" yaml:"checkIds"`                                               // The ids of the checks to copy (Required)
 }
 
-// CampaignScheduleUpdateInput Specifies the input fields used to schedule a campaign
+// CampaignScheduleUpdateInput Specifies the input fields used to update a campaign schedule
 type CampaignScheduleUpdateInput struct {
-	Id         ID           `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`      // The id of the campaign to schedule (Required)
-	StartDate  iso8601.Time `json:"startDate" yaml:"startDate" example:"2025-01-01T00:00:00Z"`   // The start date of the campaign (Required)
-	TargetDate iso8601.Time `json:"targetDate" yaml:"targetDate" example:"2025-06-01T00:00:00Z"` // The target end date of the campaign (Required)
+	Id         ID           `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`          // The id of the campaign to be updated (Required)
+	StartDate  iso8601.Time `json:"startDate" yaml:"startDate" example:"2025-01-05T01:00:00.000Z"`   // The date the campaign will start (Required)
+	TargetDate iso8601.Time `json:"targetDate" yaml:"targetDate" example:"2025-01-05T01:00:00.000Z"` // The target date the campaign should end (Required)
+}
+
+// CampaignSendReminderInput Specifies the input fields used to coordinate sending notifications to team members about a campaign
+type CampaignSendReminderInput struct {
+	CustomMessage *Nullable[string]          `json:"customMessage,omitempty" yaml:"customMessage,omitempty" example:"example_value"` // A custom message to include in the notification (Optional)
+	Id            ID                         `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                         // The ID of the campaign about which to notify team members (Required)
+	ReminderTypes []CampaignReminderTypeEnum `json:"reminderTypes" yaml:"reminderTypes" example:"[]"`                                // The list of the types of notifications to be sent (Required)
+	TeamIds       *[]ID                      `json:"teamIds,omitempty" yaml:"teamIds,omitempty" example:"[]"`                        // The list of team IDs to receive the notifications (Optional)
 }
 
 // CampaignUnscheduleInput Specifies the input fields used to unschedule a campaign
 type CampaignUnscheduleInput struct {
-	Id ID `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`
+	Id ID `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the campaign to be unscheduled (Required)
 }
 
 // CampaignUpdateInput Specifies the input fields used to update a campaign
 type CampaignUpdateInput struct {
-	Id           ID            `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                                 // The id of the campaign to be updated (Required)
-	Name         *string       `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                           // The name of the campaign (Optional)
-	OwnerId      *Nullable[ID] `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The id of the team that owns the campaign (Optional)
-	FilterId     *Nullable[ID] `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The id of the filter applied to the campaign (Optional)
-	ProjectBrief *string       `json:"projectBrief,omitempty" yaml:"projectBrief,omitempty" example:"example_value"`           // The project brief of the campaign in Markdown (Optional)
+	FilterId     *Nullable[ID]          `json:"filterId,omitempty" yaml:"filterId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"` // The ID of the filter applied to this campaign (Optional)
+	Id           ID                     `json:"id" yaml:"id" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`                                 // The id of the campaign to be updated (Required)
+	Name         *string                `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                           // The name of the campaign (Optional)
+	OwnerId      *Nullable[ID]          `json:"ownerId,omitempty" yaml:"ownerId,omitempty" example:"Z2lkOi8vc2VydmljZS8xMjM0NTY3ODk"`   // The ID of the team that owns this campaign (Optional)
+	ProjectBrief *string                `json:"projectBrief,omitempty" yaml:"projectBrief,omitempty" example:"example_value"`           // The project brief of the campaign (Optional)
+	Reminder     *CampaignReminderInput `json:"reminder,omitempty" yaml:"reminder,omitempty"`                                           // Configuration of an optional campaign reminder (Optional)
 }
 
 // CheckAlertSourceUsageCreateInput Specifies the input fields used to create an alert source usage check

--- a/object.go
+++ b/object.go
@@ -393,6 +393,14 @@ type ManualCheckFrequency struct {
 	StartingDate       iso8601.Time       // The date that the check will start to evaluate (Required)
 }
 
+// OnCall An on call record for a given source
+type OnCall struct {
+	ExternalEmail string // Email of the user on call (Required)
+	Id            ID     // The ID of the on call (Required)
+	Name          string // Name of the user on call (Required)
+	User          UserId // The associated OpsLevel user record (Optional)
+}
+
 // OwnerRelationshipType The owner relationship for a component type
 type OwnerRelationshipType struct {
 	ManagementRules []RelationshipDefinitionManagementRule // The management rules for the owner relationship (Required)

--- a/object.go
+++ b/object.go
@@ -6,13 +6,13 @@ import "github.com/relvacode/iso8601"
 // AlertSource An alert source that is currently integrated and belongs to the account
 type AlertSource struct {
 	Description string              // The description of the alert source (Optional)
-	ExternalId  string              // The external id of the alert (Required)
+	ExternalId  string              // The external ID of the alert (Required)
 	Id          ID                  // The id of the alert source (Required)
 	Integration IntegrationId       // The integration of the alert source (Optional)
 	Metadata    string              // The metadata of the alert source (Optional)
 	Name        string              // The name of the alert source (Required)
 	Type        AlertSourceTypeEnum // The type of the alert (Required)
-	Url         string              // The url to the alert source (Optional)
+	Url         string              // The URL to the alert source (Optional)
 }
 
 // AlertSourceService An alert source that is connected with a service
@@ -106,7 +106,7 @@ type CheckResult struct {
 	Check        CheckId      // The check of check result (Required)
 	LastUpdated  iso8601.Time // The time the check most recently ran (Required)
 	Message      string       // The check message (Required)
-	Service      ServiceId    // The service of check result (Optional)
+	Service      ServiceId    // The service for the check result (Optional)
 	ServiceAlias string       // The alias for the service (Optional)
 	Status       CheckStatus  // The check status (Required)
 }
@@ -126,14 +126,14 @@ type CheckStats struct {
 
 // CommonVulnerabilityEnumeration A category system for hardware and software weaknesses
 type CommonVulnerabilityEnumeration struct {
-	Identifier string // The identifer of this item in the CVE system (Required)
-	Url        string // The url for this item in the CVE system (Optional)
+	Identifier string // The identifier of this item in the CVE system (Required)
+	Url        string // The URL for this item in the CVE system (Optional)
 }
 
 // CommonWeaknessEnumeration A category system for hardware and software weaknesses
 type CommonWeaknessEnumeration struct {
-	Identifier string // The identifer of this item in the CWE system (Required)
-	Url        string // The url for this item in the CWE system (Optional)
+	Identifier string // The identifier of this item in the CWE system (Required)
+	Url        string // The URL for this item in the CWE system (Optional)
 }
 
 // ComponentTypeId Information about a particular component type
@@ -171,7 +171,7 @@ type ConfigError struct {
 // ConfigFile An OpsLevel config as code definition
 type ConfigFile struct {
 	OwnerType string // The relation for which the config was returned (Required)
-	Yaml      string // The OpsLevel config in yaml format (Required)
+	Yaml      string // The OpsLevel config in YAML format (Required)
 }
 
 // Contact A method of contact for a team
@@ -196,7 +196,7 @@ type CustomActionsTemplate struct {
 type CustomActionsTemplatesAction struct {
 	Description    string                      // A description of what the action should accomplish (Optional)
 	Headers        JSON                        `scalar:"true"` // The headers sent along with the webhook, if any (Optional)
-	HttpMethod     CustomActionsHttpMethodEnum // The HTTP Method used to call the webhook action (Required)
+	HttpMethod     CustomActionsHttpMethodEnum // The HTTP method used to call the webhook action (Required)
 	LiquidTemplate string                      // The liquid template used to generate the data sent to the external action (Optional)
 	Name           string                      // The name of the external action (Required)
 	Url            string                      // The URL of the webhook action (Required)
@@ -244,7 +244,7 @@ type CustomActionsWebhookAction struct {
 	Async          bool                        // Whether the action expects an additional, asynchronous response upon completion (Required)
 	Description    string                      // A description of what the action should accomplish (Optional)
 	Headers        JSON                        `scalar:"true"` // The headers sent along with the webhook, if any (Optional)
-	HttpMethod     CustomActionsHttpMethodEnum // The HTTP Method used to call the webhook action (Required)
+	HttpMethod     CustomActionsHttpMethodEnum // The HTTP method used to call the webhook action (Required)
 	Id             ID                          // The ID of the external action (Required)
 	LiquidTemplate string                      // The liquid template used to generate the data sent to the external action (Optional)
 	Name           string                      // The name of the external action (Required)
@@ -255,33 +255,33 @@ type CustomActionsWebhookAction struct {
 type Deploy struct {
 	AssociatedUser      UserId           // The associated OpsLevel user for the deploy (Optional)
 	Author              string           // The author of the deploy (Optional)
-	CommitAuthorEmail   string           // The email of the commit (Optional)
+	CommitAuthorEmail   string           // The email of the commit author (Optional)
 	CommitAuthorName    string           // The author of the commit (Optional)
 	CommitAuthoringDate iso8601.Time     // The time the commit was authored (Optional)
 	CommitBranch        string           // The branch the commit took place on (Optional)
 	CommitMessage       string           // The commit message associated with the deploy (Optional)
-	CommitSha           string           // The sha associated with the commit of the deploy (Optional)
+	CommitSha           string           // The SHA associated with the commit of the deploy (Optional)
 	CommittedAt         iso8601.Time     // The time the commit happened (Optional)
 	CommitterEmail      string           // The email of the person who created the commit (Optional)
 	CommitterName       string           // The name of the person who created the commit (Optional)
 	DedupId             string           // The deduplication ID provided to prevent duplicate deploys (Optional)
 	DeployNumber        string           // An identifier to keep track of the version of the deploy (Optional)
 	DeployStatus        DeployStatusEnum // The normalized status of the deploy. This is derived from the status field (Optional)
-	DeployUrl           string           // The url the where the deployment can be found (Optional)
+	DeployUrl           string           // The URL where the deployment can be found (Optional)
 	DeployedAt          iso8601.Time     // The time the deployment happened (Optional)
-	DeployerEmail       string           // The email of who is responsible for the deployment (Optional)
-	DeployerId          string           // An external id of who deployed (Optional)
-	DeployerName        string           // The name of who is responsible for the deployment (Optional)
+	DeployerEmail       string           // The email of the person responsible for the deployment (Optional)
+	DeployerId          string           // The external ID of the person who deployed (Optional)
+	DeployerName        string           // The name of the person responsible for the deployment (Optional)
 	Description         string           // The given description of the deploy (Required)
 	Duration            int              // The duration of the deploy (Optional)
-	Environment         string           // The environment in which the deployment happened in (Optional)
+	Environment         string           // The environment in which the deployment happened (Optional)
 	Id                  ID               // The id of the deploy (Required)
 	ProviderName        string           // The integration name of the deploy (Optional)
-	ProviderType        string           // The integration type used the deploy (Optional)
-	ProviderUrl         string           // The url to the deploy integration (Optional)
+	ProviderType        string           // The integration type used by the deploy (Optional)
+	ProviderUrl         string           // The URL to the deploy integration (Optional)
 	Service             ServiceId        // The service object the deploy is attached to (Optional)
-	ServiceAlias        string           // The alias used to associated this deploy to its service (Required)
-	ServiceId           string           // The id the deploy is associated to (Optional)
+	ServiceAlias        string           // The alias used to associate this deploy with its service (Required)
+	ServiceId           string           // The ID of the service the deploy is associated with (Optional)
 	StartedAt           iso8601.Time     // The time the deploy started (Optional)
 	Status              string           // The deployment status (Optional)
 }
@@ -428,7 +428,7 @@ type RelationshipDefinitionMetadata struct {
 	MinItems          int      // The minimum number of records this relationship must associate to the component type. Defaults to 0 (optional) (Optional)
 }
 
-// RelationshipDefinitionType A dynamic definition for a relationship between one catalog entity to another
+// RelationshipDefinitionType A dynamic definition for a relationship between one catalog entity and another
 type RelationshipDefinitionType struct {
 	Alias           string                                 // The programmatic alias that can be used to reference the relationship in OpsLevel tooling (Required)
 	ComponentType   ComponentTypeId                        // The component type that the relationship belongs to (Required)
@@ -469,8 +469,8 @@ type RubricReport struct {
 
 // SBOMGenerationConfiguration The configuration details that explain whether SBOM generation is allowed for the repository
 type SBOMGenerationConfiguration struct {
-	DisabledReason   RepositorySBOMGenerationDisabledReasonEnum // A brief explanation of why SBOM autogeneration is disabled (Optional)
-	Enabled          bool                                       // Whether SBOM autogeneration is enabled through all associated configuration objects (Required)
+	DisabledReason   RepositorySBOMGenerationDisabledReasonEnum // A brief explanation of why SBOM auto-generation is disabled (Optional)
+	Enabled          bool                                       // Whether SBOM auto-generation is enabled through all associated configuration objects (Required)
 	NextGenerationAt iso8601.Time                               // The approximate time at which a new software bill of material will be generated for this repository (Optional)
 	State            RepositorySBOMGenerationConfigEnum         // The configuration option set by the current object (Required)
 }
@@ -599,7 +599,7 @@ type TeamMembership struct {
 	User UserId // User for the membership (Required)
 }
 
-// TeamPropertyDefinition The definition of a property
+// TeamPropertyDefinition The definition of a property that applies to teams
 type TeamPropertyDefinition struct {
 	Alias          string                            // The human-friendly, unique identifier of the property definition (Required)
 	Description    string                            // The description of the property definition (Required)

--- a/object.go
+++ b/object.go
@@ -76,10 +76,10 @@ type CampaignReminder struct {
 	Timezone            string                            // The timezone at which the timeOfDay field is evaluated (in IANA format (e.g. "America/Chicago")) (Required)
 }
 
-// CampaignSendReminderOutcomeTeams Summarizes list of teams returned from attempt to send reminders for their failed campaigns
+// CampaignSendReminderOutcomeTeams Summarizes the list of teams returned from an attempt to send reminders for their failed campaigns
 type CampaignSendReminderOutcomeTeams struct {
 	ReminderType CampaignReminderTypeEnum // The reminder type linked to the attempt at notifying the listed teams (Required)
-	TeamIds      []ID                     // List of team_ids in this group of teams (Optional)
+	TeamIds      []ID                     // List of team IDs in this group of teams (Optional)
 	TotalCount   int                      // Count of number of teams listed (Required)
 }
 

--- a/object.go
+++ b/object.go
@@ -406,6 +406,19 @@ type OwnerRelationshipType struct {
 	ManagementRules []RelationshipDefinitionManagementRule // The management rules for the owner relationship (Required)
 }
 
+// Package A software package belonging to a service or repository
+type Package struct {
+	Id              ID                 // The id of the package (Required)
+	Name            string             // The name of the package (Required)
+	PackageManager  PackageManagerEnum // The package manager type for a software package (Optional)
+	PackageVersions []PackageVersion   // The version of a specific software package (Optional)
+}
+
+// PackageVersion A software package version entry
+type PackageVersion struct {
+	Version string // The version of a software package (Optional)
+}
+
 // SystemRelationshipType The system relationship for a component type
 type SystemRelationshipType struct {
 	ManagementRules []RelationshipDefinitionManagementRule // The management rules for the system relationship (Required)

--- a/on_call.go
+++ b/on_call.go
@@ -1,13 +1,5 @@
 package opslevel
 
-// OnCall A user that is currently on call for a service.
-type OnCall struct {
-	ExternalEmail string  `graphql:"externalEmail"`
-	Id            ID      `graphql:"id"`
-	Name          string  `graphql:"name"`
-	User          *UserId `graphql:"user"`
-}
-
 // OnCallConnection The connection type for OnCall.
 type OnCallConnection struct {
 	Edges      []OnCallEdge `graphql:"edges"`


### PR DESCRIPTION
## Summary

This is one in a series of MR's that attempt to get client-gen back to being the source of truth for our go api schema.

This specific MR does all of the stuff below, but more generally it:
- gets the Campaign types in line with the graphql schema. That means adding missed types, and modifying client gen to permit campaign to be generated
- Does the exact same thing with OnCall
- Adds Package types.

- Campaign structs (`Campaign`, `CampaignConnection`, `CampaignCreateInput`, etc.) were hand-authored directly into the generated files (PRs #565, #611) because client-gen unconditionally excluded anything named `Campaign` from generation, the same way it excludes the genuinely-unimplemented `Group`.
- Fixed that exclusion in client-gen ([OpsLevel/client-gen@14-08-2026-gen-fixes](https://github.com/OpsLevel/client-gen/tree/14-08-2026-gen-fixes)) and regenerated. This brings in `CampaignTeamConnection`, `CampaignEndInput`, `CampaignFilterInput`, `CampaignReminderInput`, `CampaignSendReminderInput`, and refreshed field sets/docs on the existing Campaign types.
- `CampaignUpdateInput.name`/`.projectBrief` and `CampaignCreateInput.projectBrief` are kept as plain `*string` (not the generator's `Nullable[string]` default) — verified against the OpsLevel backend that explicit null is silently dropped on update (`.compact`) or has nothing to clear on create, so the tri-state wrapper would overpromise.
- Separately picked up doc-comment wording fixes surfaced by the same regen (grammar, "api"->"API", "url"->"URL", curly apostrophes, trailing periods) — verified programmatically that every changed line differs only in its trailing comment text, no field/type/tag changes.
- `OnCall` (PR #619) had the same problem as Campaign: hand-authored because `OnCallConnection` needs `edges` (which client-gen's generic `ConnectionBase[T]` can't express), but the whole feature — including the plain `OnCall` struct, which has no edges dependency — got hand-written along with it. Added `OnCallConnection` to client-gen's existing "uses edges, not nodes" exclusion list (same mechanism already used for 4 other connections) and let `OnCall` itself generate normally, removing the duplicate from `on_call.go`.
- Added new `Package`/`PackageVersion`/`PackageConnection` types — no conflicts with existing code, no client-gen changes needed.


## Test plan

- [x] `go vet ./...` passes (build + all tests compile) after each commit
- [x] Diff scoped to one reviewed change per commit; verified programmatically that the wording commit touches only comment text
- [x] No other in-flight schema-regen diffs included

🤖 Generated with [Claude Code](https://claude.com/claude-code)