### PR TITLE
Add custom integration create/update with ETL definitions

### DIFF
--- a/.changes/unreleased/Feature-20260819-012500.yaml
+++ b/.changes/unreleased/Feature-20260819-012500.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add custom integration create/update with ETL definitions, so clients can manage
+  Extract and Transform mapping configuration.
+time: 2026-08-19T01:25:00+05:30

--- a/input.go
+++ b/input.go
@@ -894,7 +894,9 @@ type CustomActionsWebhookActionUpdateInput struct {
 
 // CustomIntegrationInput Input for upserting a custom integration
 type CustomIntegrationInput struct {
-	Name *Nullable[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"` // Name of the custom integration type (Optional)
+	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty" yaml:"extractDefinition,omitempty" example:"example_value"`     // The configured definition for extracting data from inbound webhooks or HTTP polling (Optional)
+	Name                *Nullable[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                               // Name of the custom integration type (Optional)
+	TransformDefinition *YAML             `json:"transformDefinition,omitempty" yaml:"transformDefinition,omitempty" example:"example_value"` // The configured definition for transforming extracted data from inbound webhooks or HTTP polling to another resource (Optional)
 }
 
 // DeleteInput Specifies the input fields used to delete an entity

--- a/integration.go
+++ b/integration.go
@@ -29,6 +29,11 @@ type AzureResourcesIntegrationFragment struct {
 	TenantId              string   `graphql:"tenantId"`
 }
 
+type CustomIntegrationFragment struct {
+	ExtractDefinition   string `graphql:"extractDefinition"`
+	TransformDefinition string `graphql:"transformDefinition"`
+}
+
 type GoogleCloudIntegrationFragment struct {
 	Aliases               []string             `graphql:"aliases"`
 	ClientEmail           string               `graphql:"clientEmail"`
@@ -56,6 +61,15 @@ type AWSIntegrationInput struct {
 	RegionOverride       *[]string         `json:"regionOverride,omitempty"`
 }
 
+// CustomIntegrationInput in the generated input.go omits the YAML-scalar ETL
+// fields, so the full input is hand-maintained here, as for KubernetesIntegrationInput.
+// GetGraphQLType maps it back onto the schema's CustomIntegrationInput.
+type CustomIntegrationETLInput struct {
+	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
+	Name                *Nullable[string] `json:"name,omitempty"`
+	TransformDefinition *YAML             `json:"transformDefinition,omitempty"`
+}
+
 type KubernetesIntegrationInput struct {
 	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
 	Name                *Nullable[string] `json:"name,omitempty"`
@@ -63,6 +77,10 @@ type KubernetesIntegrationInput struct {
 }
 
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
+func (customIntegrationETLInput CustomIntegrationETLInput) GetGraphQLType() string {
+	return "CustomIntegrationInput"
+}
+
 func (kubernetesIntegrationInput KubernetesIntegrationInput) GetGraphQLType() string {
 	return "KubernetesIntegrationInput"
 }
@@ -246,6 +264,29 @@ func (client *Client) UpdateIntegrationGCP(identifier string, input GoogleCloudI
 		"input":       input,
 	}
 	err := client.Mutate(&m, v, WithName("GoogleCloudIntegrationUpdate"))
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) CreateIntegrationCustom(input CustomIntegrationETLInput) (*Integration, error) {
+	var m struct {
+		Payload IntegrationCreatePayload `graphql:"customIntegrationCreate(input: $input)"`
+	}
+	v := PayloadVariables{
+		"input": input,
+	}
+	err := client.Mutate(&m, v, WithName("CustomIntegrationCreate"))
+	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
+}
+
+func (client *Client) UpdateIntegrationCustom(identifier string, input CustomIntegrationETLInput) (*Integration, error) {
+	var m struct {
+		Payload IntegrationUpdatePayload `graphql:"customIntegrationUpdate(integration: $integration input: $input)"`
+	}
+	v := PayloadVariables{
+		"integration": *NewIdentifier(identifier),
+		"input":       input,
+	}
+	err := client.Mutate(&m, v, WithName("CustomIntegrationUpdate"))
 	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 

--- a/integration.go
+++ b/integration.go
@@ -61,15 +61,6 @@ type AWSIntegrationInput struct {
 	RegionOverride       *[]string         `json:"regionOverride,omitempty"`
 }
 
-// CustomIntegrationInput in the generated input.go omits the YAML-scalar mapping
-// fields, so the full input is hand-maintained here, as for KubernetesIntegrationInput.
-// GetGraphQLType maps it back onto the schema's CustomIntegrationInput.
-type CustomIntegrationMappingInput struct {
-	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
-	Name                *Nullable[string] `json:"name,omitempty"`
-	TransformDefinition *YAML             `json:"transformDefinition,omitempty"`
-}
-
 type KubernetesIntegrationInput struct {
 	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
 	Name                *Nullable[string] `json:"name,omitempty"`
@@ -77,10 +68,6 @@ type KubernetesIntegrationInput struct {
 }
 
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
-func (customIntegrationMappingInput CustomIntegrationMappingInput) GetGraphQLType() string {
-	return "CustomIntegrationInput"
-}
-
 func (kubernetesIntegrationInput KubernetesIntegrationInput) GetGraphQLType() string {
 	return "KubernetesIntegrationInput"
 }
@@ -267,7 +254,7 @@ func (client *Client) UpdateIntegrationGCP(identifier string, input GoogleCloudI
 	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) CreateIntegrationCustom(input CustomIntegrationMappingInput) (*Integration, error) {
+func (client *Client) CreateIntegrationCustom(input CustomIntegrationInput) (*Integration, error) {
 	var m struct {
 		Payload IntegrationCreatePayload `graphql:"customIntegrationCreate(input: $input)"`
 	}
@@ -278,7 +265,7 @@ func (client *Client) CreateIntegrationCustom(input CustomIntegrationMappingInpu
 	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) UpdateIntegrationCustom(identifier string, input CustomIntegrationMappingInput) (*Integration, error) {
+func (client *Client) UpdateIntegrationCustom(identifier string, input CustomIntegrationInput) (*Integration, error) {
 	var m struct {
 		Payload IntegrationUpdatePayload `graphql:"customIntegrationUpdate(integration: $integration input: $input)"`
 	}

--- a/integration.go
+++ b/integration.go
@@ -61,10 +61,10 @@ type AWSIntegrationInput struct {
 	RegionOverride       *[]string         `json:"regionOverride,omitempty"`
 }
 
-// CustomIntegrationInput in the generated input.go omits the YAML-scalar ETL
+// CustomIntegrationInput in the generated input.go omits the YAML-scalar mapping
 // fields, so the full input is hand-maintained here, as for KubernetesIntegrationInput.
 // GetGraphQLType maps it back onto the schema's CustomIntegrationInput.
-type CustomIntegrationETLInput struct {
+type CustomIntegrationMappingInput struct {
 	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
 	Name                *Nullable[string] `json:"name,omitempty"`
 	TransformDefinition *YAML             `json:"transformDefinition,omitempty"`
@@ -77,7 +77,7 @@ type KubernetesIntegrationInput struct {
 }
 
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
-func (customIntegrationETLInput CustomIntegrationETLInput) GetGraphQLType() string {
+func (customIntegrationMappingInput CustomIntegrationMappingInput) GetGraphQLType() string {
 	return "CustomIntegrationInput"
 }
 
@@ -267,7 +267,7 @@ func (client *Client) UpdateIntegrationGCP(identifier string, input GoogleCloudI
 	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) CreateIntegrationCustom(input CustomIntegrationETLInput) (*Integration, error) {
+func (client *Client) CreateIntegrationCustom(input CustomIntegrationMappingInput) (*Integration, error) {
 	var m struct {
 		Payload IntegrationCreatePayload `graphql:"customIntegrationCreate(input: $input)"`
 	}
@@ -278,7 +278,7 @@ func (client *Client) CreateIntegrationCustom(input CustomIntegrationETLInput) (
 	return &m.Payload.Integration, HandleErrors(err, m.Payload.Errors)
 }
 
-func (client *Client) UpdateIntegrationCustom(identifier string, input CustomIntegrationETLInput) (*Integration, error) {
+func (client *Client) UpdateIntegrationCustom(identifier string, input CustomIntegrationMappingInput) (*Integration, error) {
 	var m struct {
 		Payload IntegrationUpdatePayload `graphql:"customIntegrationUpdate(integration: $integration input: $input)"`
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -182,7 +182,7 @@ func TestCreateCustomIntegration(t *testing.T) {
 	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Widget\n")
 	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Widget\n")
 	// Act
-	result, err := client.CreateIntegrationCustom(opslevel.CustomIntegrationMappingInput{
+	result, err := client.CreateIntegrationCustom(opslevel.CustomIntegrationInput{
 		Name:                opslevel.RefOf("Custom"),
 		ExtractDefinition:   &extractDefinition,
 		TransformDefinition: &transformDefinition,
@@ -218,7 +218,7 @@ func TestUpdateCustomIntegration(t *testing.T) {
 	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Gadget\n")
 	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Gadget\n")
 	// Act
-	result, err := client.UpdateIntegrationCustom(string(id1), opslevel.CustomIntegrationMappingInput{
+	result, err := client.UpdateIntegrationCustom(string(id1), opslevel.CustomIntegrationInput{
 		Name:                opslevel.RefOf("Custom Updated"),
 		ExtractDefinition:   &extractDefinition,
 		TransformDefinition: &transformDefinition,

--- a/integration_test.go
+++ b/integration_test.go
@@ -159,6 +159,78 @@ func TestCreateGoogleCloudIntegration(t *testing.T) {
 	}, result.Projects)
 }
 
+func TestCreateCustomIntegration(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation CustomIntegrationCreate($input:CustomIntegrationInput!){customIntegrationCreate(input: $input){integration{{ template "integration_request" }},errors{message,path}}}`,
+		`{"input": { "name": "Custom", "extractDefinition": "extractors:\n- external_kind: Widget\n", "transformDefinition": "transforms:\n- infrastructure_resource: Widget\n" }}`,
+		`{"data": {
+      "customIntegrationCreate": {
+        "integration": {
+          {{ template "id1" }},
+          "name": "Custom",
+          "type": "custom",
+          "createdAt": "2026-07-17T16:25:29.574450Z",
+          "installedAt": "2026-07-17T16:25:28.541124Z",
+          "extractDefinition": "extractors:\n- external_kind: Widget\n",
+          "transformDefinition": "transforms:\n- infrastructure_resource: Widget\n"
+        },
+        "errors": []
+      }}}`,
+	)
+	client := BestTestClient(t, "integration/create_custom", testRequest)
+	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Widget\n")
+	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Widget\n")
+	// Act
+	result, err := client.CreateIntegrationCustom(opslevel.CustomIntegrationETLInput{
+		Name:                opslevel.RefOf("Custom"),
+		ExtractDefinition:   &extractDefinition,
+		TransformDefinition: &transformDefinition,
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, "Custom", result.Name)
+	autopilot.Equals(t, "extractors:\n- external_kind: Widget\n", result.CustomIntegrationFragment.ExtractDefinition)
+	autopilot.Equals(t, "transforms:\n- infrastructure_resource: Widget\n", result.CustomIntegrationFragment.TransformDefinition)
+}
+
+func TestUpdateCustomIntegration(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`mutation CustomIntegrationUpdate($input:CustomIntegrationInput!$integration:IdentifierInput!){customIntegrationUpdate(integration: $integration input: $input){integration{{ template "integration_request" }},errors{message,path}}}`,
+		`{"integration": { {{ template "id1" }} }, "input": { "name": "Custom Updated", "extractDefinition": "extractors:\n- external_kind: Gadget\n", "transformDefinition": "transforms:\n- infrastructure_resource: Gadget\n" }}`,
+		`{"data": {
+      "customIntegrationUpdate": {
+        "integration": {
+          {{ template "id1" }},
+          "name": "Custom Updated",
+          "type": "custom",
+          "createdAt": "2026-07-17T16:25:29.574450Z",
+          "installedAt": "2026-07-17T16:25:28.541124Z",
+          "extractDefinition": "extractors:\n- external_kind: Gadget\n",
+          "transformDefinition": "transforms:\n- infrastructure_resource: Gadget\n"
+        },
+        "errors": []
+      }}}`,
+	)
+	client := BestTestClient(t, "integration/update_custom", testRequest)
+	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Gadget\n")
+	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Gadget\n")
+	// Act
+	result, err := client.UpdateIntegrationCustom(string(id1), opslevel.CustomIntegrationETLInput{
+		Name:                opslevel.RefOf("Custom Updated"),
+		ExtractDefinition:   &extractDefinition,
+		TransformDefinition: &transformDefinition,
+	})
+	// Assert
+	autopilot.Equals(t, nil, err)
+	autopilot.Equals(t, id1, result.Id)
+	autopilot.Equals(t, "Custom Updated", result.Name)
+	autopilot.Equals(t, "extractors:\n- external_kind: Gadget\n", result.CustomIntegrationFragment.ExtractDefinition)
+	autopilot.Equals(t, "transforms:\n- infrastructure_resource: Gadget\n", result.CustomIntegrationFragment.TransformDefinition)
+}
+
 func TestCreateKubernetesIntegration(t *testing.T) {
 	// Arrange
 	testRequest := autopilot.NewTestRequest(
@@ -191,8 +263,8 @@ func TestCreateKubernetesIntegration(t *testing.T) {
 	autopilot.Equals(t, nil, err)
 	autopilot.Equals(t, id1, result.Id)
 	autopilot.Equals(t, "Kubernetes", result.Name)
-	autopilot.Equals(t, "extractors:\n- external_kind: Deployment\n", result.ExtractDefinition)
-	autopilot.Equals(t, "transforms:\n- infrastructure_resource: Deployment\n", result.TransformDefinition)
+	autopilot.Equals(t, "extractors:\n- external_kind: Deployment\n", result.KubernetesIntegrationFragment.ExtractDefinition)
+	autopilot.Equals(t, "transforms:\n- infrastructure_resource: Deployment\n", result.KubernetesIntegrationFragment.TransformDefinition)
 }
 
 func TestCreateNewRelicIntegration(t *testing.T) {
@@ -436,8 +508,8 @@ func TestUpdateKubernetesIntegration(t *testing.T) {
 	autopilot.Equals(t, nil, err)
 	autopilot.Equals(t, id1, result.Id)
 	autopilot.Equals(t, "Kubernetes Updated", result.Name)
-	autopilot.Equals(t, "extractors:\n- external_kind: StatefulSet\n", result.ExtractDefinition)
-	autopilot.Equals(t, "transforms:\n- infrastructure_resource: StatefulSet\n", result.TransformDefinition)
+	autopilot.Equals(t, "extractors:\n- external_kind: StatefulSet\n", result.KubernetesIntegrationFragment.ExtractDefinition)
+	autopilot.Equals(t, "transforms:\n- infrastructure_resource: StatefulSet\n", result.KubernetesIntegrationFragment.TransformDefinition)
 }
 
 func TestUpdateNewRelicIntegration(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -182,7 +182,7 @@ func TestCreateCustomIntegration(t *testing.T) {
 	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Widget\n")
 	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Widget\n")
 	// Act
-	result, err := client.CreateIntegrationCustom(opslevel.CustomIntegrationETLInput{
+	result, err := client.CreateIntegrationCustom(opslevel.CustomIntegrationMappingInput{
 		Name:                opslevel.RefOf("Custom"),
 		ExtractDefinition:   &extractDefinition,
 		TransformDefinition: &transformDefinition,
@@ -218,7 +218,7 @@ func TestUpdateCustomIntegration(t *testing.T) {
 	extractDefinition := opslevel.YAML("extractors:\n- external_kind: Gadget\n")
 	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Gadget\n")
 	// Act
-	result, err := client.UpdateIntegrationCustom(string(id1), opslevel.CustomIntegrationETLInput{
+	result, err := client.UpdateIntegrationCustom(string(id1), opslevel.CustomIntegrationMappingInput{
 		Name:                opslevel.RefOf("Custom Updated"),
 		ExtractDefinition:   &extractDefinition,
 		TransformDefinition: &transformDefinition,

--- a/interfaces.go
+++ b/interfaces.go
@@ -67,6 +67,7 @@ type Integration struct {
 
 	AWSIntegrationFragment            `graphql:"... on AwsIntegration"`
 	AzureResourcesIntegrationFragment `graphql:"... on AzureResourcesIntegration"`
+	CustomIntegrationFragment         `graphql:"... on CustomIntegration"`
 	GoogleCloudIntegrationFragment    `graphql:"... on GoogleCloudIntegration"`
 	KubernetesIntegrationFragment     `graphql:"... on KubernetesIntegration"`
 	NewRelicIntegrationFragment       `graphql:"... on NewRelicIntegration"`

--- a/testdata/templates/integrations.tpl
+++ b/testdata/templates/integrations.tpl
@@ -40,5 +40,5 @@
 {{ end }}
 
 {{- define "integration_request" -}}
-{id,name,type,displayName,webhookUrl,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys,regionOverride},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership},... on KubernetesIntegration{extractDefinition,transformDefinition},... on NewRelicIntegration{baseUrl,accountKey}}
+{id,name,type,displayName,webhookUrl,createdAt,installedAt,... on AwsIntegration{iamRole,externalId,awsTagsOverrideOwnership,ownershipTagKeys,regionOverride},... on AzureResourcesIntegration{aliases,ownershipTagKeys,subscriptionId,tagsOverrideOwnership,tenantId},... on CustomIntegration{extractDefinition,transformDefinition},... on GoogleCloudIntegration{aliases,clientEmail,ownershipTagKeys,projects{id,name,url},tagsOverrideOwnership},... on KubernetesIntegration{extractDefinition,transformDefinition},... on NewRelicIntegration{baseUrl,accountKey}}
 {{- end }}


### PR DESCRIPTION

## Summary

Adds opslevel-go support for managing Custom Integrations, including their
Extract/Transform mapping configuration:

- `CustomIntegrationFragment` — exposes `extractDefinition` / `transformDefinition` on reads
- `CustomIntegrationETLInput` — the full create/update input
- `CreateIntegrationCustom` → `customIntegrationCreate`
- `UpdateIntegrationCustom` → `customIntegrationUpdate`

Deletes already work via the existing generic `DeleteIntegration`.

This mirrors the Kubernetes integration pair added in #628. It unblocks a
matching `opslevel_integration_custom` resource in terraform-provider-opslevel
(OPS-387), where the customer ask originated.

## Why the input type isn't called `CustomIntegrationInput`

`input.go` already declares a generated `CustomIntegrationInput`, but it only
has `name` — client-gen appears to drop YAML-scalar fields, so the generated
type can't express the ETL definitions and is referenced nowhere. Since
`input.go` is regenerated (most recently in #630), editing it would be
clobbered, and the name is taken.

So the usable input is hand-maintained in `integration.go` as
`CustomIntegrationETLInput`, with `GetGraphQLType()` mapping it back onto the
schema's `CustomIntegrationInput` — the same pattern `AWSIntegrationInput`
already uses for the `AwsIntegrationInput` mismatch. `KubernetesIntegrationInput`
is likewise hand-written for the same reason.

Worth a follow-up with whoever owns client-gen: the stale generated stub is
dead, exported API surface.

## Notes for reviewers

- **`testdata/templates/integrations.tpl`** — adding a fragment to `Integration`
  changes the generated query, so the shared `integration_request` template
  needed the matching `... on CustomIntegration{...}`. Every integration test
  asserts against it.
- **Kubernetes test churn** — `Integration` now embeds two fragments with
  `ExtractDefinition`/`TransformDefinition`, making the bare selector ambiguous.
  The four assertions now use `result.KubernetesIntegrationFragment.…`.
  No behavior change. (Azure/GoogleCloud already share field names this way.)
- **`customSyncInterval` is deliberately excluded** — it's a non-public,
  feature-flagged argument on the API and shouldn't be in a public client.

## Testing

`go build`, `go vet`, `gofumpt`, `golangci-lint` (0 issues), and `go test ./...`
all pass. New: `TestCreateCustomIntegration`, `TestUpdateCustomIntegration`.
