### PR TITLE
Fix CustomIntegrationInput.Name type, add generated KubernetesIntegrationInput

### DIFF
--- a/input.go
+++ b/input.go
@@ -894,9 +894,9 @@ type CustomActionsWebhookActionUpdateInput struct {
 
 // CustomIntegrationInput Input for upserting a custom integration
 type CustomIntegrationInput struct {
-	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty" yaml:"extractDefinition,omitempty" example:"example_value"`     // The configured definition for extracting data from inbound webhooks or HTTP polling (Optional)
-	Name                *Nullable[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                               // Name of the custom integration type (Optional)
-	TransformDefinition *YAML             `json:"transformDefinition,omitempty" yaml:"transformDefinition,omitempty" example:"example_value"` // The configured definition for transforming extracted data from inbound webhooks or HTTP polling to another resource (Optional)
+	ExtractDefinition   *YAML   `json:"extractDefinition,omitempty" yaml:"extractDefinition,omitempty" example:"extractors:\n- external_kind: Widget\n"`     // The configured definition for extracting data from inbound webhooks or HTTP polling (Optional)
+	Name                *string `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                                                        // Name of the custom integration type (Optional)
+	TransformDefinition *YAML   `json:"transformDefinition,omitempty" yaml:"transformDefinition,omitempty" example:"extractors:\n- external_kind: Widget\n"` // The configured definition for transforming extracted data from inbound webhooks or HTTP polling to another resource (Optional)
 }
 
 // DeleteInput Specifies the input fields used to delete an entity
@@ -999,6 +999,13 @@ type InfrastructureResourceProviderDataInput struct {
 // InfrastructureResourceSchemaInput Specifies the schema for an infrastructure resource
 type InfrastructureResourceSchemaInput struct {
 	Type string `json:"type" yaml:"type" example:"example_value"` // The type of the infrastructure resource (Required)
+}
+
+// KubernetesIntegrationInput Specifies the input fields used to create and update a Kubernetes integration
+type KubernetesIntegrationInput struct {
+	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty" yaml:"extractDefinition,omitempty" example:"extractors:\n- external_kind: Widget\n"`     // The configured definition for extracting data from inbound webhooks or HTTP polling (Optional)
+	Name                *Nullable[string] `json:"name,omitempty" yaml:"name,omitempty" example:"example_value"`                                                        // The name of the integration (Optional)
+	TransformDefinition *YAML             `json:"transformDefinition,omitempty" yaml:"transformDefinition,omitempty" example:"extractors:\n- external_kind: Widget\n"` // The configured definition for transforming extracted data from inbound webhooks or HTTP polling to another resource (Optional)
 }
 
 // LevelCreateInput Specifies the input fields used to create a level. The new level will be added as the highest level (greatest level index)

--- a/integration.go
+++ b/integration.go
@@ -61,16 +61,7 @@ type AWSIntegrationInput struct {
 	RegionOverride       *[]string         `json:"regionOverride,omitempty"`
 }
 
-type KubernetesIntegrationInput struct {
-	ExtractDefinition   *YAML             `json:"extractDefinition,omitempty"`
-	Name                *Nullable[string] `json:"name,omitempty"`
-	TransformDefinition *YAML             `json:"transformDefinition,omitempty"`
-}
-
 func (awsIntegrationInput AWSIntegrationInput) GetGraphQLType() string { return "AwsIntegrationInput" }
-func (kubernetesIntegrationInput KubernetesIntegrationInput) GetGraphQLType() string {
-	return "KubernetesIntegrationInput"
-}
 
 func (newRelicIntegrationInput NewRelicIntegrationInput) GetGraphQLType() string {
 	return "NewRelicIntegrationInput"

--- a/integration_test.go
+++ b/integration_test.go
@@ -183,7 +183,7 @@ func TestCreateCustomIntegration(t *testing.T) {
 	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Widget\n")
 	// Act
 	result, err := client.CreateIntegrationCustom(opslevel.CustomIntegrationInput{
-		Name:                opslevel.RefOf("Custom"),
+		Name:                opslevel.NewString("Custom"),
 		ExtractDefinition:   &extractDefinition,
 		TransformDefinition: &transformDefinition,
 	})
@@ -219,7 +219,7 @@ func TestUpdateCustomIntegration(t *testing.T) {
 	transformDefinition := opslevel.YAML("transforms:\n- infrastructure_resource: Gadget\n")
 	// Act
 	result, err := client.UpdateIntegrationCustom(string(id1), opslevel.CustomIntegrationInput{
-		Name:                opslevel.RefOf("Custom Updated"),
+		Name:                opslevel.NewString("Custom Updated"),
 		ExtractDefinition:   &extractDefinition,
 		TransformDefinition: &transformDefinition,
 	})


### PR DESCRIPTION
## Summary
- `CustomIntegrationInput.Name` is now `*string` instead of `*Nullable[string]`. The backend declares `validates: { allow_null: false, allow_blank: false }` on this field, so an explicit `null` is rejected outright — confirmed against the backend's own `"fails if name is null"` test in `custom_integration_create_test.rb`.
- Adds the generated `KubernetesIntegrationInput` to `input.go`, replacing the hand-maintained duplicate that previously lived in `integration.go` (client-gen had never generated this type because the `YAML` scalar had no example value, so it silently produced nothing for it — see companion fix in `client-gen`). `KubernetesIntegrationInput.Name` stays `*Nullable[string]`: it has no `allow_null` validator, and sending `null` was verified (via `kubernetesIntegrationCreate`/`kubernetesIntegrationUpdate` mutation tests) to be silently reset to a computed default name rather than rejected.
- Updates `integration_test.go` to construct `CustomIntegrationInput.Name` with `NewString` instead of `RefOf`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all passing, including `TestCreateCustomIntegration`, `TestUpdateCustomIntegration`, `TestCreateKubernetesIntegration`, `TestUpdateKubernetesIntegration`
- [x] Verified both field-nullability behaviors empirically against the backend's own test suite (not just inferred from schema declarations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)