### PR TITLE
Add ListTeamsIncludingProperties for batched team metadata reads

### DIFF
--- a/.changes/unreleased/Feature-20260825-165216.yaml
+++ b/.changes/unreleased/Feature-20260825-165216.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add ListTeamsIncludingProperties, which returns teams with their tags and custom
+  properties loaded in one request per page rather than one request per team.
+time: 2026-08-25T16:52:16+05:30

--- a/team.go
+++ b/team.go
@@ -409,6 +409,77 @@ func (client *Client) ListTeams(variables *PayloadVariables) (*TeamConnection, e
 	return &q.Account.Teams, nil
 }
 
+// TeamWithProperties is a Team with its custom properties already loaded.
+//
+// Team.Properties is excluded from generated queries with `graphql:"-"`, so callers that
+// need properties for many teams would otherwise pay one extra request per team.
+// Embedding Team and redeclaring the field selects the connection inline instead.
+type TeamWithProperties struct {
+	Team
+	Properties PropertiesConnection `graphql:"properties"`
+}
+
+// ListTeamsIncludingProperties returns every team with its tags and properties populated,
+// costing one request per page of teams rather than one request per team.
+//
+// The inlined properties connection is selected without pagination arguments, so the API
+// returns its first 100 entries; any team holding more than that is topped up on its own.
+func (client *Client) ListTeamsIncludingProperties(variables *PayloadVariables) ([]TeamWithProperties, error) {
+	if variables == nil {
+		variables = client.InitialPageVariablesPointer()
+	}
+
+	teams := make([]TeamWithProperties, 0)
+	for {
+		var q struct {
+			Account struct {
+				Teams struct {
+					Nodes    []TeamWithProperties
+					PageInfo PageInfo
+				} `graphql:"teams(after: $after, first: $first)"`
+			}
+		}
+		if err := client.Query(&q, *variables, WithName("TeamListIncludingProperties")); err != nil {
+			return nil, err
+		}
+		teams = append(teams, q.Account.Teams.Nodes...)
+		if !q.Account.Teams.PageInfo.HasNextPage {
+			break
+		}
+		(*variables)["after"] = q.Account.Teams.PageInfo.End
+	}
+
+	for i := range teams {
+		// Hydrate covers the tags and memberships that came back inline; it issues no
+		// request unless one of those connections actually spilled past its first page.
+		if err := teams[i].Hydrate(client); err != nil {
+			return nil, err
+		}
+		if err := teams[i].hydrateProperties(client); err != nil {
+			return nil, err
+		}
+	}
+	return teams, nil
+}
+
+// hydrateProperties collects any pages of properties beyond the first that the list query
+// already returned. It issues no request for a team holding 100 properties or fewer.
+func (team *TeamWithProperties) hydrateProperties(client *Client) error {
+	// Point the embedded Team at the inlined connection so both views agree, and so
+	// GetProperties appends later pages onto the nodes already returned.
+	team.Team.Properties = &team.Properties
+
+	if !team.Properties.PageInfo.HasNextPage {
+		team.Properties.TotalCount = len(team.Properties.Nodes)
+		return nil
+	}
+
+	variables := client.InitialPageVariablesPointer()
+	(*variables)["after"] = team.Properties.PageInfo.End
+	_, err := team.GetProperties(client, variables)
+	return err
+}
+
 func (client *Client) ListTeamsWithManager(email string, variables *PayloadVariables) (*TeamConnection, error) {
 	var q struct {
 		Account struct {

--- a/team_test.go
+++ b/team_test.go
@@ -1024,3 +1024,78 @@ func TestSearchTeams(t *testing.T) {
 	autopilot.Equals(t, "DevOps", result[0].Name)
 	autopilot.Equals(t, "Own Infra & Tools.", result[0].Responsibilities)
 }
+
+// ListTeamsIncludingProperties exists so that reading properties for many teams costs one
+// request per page instead of one per team. Registering a single request is what proves
+// that: the harness fails on any request it was not told to expect, so a per-team
+// GetProperties fan-out would surface here as an unregistered call.
+func TestListTeamsIncludingProperties(t *testing.T) {
+	// Arrange
+	testRequest := autopilot.NewTestRequest(
+		`query TeamListIncludingProperties($after:String!$first:Int!){account{teams(after: $after, first: $first){nodes{alias,id,aliases,managedAliases,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,manager{id,email,name,contacts{address,displayName,displayType,externalId,id,isDefault,type},htmlUrl,provisionedBy,role,tags{nodes{id,key,value},{{ template "pagination_request" }}},teams{nodes{alias,id},{{ template "pagination_request" }}}},memberships{nodes{role,team{alias,id},user{id,email,name}},{{ template "pagination_request" }}},name,parentTeam{alias,id},responsibilities,tags{nodes{id,key,value},{{ template "pagination_request" }}},properties{nodes{definition{id,aliases},locked,owner{__typename,... on Team{alias,id},... on Service{id,aliases}},validationErrors{message,path},value},{{ template "pagination_request" }}}},{{ template "pagination_request" }}}}}`,
+		`{{ template "pagination_initial_query_variables" }}`,
+		`{ "data": {
+      "account": {
+        "teams": {
+          "nodes": [
+            {
+              "alias": "devops",
+              "aliases": [ "devops" ],
+              "contacts": [],
+              {{ template "id1" }},
+              "name": "DevOps",
+              "responsibilities": "Own Infra & Tools.",
+              "tags": {
+                "nodes": [ {{ template "tag1" }}, {{ template "tag2" }} ],
+                {{ template "no_pagination_response" }}
+              },
+              "properties": {
+                "nodes": [ {{ template "team_properties_page_1" }} ],
+                {{ template "no_pagination_response" }}
+              }
+            },
+            {
+              "alias": "developers",
+              "aliases": [ "developers" ],
+              "contacts": [],
+              {{ template "id2" }},
+              "name": "Developers",
+              "responsibilities": null,
+              "tags": {
+                "nodes": [ {{ template "tag3" }} ],
+                {{ template "no_pagination_response" }}
+              },
+              "properties": {
+                "nodes": [],
+                {{ template "no_pagination_response" }}
+              }
+            }
+          ],
+          {{ template "no_pagination_response" }}
+        }
+      }
+    }}`,
+	)
+	client := BestTestClient(t, "team/list_including_properties", testRequest)
+
+	// Act
+	result, err := client.ListTeamsIncludingProperties(nil)
+
+	// Assert
+	autopilot.Ok(t, err)
+	autopilot.Equals(t, 2, len(result))
+
+	autopilot.Equals(t, "devops", result[0].Alias)
+	autopilot.Equals(t, 2, len(result[0].Tags.Nodes))
+	autopilot.Equals(t, "dev", result[0].Tags.Nodes[0].Key)
+	autopilot.Equals(t, 1, len(result[0].Properties.Nodes))
+	autopilot.Equals(t, 1, result[0].Properties.TotalCount)
+	autopilot.Equals(t, "true", string(*result[0].Properties.Nodes[0].Value))
+
+	autopilot.Equals(t, "developers", result[1].Alias)
+	autopilot.Equals(t, 1, len(result[1].Tags.Nodes))
+	autopilot.Equals(t, 0, len(result[1].Properties.Nodes))
+
+	// The embedded Team should expose the same properties the inlined field returned.
+	autopilot.Equals(t, 1, len(result[0].Team.Properties.Nodes))
+}


### PR DESCRIPTION
### Problem

`Team.Properties` is tagged `graphql:"-"`, so it is never selected by generated
queries. Any caller that wants properties for a list of teams has to call
`(*Team).GetProperties` per team.

For the Terraform provider's `opslevel_teams` data source that is one request
per team. Measured against a 263-team account, the per-team approach issued
~266 requests and took **26 seconds**, close enough to the provider's 30s
client timeout that one of two runs died mid-read. It is not viable at
customer scale.

### Solution

`ListTeamsIncludingProperties` selects the properties connection inline
alongside the team list, so listing every team costs **one request per page**
instead of one per team. Same account, same data: **3 requests, under a
second** end to end through the provider.

`TeamWithProperties` embeds `Team` and redeclares `Properties` with a graphql
tag. Go field shadowing means the embedded `graphql:"-"` field is skipped and
ours is selected, so the query asks for `properties` exactly once. That is
subtle enough to be worth a guard, so `TestListTeamsIncludingProperties`
asserts the full constructed query string.

Because the test registers a **single** request and the autopilot harness fails
on any request it was not told to expect, a per-team fan-out regression would
surface as an unregistered call rather than silently passing.

Tags and memberships are completed by the existing `Team.Hydrate`, which issues
no request unless a connection actually spills past its first page. The inlined
properties connection is selected without pagination arguments, so the API
returns its first 100; a team holding more than that is topped up individually.

**Alternatives considered**

- *Remove `graphql:"-"` from `Team.Properties`.* Simplest, but it would make
  every existing Team query heavier for every consumer. Rejected.
- *Implement this in the Terraform provider.* Works, but couples the provider
  to an opslevel-go internal modeling decision and leaves other consumers
  (`opslevel-mcp` calls `ListTeams` too) to reinvent it. Rejected in favour of
  fixing it at the client layer.
- *Naming.* Deliberately **not** `ListTeamsWithProperties` — every existing
  `ListXWith*` in this repo means *filtered by* (`ListTeamsWithManager`,
  `ListServicesWithTier`), so that name would read as "teams that have
  properties".

**No regression by construction:** the diff is 146 insertions and 0 deletions.
Not one existing line changed.

### Noted but not fixed here

`ListTeams` only calls `Hydrate` on nodes from its recursive call, so teams on
the **first** page are never hydrated. With a default page size of 500, that
means most accounts get no hydration at all: `Responsibilities` stays
HTML-escaped and `TotalCount` stays 0. The same pattern appears in 17 places
across 5 files. Filing separately, since fixing it changes observable values
for every existing consumer and does not belong in an additive PR.

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Does this change require a Terraform schema change?
  - Yes — OpsLevel/terraform-provider-opslevel PR for OPS-27, which consumes this and must merge after this releases.
- [x] Make a changie entry that explains the customer facing outcome of this change