### PR TITLE
Stop changie-gen from creating duplicate changelog entries

### DIFF
--- a/.github/workflows/changie-gen.yml
+++ b/.github/workflows/changie-gen.yml
@@ -9,9 +9,18 @@ permissions:
   contents: write
   pull-requests: read
 
+# Serialize runs per PR. Without this, two runs can both pass the
+# "does a changelog already exist?" check before either has pushed one.
+concurrency:
+  group: changie-gen-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   generate-changelog:
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    # React only to the 'dependencies' label being added. Checking
+    # contains(labels.*.name, 'dependencies') instead re-runs the job for every
+    # later label Dependabot applies, once per label.
+    if: github.event.label.name == 'dependencies'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch that Dependabot labeled
@@ -19,16 +28,24 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
+        # The check below needs the base branch and enough history for a
+        # merge-base. The default shallow, single-ref checkout has neither.
+        fetch-depth: 0
 
     - name: Check if changelog file exists already
       shell: bash
       id: changelog_check
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        if [[ -n $(git diff --name-only main -- .changes/unreleased/*.yaml) ]]; then
-          echo "exists=true" >> $GITHUB_OUTPUT
+        # Fail loudly rather than silently falling through to "create a new
+        # one", which is how this check used to mask its own errors.
+        set -euo pipefail
+        if [[ -n "$(git diff --name-only "origin/${BASE_REF}...HEAD" -- .changes/unreleased/)" ]]; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
           echo "Changelog already exists for this PR, skip creating a new one"
         else
-          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "exists=false" >> "$GITHUB_OUTPUT"
           echo "No changelog exists for this PR, creating a new one"
         fi
 
@@ -49,9 +66,14 @@ jobs:
       if: steps.changelog_check.outputs.exists == 'false'
       shell: bash
       run: |
+        set -euo pipefail
         git config user.name "OpsLevel Bots"
         git config user.email "bots@opslevel.com"
-        git pull
-        git add .
+        git add .changes/unreleased
+        if git diff --cached --quiet; then
+          echo "changie produced no new file, nothing to commit"
+          exit 0
+        fi
         git commit -m "Add automated changelog yaml from template"
+        git pull --rebase
         git push


### PR DESCRIPTION
Dependabot PRs have been landing with two to four identical `.changes/unreleased` entries. Three separate defects combined to cause it.

### 1. The job ran once per label

The trigger is `pull_request: types: [labeled]`, but the guard only asked whether the `dependencies` label was present *somewhere* on the PR:

```yaml
if: contains(github.event.pull_request.labels.*.name, 'dependencies')
```

So every subsequent label Dependabot applied re-fired the job, and the condition still passed. Now it reacts only to the moment `dependencies` is added:

```yaml
if: github.event.label.name == 'dependencies'
```

### 2. The runs were concurrent

Four runs fired for #665 within one second of each other:

```
2026-08-21T22:42:52Z pull_request success
2026-08-21T22:42:52Z pull_request success
2026-08-21T22:42:52Z pull_request success
2026-08-21T22:42:51Z pull_request success
```

All four passed the "does a changelog exist?" check before any had pushed. A per-PR `concurrency` group with `cancel-in-progress: false` serializes them, so run N sees run N-1's commit.

### 3. The existence check never worked at all

This is the one that matters most:

```bash
if [[ -n $(git diff --name-only main -- .changes/unreleased/*.yaml) ]]; then
```

`actions/checkout` with `ref:` does a shallow, single-ref checkout — there is no local `main`. Reproduced against this repo:

```
$ git clone --depth 1 --single-branch --branch <some-branch> ...
$ git diff --name-only main -- .changes/unreleased/*.yaml
fatal: bad revision 'main'
```

The error goes to stderr, stdout is empty, `-n ""` is false — so the check reported "no changelog exists" **every single time** and fell through to creating one. The guard has never once prevented a duplicate.

The replacement fetches full history, diffs against `origin/<base>` through the merge-base, and runs under `set -euo pipefail` so a future breakage fails the job loudly instead of silently duplicating. Verified in both directions on a simulated Dependabot branch: no entries → `exists=false` (create); one entry → `exists=true` (skip).

### Also

- `git add .` narrowed to `.changes/unreleased` so unrelated working-tree changes can't ride along.
- Skips the commit when changie produced nothing, instead of failing on an empty commit.
- `git pull` → `git pull --rebase` to avoid merge commits on Dependabot branches.

### Not fixed here

Changie names fragments `Dependency-<YYYYMMDD-HHMMSS>.yaml` — one-second resolution. When Dependabot opens a batch of PRs at once, two PRs can generate the *same filename with different content*. That already happened: `Dependency-20260821-224324.yaml` held the jsonparser bump on `main` and the ebpf bump on #665, which is what made that PR conflict. Fewer runs makes this rarer but doesn't eliminate it — the real fix is a `fragmentFileFormat` in `.changie.yaml` that includes the PR number. Happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)